### PR TITLE
just put all windows apis in UWP

### DIFF
--- a/swiftwinrt/Resources/Support/IInspectable+Swift.swift
+++ b/swiftwinrt/Resources/Support/IInspectable+Swift.swift
@@ -34,10 +34,10 @@ extension IInspectable {
   private func GetSwiftModule(from ns: String) -> String {
     if ns.starts(with: "Windows.Foundation") {
        return "WindowsFoundation"
+    } else if ns.starts(with: "Microsoft.UI.Xaml") || ns.starts(with: "Windows.UI.Xaml") {
+      return "WinUI"
     } else if ns.starts(with: "Windows") {
       return "UWP"
-    } else if ns.starts(with: "Microsoft.UI.Xaml") {
-      return "WinUI"
     } else if ns.starts(with: "Microsoft.Web.WebView2.Core") {
       return "WebView2Core"
     } else if ns.starts(with: "Microsoft.Graphics.Canvas"){

--- a/swiftwinrt/common.h
+++ b/swiftwinrt/common.h
@@ -52,13 +52,18 @@ namespace swiftwinrt
         {
             return "WindowsFoundation";
         }
+        // Put both system xaml and winui3 in the "WinUI" module. In WinUI3 applications, there are still
+        // types in the Windows.UI.Xaml.Interop namespace and it doesn't make sense to pull in the whole
+        // UWP module for that. Plus, WinUI is such a distinct chunk, that even a non-winui3 app it makes
+        // sense to have it be it's own thing. There will be compilation errors if the user tries to use
+        // both, but this is a non-supported scenario anyway.
+        else if (ns.starts_with("Microsoft.UI.Xaml") || ns.starts_with("Windows.UI.Xaml"))
+        {
+            return "WinUI";
+        }
         else if (ns.starts_with("Windows"))
         {
             return "UWP";
-        }
-        else if (ns.starts_with("Microsoft.UI.Xaml"))
-        {
-            return "WinUI";
         }
         else if (ns.starts_with("Microsoft.Web.WebView2.Core"))
         {

--- a/tests/test_component/Sources/test_component/Support/IInspectable+Swift.swift
+++ b/tests/test_component/Sources/test_component/Support/IInspectable+Swift.swift
@@ -34,10 +34,10 @@ extension IInspectable {
   private func GetSwiftModule(from ns: String) -> String {
     if ns.starts(with: "Windows.Foundation") {
        return "WindowsFoundation"
+    } else if ns.starts(with: "Microsoft.UI.Xaml") || ns.starts(with: "Windows.UI.Xaml") {
+      return "WinUI"
     } else if ns.starts(with: "Windows") {
       return "UWP"
-    } else if ns.starts(with: "Microsoft.UI.Xaml") {
-      return "WinUI"
     } else if ns.starts(with: "Microsoft.Web.WebView2.Core") {
       return "WebView2Core"
     } else if ns.starts(with: "Microsoft.Graphics.Canvas"){


### PR DESCRIPTION
there is a circular dependency between `WindowsGraphics` and `UWP`. I only split them out bc i thought `WinAppSDK` didn't need `UWP` but I was wrong. the `WindowsGraphics` api surface area is so small it should just be moved into UWP

not sure how this built when i was testing locally but maybe i hadn't properly regenerated the bindings.
