### PR TITLE
Add build dependency on support resource files

### DIFF
--- a/swiftwinrt/CMakeLists.txt
+++ b/swiftwinrt/CMakeLists.txt
@@ -55,13 +55,7 @@ target_sources(swiftwinrt PUBLIC
 
 # Make resources.rc depend on the files it embeds
 file(GLOB SUPPORT_FILES Support/*)
-set(SUPPORT_FILES_CHANGED_STAMP ${CMAKE_CURRENT_BINARY_DIR}/support-files-stamp.txt)
-add_custom_command(
-    OUTPUT ${SUPPORT_FILES_CHANGED_STAMP}
-    COMMAND ${CMAKE_COMMAND} -E echo "Support files changed" > ${SUPPORT_FILES_CHANGED_STAMP}
-    DEPENDS ${SUPPORT_FILES})
-set_source_files_properties(resources.rc PROPERTIES
-    OBJECT_DEPENDS ${SUPPORT_FILES_CHANGED_STAMP})
+set_source_files_properties(resources.rc PROPERTIES OBJECT_DEPENDS ${SUPPORT_FILES})
 
 target_include_directories(swiftwinrt PUBLIC ${MicrosoftWindowsWinMD_INCLUDE_DIR} ${PROJECT_BINARY_DIR} ${PROJECT_SOURCE_DIR})
 target_compile_definitions(swiftwinrt PUBLIC "SWIFTWINRT_VERSION_STRING=\"${SWIFTWINRT_VERSION_STRING}\"")


### PR DESCRIPTION
Currently `swiftwinrt.exe` does not get rebuilt when a support swift file which gets embedded as a resource is modified, so it is easy end up with an executable producing stale support files. This change configures CMake to add the build time dependency.