### PR TITLE
Use EnumResourceNamesExA to avoid Windows 11 dependency

### DIFF
--- a/swiftwinrt/resources.h
+++ b/swiftwinrt/resources.h
@@ -65,7 +65,7 @@ namespace swiftwinrt
             bool make_lowercase = make_lowercase;
         } closure;
 
-        EnumResourceNamesA(hModule, type,
+        EnumResourceNamesExA(hModule, type,
             [](HMODULE hModule, LPCSTR lpType, LPSTR lpName, LONG_PTR lParam) -> BOOL
             {
                 auto& closure = *(closure_type*)lParam;
@@ -91,7 +91,7 @@ namespace swiftwinrt
                 closure.resources.emplace(std::move(res_name), res_data);
                 return TRUE;
             },
-            (LONG_PTR)&closure);
+            (LONG_PTR)&closure, /* dwFlags: */ 0, /* LangId: */ 0);
 
         return std::move(closure.resources);
     }


### PR DESCRIPTION
`EnumResourceNamesA` is a Windows 11 convenience addition whereas `EnumResourceNamesExA` exists since Vista. This was preventing the use of `swiftwinrt.exe` on Windows 10.

Fixes WIN-257