### PR TITLE
Enable null value test for IInspectable

### DIFF
--- a/tests/test_app/main.swift
+++ b/tests/test_app/main.swift
@@ -729,7 +729,7 @@ class SwiftWinRTTests : XCTestCase {
     XCTAssertTrue(NullValues.IsClassNull(nil))
     XCTAssertTrue(NullValues.IsDelegateNull(nil))
     
-    // XCTAssertFalse(NullValues.IsObjectNull(NoopClosable())) // TODO: How to create an IInspectable?
+    XCTAssertFalse(NullValues.IsObjectNull(NoopClosable().getDefault()))
     XCTAssertFalse(NullValues.IsInterfaceNull(NoopClosable()))
     XCTAssertFalse(NullValues.IsGenericInterfaceNull([""].toVector()))
     XCTAssertFalse(NullValues.IsClassNull(NoopClosable()))


### PR DESCRIPTION
The test worked, I just didn't know how to convert to `IInspectable`.

`getDefault()` will need renaming after https://github.com/thebrowsercompany/swiftwinrt/pull/38