### PR TITLE
undef GetObject API

### DIFF
--- a/swiftwinrt/abi_writer.h
+++ b/swiftwinrt/abi_writer.h
@@ -309,6 +309,7 @@ namespace swiftwinrt
 #undef GetCurrentTime
 #undef FindText
 #undef GetClassName
+#undef GetObject
 
 #define ENABLE_WINRT_EXPERIMENTAL_TYPES
 


### PR DESCRIPTION
when including XamlDirect APIs, there is an API called `IXamlDirect.GetObject` - the compiler isn't able to find this because `GetObject` is a macro. We should follow the other pattern we do for these conflicts and undef it

Fixes WIN-518