### PR TITLE
Add a CODEOWNERS file to include the windows-eng team on code reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@thebrowsercompany/windows-eng
+* @thebrowsercompany/windows-eng


### PR DESCRIPTION
This will make it easier to monitor pull requests across Windows repos.

How tested:
Created a dummy change on top of this branch and created a PR into it. The `windows-eng` team was automatically added as reviewer.