### PR TITLE
Lower build SDK version to Windows 10-era

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -17,7 +17,7 @@
             "cacheVariables": {
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl",
-                "CMAKE_SYSTEM_VERSION": "10.0.19041.0",
+                "CMAKE_SYSTEM_VERSION": "10.0.17763.0",
                 "CMAKE_MODULE_PATH": "${sourceDir}/cmake"
             }
         },


### PR DESCRIPTION
In the hope that this prevents introducing unnecessary dependencies on Windows 11 in the future, such as the `EnumResourceNamesA` call.

Switched to `10.0.19041.0` which corresponds to Windows 10 version 2004 (04/2020), the most recent client Windows 10 SDK installed on the GitHub CI images. See https://github.com/actions/runner-images/blob/main/images/win/Windows2022-Readme.md .

Related to WIN-257