### PR TITLE
cache the filtered names in a better data structure so that querying them is quicker

### DIFF
--- a/swiftwinrt/helpers.h
+++ b/swiftwinrt/helpers.h
@@ -45,26 +45,22 @@ namespace swiftwinrt
 
         explicit type_name(metadata_type const& type)
         {
-            name_space = type.swift_abi_namespace();
-            name = type.swift_type_name();
+            construct(&type);
         }
 
         explicit type_name(metadata_type const* type)
         {
-            name_space = type->swift_abi_namespace();
-            name = type->swift_type_name();
+            construct(type);
         }
 
         explicit type_name(typedef_base const& type)
         {
-            name_space = type.type().TypeNamespace();
-            name = type.type().TypeName();
+            construct(&type);
         }
 
         explicit type_name(typedef_base const* type)
         {
-            name_space = type->type().TypeNamespace();
-            name = type->type().TypeName();
+            construct(type);
         }
 
         // Same as winmd::reader::get_type_namespace_and_name, but also handles TypeSpecs
@@ -86,6 +82,28 @@ namespace swiftwinrt
                 auto generic_type = type.TypeSpec().Signature().GenericTypeInst().GenericType();
                 return get_namespace_and_name(generic_type);
             }
+        }
+
+    private: 
+        void construct(metadata_type const* type)
+        {
+            // Check if this is a typedef_base, otherwise we could fail trying to get the swift_abi_namespace
+            // for static classes where there is no default interface
+            if (auto typedefbase = dynamic_cast<const typedef_base*>(type))
+            {
+                construct(typedefbase);
+            }
+            else
+            {
+                name_space = type->swift_abi_namespace();
+                name = type->swift_type_name();
+            }
+        }
+
+        void construct(typedef_base const* type)
+        {
+            name_space = type->type().TypeNamespace();
+            name = type->type().TypeName();
         }
     };
 

--- a/swiftwinrt/metadata_filter.h
+++ b/swiftwinrt/metadata_filter.h
@@ -47,7 +47,7 @@ namespace swiftwinrt
             };
         }
     private:
-        std::set<std::string> full_type_names;
+        std::map<std::string_view, std::set<std::string_view>> types;
         std::set<std::string> namespaces;
         std::set<std::string> generics;
     };


### PR DESCRIPTION
The `wimd::reader::filter` has optimizations for checking if a type is included which we lost when we refactored our code to not need that. We can actually be better than what the `wimd::reader` code does since we are only holding onto types we know we're writing (compared to also having exclusions)

This brings the average time to run swiftwinrt down from 1.4S to ~200MS

Fixes WIN-239