### PR TITLE
Use implicitly unwrapped optionals in func/property input/outputs

### DIFF
--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -517,8 +517,7 @@ namespace swiftwinrt
         w.write(" __%Size", get_swift_name(param));
     }
 
-    static void write_function_params(writer& w, function_def const& function, projection_layer layer,
-        bool allow_implicit_unwrap)
+    static void write_function_params(writer& w, function_def const& function, write_type_params const& type_params)
     {
         separator s{ w };
 
@@ -528,7 +527,7 @@ namespace swiftwinrt
 
             w.write("_ %: ", get_swift_name(param));
             if (param.out()) w.write("inout ");
-            write_type_ex(w, *param.type, layer, allow_implicit_unwrap);
+            write_type(w, *param.type, type_params);
         }
     }
 
@@ -745,7 +744,7 @@ namespace swiftwinrt
     {
         auto category = get_category(signature.type);
         auto guard{ w.push_mangled_names_if_needed(category) };
-        write_type(w, *signature.type, projection_layer::c_abi);
+        write_type(w, *signature.type, write_type_params::c_abi);
         write_default_init_assignment(w, *signature.type, projection_layer::c_abi);
     }
 
@@ -777,8 +776,7 @@ bind<write_abi_args>(function));
         }
     }
 
-    static void write_return_type_declaration(writer& w, function_def function, projection_layer layer,
-        bool allow_implicit_unwrap)
+    static void write_return_type_declaration(writer& w, function_def function, write_type_params const& type_params)
     {
         if (!function.return_type)
         {
@@ -786,7 +784,7 @@ bind<write_abi_args>(function));
         }
 
         w.write(" -> ");
-        write_type_ex(w, *function.return_type->type, layer, allow_implicit_unwrap);
+        write_type(w, *function.return_type->type, type_params);
     }
 
     static void do_write_interface_abi(writer& w, typedef_base const& type, std::vector<function_def> const& methods)
@@ -830,8 +828,8 @@ bind<write_abi_args>(function));
                 w.write("% func %Impl(%) throws% {\n",
                     internal || is_exclusive(type) ? "internal" : "open",
                     func_name,
-                    bind<write_function_params>(function, projection_layer::c_abi, /* allow_implicit_unwrap: */ false),
-                    bind<write_return_type_declaration>(function, projection_layer::c_abi, /* allow_implicit_unwrap: */ false));
+                    bind<write_function_params>(function, write_type_params::c_abi),
+                    bind<write_return_type_declaration>(function, write_type_params::c_abi));
                 {
                     auto function_indent_guard = w.push_indent();
                     write_abi_func_body(w, type, function);
@@ -1060,14 +1058,14 @@ class % : WinRTWrapperBase<%, %> {
                     {
                         w.write("guard let %: % = % else { return E_INVALIDARG }\n",
                             get_swift_name(param),
-                            bind<write_type>(*param.type, projection_layer::swift),
+                            bind<write_type>(*param.type, write_type_params::swift),
                             bind<write_consume_type>(param.type, param_name));
                     }
                     else
                     {
                         w.write("let %: % = %\n",
                             get_swift_name(param),
-                            bind<write_type>(*param.type, projection_layer::swift),
+                            bind<write_type>(*param.type, write_type_params::swift),
                             bind<write_consume_type>(param.type, param_name));
                     }
                 }
@@ -1077,7 +1075,7 @@ class % : WinRTWrapperBase<%, %> {
                     assert(param.out());
                     w.write("var %: %%\n",
                         get_swift_name(param), 
-                        bind<write_type>(*param.type, projection_layer::swift),
+                        bind<write_type>(*param.type, write_type_params::swift),
                         bind<write_default_init_assignment>(*param.type, projection_layer::swift));
                 }
             }
@@ -1533,8 +1531,8 @@ public static func makeAbi() -> CABI {
                     auto full_type_name = w.push_full_type_names(true);
                     w.write("\n        func %(%)%",
                         get_swift_name(method),
-                        bind<write_function_params>(method, projection_layer::swift, /* allow_implicit_unwrap: */ true),
-                        bind<write_return_type_declaration>(method, projection_layer::swift, /* allow_implicit_unwrap: */ true));
+                        bind<write_function_params>(method, write_type_params::swift_allow_implicit_unwrap),
+                        bind<write_return_type_declaration>(method, write_type_params::swift_allow_implicit_unwrap));
                 }
 
                 for (auto& prop : type.properties)
