### PR TITLE
fix warning - make hwnd initializer failable

### DIFF
--- a/swiftwinrt/Resources/Support/WinSDK+Extensions.swift
+++ b/swiftwinrt/Resources/Support/WinSDK+Extensions.swift
@@ -37,9 +37,8 @@ extension boolean {
 }
 
 extension HWND {
-  public init(from val: UInt64) {
-    // TODO: Revisit since this gives a compiler warning.
-    self.init(unsafeBitCast(val, to: UnsafeMutablePointer<HWND__>.self))
+  public init?(from val: UInt64) {
+    self.init(HWND(bitPattern: UInt(val)))
   }
 }
 


### PR DESCRIPTION
we've had this warning since the dawn of time (ok - not really, just a few months)

changing HWND initializer to be fail-able, since theoretically someone can pass in `0` for the handle value, in which case the HWND should represent `null` 