### PR TITLE
Regenerate Swift binding code for test_component

### DIFF
--- a/tests/test_component/Source/test_component/Support/WinSDK+Extensions.swift
+++ b/tests/test_component/Source/test_component/Support/WinSDK+Extensions.swift
@@ -37,9 +37,8 @@ extension boolean {
 }
 
 extension HWND {
-  public init(from val: UInt64) {
-    // TODO: Revisit since this gives a compiler warning.
-    self.init(unsafeBitCast(val, to: UnsafeMutablePointer<HWND__>.self))
+  public init?(from val: UInt64) {
+    self.init(HWND(bitPattern: UInt(val)))
   }
 }
 


### PR DESCRIPTION
This was missing from https://github.com/thebrowsercompany/swiftwinrt/pull/34