@@ -1544,7 +1542,7 @@ public static func makeAbi() -> CABI {
                     auto&& return_type = *prop.getter->return_type->type;
                     w.write("\n        var %: % { get% }",
                         get_swift_name(prop),
-                        bind<write_type_ex>(return_type, projection_layer::swift, /* allow_implicit_unwrap: */ true),
+                        bind<write_type>(return_type, write_type_params::swift_allow_implicit_unwrap),
                         prop.setter ? " set" : "");
                 }
             }));
@@ -1573,8 +1571,7 @@ public static func makeAbi() -> CABI {
     {
         if (sig.return_type)
         {
-            write_type_ex(w, *sig.return_type->type, projection_layer::swift,
-                /* allow_implicit_unwrap: */ false);
+            write_type(w, *sig.return_type->type, write_type_params::swift);
         }
         else
         {
@@ -1588,7 +1585,7 @@ public static func makeAbi() -> CABI {
         for (auto& param : params)
         {
             s();
-            write_type(w, *param.type, projection_layer::swift);
+            write_type(w, *param.type, write_type_params::swift);
         }
     }
 
@@ -1644,12 +1641,12 @@ public static func makeAbi() -> CABI {
         auto&& generic_params = type.generic_params();
         if (type.swift_type_name().starts_with("IVector")) // IVector and IVectorView
         {
-            w.write("typealias Element = %\n", bind<write_type>(*generic_params[0], projection_layer::swift));
+            w.write("typealias Element = %\n", bind<write_type>(*generic_params[0], write_type_params::swift));
         }
         else if (type.swift_type_name().starts_with("IMap")) // IMap and IMapView
         {
-            w.write("typealias Key = %\n", bind<write_type>(*generic_params[0], projection_layer::swift));
-            w.write("typealias Value = %\n", bind<write_type>(*generic_params[1], projection_layer::swift));
+            w.write("typealias Key = %\n", bind<write_type>(*generic_params[0], write_type_params::swift));
+            w.write("typealias Value = %\n", bind<write_type>(*generic_params[1], write_type_params::swift));
         }
         else
         {
@@ -1831,7 +1828,7 @@ public static func makeAbi() -> CABI {
                 {
                     w.write("var _%: %\n",
                         get_swift_name(param),
-                        bind<write_type>(*param.type, projection_layer::c_abi));
+                        bind<write_type>(*param.type, write_type_params::c_abi));
 
                     guard.push("% = %.%Impl.from(abi: _%)\n",
                         get_swift_name(param),
@@ -1880,7 +1877,7 @@ public static func makeAbi() -> CABI {
             {
                 if (!can_write(w, method)) continue;
 
-                w.write("public init(%) {\n", bind<write_function_params>(method, projection_layer::swift, /* allow_implicit_unwrap: */ true));
+                w.write("public init(%) {\n", bind<write_function_params>(method, write_type_params::swift_allow_implicit_unwrap));
                 {
                     auto indent = w.push_indent();
                     write_factory_body(w, method, factory_info, type, default_interface);
@@ -2028,7 +2025,7 @@ override public init<Factory: ComposableActivationFactory>(_ factory: Factory) {
             w.write("public %var % : % {\n",
                 iface.attributed ? "static " : "",
                 get_swift_name(prop),
-                bind<write_type_ex>(*prop.getter->return_type->type, projection_layer::swift, /* allow_implicit_unwrap: */ true));
+                bind<write_type>(*prop.getter->return_type->type, write_type_params::swift_allow_implicit_unwrap));
         }
         auto property_indent_guard = w.push_indent();
 
@@ -2111,13 +2108,14 @@ override public init<Factory: ComposableActivationFactory>(_ factory: Factory) {
         // we cannot use implicit unwrapping, because of Swift limitations:
         // typename Element must be Base? and not Base!,
         // and declaring GetAt(_: UInt32) -> Base! would not bind to GetAt(_: UInt32) -> Element.
-        bool allow_implicit_unwrap = !is_collection_type(iface.type);
+        auto&& type_params = is_winrt_generic_collection(iface.type)
+            ? write_type_params::swift : write_type_params::swift_allow_implicit_unwrap;
 
         w.write("% func %(%)% {\n",
             iface.overridable ? "open" : "public",
             get_swift_name(function),
-            bind<write_function_params>(function, projection_layer::swift, allow_implicit_unwrap),
-            bind<write_return_type_declaration>(function, projection_layer::swift, allow_implicit_unwrap));
+            bind<write_function_params>(function, type_params),
+            bind<write_return_type_declaration>(function, type_params));
         {
             auto indent = w.push_indent();
             write_class_func_body(w, function, iface);
@@ -2248,8 +2246,8 @@ public % var % : Event<(%),%> = EventImpl<%>(register: %_%, owner:%)
 
                 w.write("public static func %(%)% {\n",
                     get_swift_name(method),
-                    bind<write_function_params>(method, projection_layer::swift, /* allow_implicit_unwrap: */ true),
-                    bind<write_return_type_declaration>(method, projection_layer::swift, /* allow_implicit_unwrap: */ true));
+                    bind<write_function_params>(method, write_type_params::swift_allow_implicit_unwrap),
+                    bind<write_return_type_declaration>(method, write_type_params::swift_allow_implicit_unwrap));
                 {
                     auto indent = w.push_indent();
                     write_statics_body(w, method, *statics.type);
@@ -2438,7 +2436,7 @@ public % var % : Event<(%),%> = EventImpl<%>(register: %_%, owner:%)
         {
             w.write("public typealias % = %\n",
                 collection_type_alias.first,
-                bind<write_type>(*collection_type_alias.second, projection_layer::swift));
+                bind<write_type>(*collection_type_alias.second, write_type_params::swift));
         }
 
         writer::generic_param_guard guard;
@@ -2615,7 +2613,7 @@ private var _default: SwiftABI!
 
                 w.write("public var %: %%\n", 
                     get_swift_name(field),
-                    bind<write_type_ex>(*field_type, projection_layer::swift, /* allow_implicit_unwrap: */ true),
+                    bind<write_type>(*field_type, write_type_params::swift_allow_implicit_unwrap),
                     bind<write_default_init_assignment>(*field_type, projection_layer::swift));
             }
 

--- a/swiftwinrt/code_writers/type_writers.cpp
+++ b/swiftwinrt/code_writers/type_writers.cpp
@@ -6,6 +6,10 @@
 
 using namespace swiftwinrt;
 
+const write_type_params write_type_params::swift{ projection_layer::swift };
+const write_type_params write_type_params::c_abi{ projection_layer::c_abi };
+const write_type_params write_type_params::swift_allow_implicit_unwrap{ projection_layer::swift, true };
+
 // Writes the Swift code representation of a WinRT type at the Swift projection layer
 // as a 'type' syntax node.
 static void write_swift_type(writer& w, metadata_type const& type, bool allow_implicit_unwrap)
@@ -20,7 +24,7 @@ static void write_swift_type(writer& w, metadata_type const& type, bool allow_im
         if (is_winrt_ireference(generic_typedef))
         {
             auto boxed_type = generic_params[0];
-            w.write("%%", bind<write_swift_type>(*boxed_type, /* allow_implicit_unwrap: */ false), optional_suffix);
+            w.write("%?", bind<write_swift_type>(*boxed_type, /* allow_implicit_unwrap: */ false));
             return;
         }
 
@@ -209,11 +213,11 @@ static void write_c_abi_type(writer& w, metadata_type const& type)
     }
 }
 
-void swiftwinrt::write_type_ex(writer& w, metadata_type const& type, projection_layer layer, bool allow_implicit_unwrap)
+void swiftwinrt::write_type(writer& w, metadata_type const& type, write_type_params const& params)
 {
-    if (layer == projection_layer::swift)
+    if (params.layer == projection_layer::swift)
     {
-        write_swift_type(w, type, allow_implicit_unwrap);
+        write_swift_type(w, type, params.allow_implicit_unwrap);
     }
     else
     {

--- a/swiftwinrt/code_writers/type_writers.h
+++ b/swiftwinrt/code_writers/type_writers.h
@@ -15,17 +15,21 @@ namespace swiftwinrt
         c_abi // UnsafeMutablePointer<__x_IVector_HSTRING>?
     };
 
+    struct write_type_params
+    {
+        projection_layer layer;
+        bool allow_implicit_unwrap = false;
+
+        static const write_type_params swift;
+        static const write_type_params c_abi;
+        static const write_type_params swift_allow_implicit_unwrap;
+    };
+
     // Writes the Swift code representation of a WinRT type as a 'type' syntax node.
     // This is a type as can appear in a variable, parameter, return or property declaration,
     // and may include decorators like "any" or "?".
     // For example: (any IVector<(any IVector<String>)?>)?
-    void write_type_ex(writer& w, metadata_type const& type, projection_layer layer, bool allow_implicit_unwrap);
-
-    // Simple case with no extra parameters (default parameter values break bind<>)
-    inline void write_type(writer& w, metadata_type const& type, projection_layer layer)
-    {
-        write_type_ex(w, type, layer, /* allow_implicit_unwrap: */ false);
-    }
+    void write_type(writer& w, metadata_type const& type, write_type_params const& params);
 
     // Writes the Swift code representation of a WinRT type at the Swift projection layer
     // as a 'type-identifier' syntax node. This includes:

--- a/tests/test_app/main.swift
+++ b/tests/test_app/main.swift
@@ -279,7 +279,7 @@ class SwiftWinRTTests : XCTestCase {
 
     var EnumProperty: Fruit = .Apple
 
-    var ID: WinSDK.UUID!
+    var ID: WinSDK.UUID?
     func FireEvent() {
     }
   } 
@@ -645,7 +645,7 @@ class SwiftWinRTTests : XCTestCase {
     let derivedNoOverrides = AppDerivedNoOverrides()
     classy.BaseNoOverridesProperty = derivedNoOverrides
 
-    var baseNoOverrides_returned = classy.BaseNoOverridesProperty
+    var baseNoOverrides_returned = classy.BaseNoOverridesProperty!
     XCTAssert(type(of: baseNoOverrides_returned) == AppDerivedNoOverrides.self)
     XCTAssertIdentical(baseNoOverrides_returned, derivedNoOverrides)
 

--- a/tests/test_component/Source/test_component/test_component+Impl.swift
+++ b/tests/test_component/Source/test_component/test_component+Impl.swift
@@ -105,7 +105,7 @@ public enum __IMPL_test_component {
             }
         }
 
-        public var ID : UUID! {
+        public var ID : UUID? {
             get {
                 let value = try! _default.get_IDImpl()
                 return .init(ref: value)

--- a/tests/test_component/Source/test_component/test_component.swift
+++ b/tests/test_component/Source/test_component/test_component.swift
@@ -548,7 +548,7 @@ public final class Class : WinRTClass, IBasic {
         }
     }
 
-    public var ID : UUID! {
+    public var ID : UUID? {
         get {
             let value = try! _default.get_IDImpl()
             return .init(ref: value)
@@ -574,7 +574,7 @@ public final class Class : WinRTClass, IBasic {
         }
     }
 
-    public var StartValue : Int32! {
+    public var StartValue : Int32? {
         get {
             let value = try! _default.get_StartValueImpl()
             return .init(ref: value)
@@ -1216,7 +1216,7 @@ public protocol IIAmImplementable : IWinRTObject {
         func ReturnEnum() -> test_component.Signed
         func FireEvent()
         var EnumProperty: test_component.Fruit { get set }
-        var ID: UUID! { get set }
+        var ID: UUID? { get set }
 }
 public protocol ISimpleDelegate : IWinRTObject { 
         func DoThis()


### PR DESCRIPTION
Switches code generation for funcs and properties to use implicitly wrapped optionals. This is the least intrusive way to expose the nullability of reference types to Swift and migrate Arc to the latest version of SwiftWinRT. It also aligns with the C# experience of using WinRT APIs.

Implicitly unwrapped optionals are not proper types in the Swift type system so there are some limitations when the function is meant to be conform to a function from a generic protocol, or if an implicitly unwrapped optional return value is stored in a variable (which will become a normal optional).