### PR TITLE
Prevent removing multiple event handlers in one call

### DIFF
--- a/swiftwinrt/Resources/Support/Events/EventHandlerSubscription.swift
+++ b/swiftwinrt/Resources/Support/Events/EventHandlerSubscription.swift
@@ -23,7 +23,9 @@ struct EventHandlerSubscriptions<Handler> {
     
     mutating func remove(token: C_BINDINGS_MODULE.EventRegistrationToken) {
         lock.lock()
-        if let index = buffer.firstIndex(where: { $0.token == token }) {
+        // The semantics when the same event handler is added multiple times
+        // is to append to the end and to remove the last occurrence first.
+        if let index = buffer.lastIndex(where: { $0.token == token }) {
             buffer.remove(at: index)
         }
         lock.unlock()

--- a/tests/test_component/Sources/test_component/Support/eventhandlersubscription.swift
+++ b/tests/test_component/Sources/test_component/Support/eventhandlersubscription.swift
@@ -23,7 +23,11 @@ struct EventHandlerSubscriptions<Handler> {
     
     mutating func remove(token: Ctest_component.EventRegistrationToken) {
         lock.lock()
-        buffer = buffer.filter { $0.token != token }
+        // The semantics when the same event handler is added multiple times
+        // is to append to the end and to remove the last occurrence first.
+        if let index = buffer.lastIndex(where: { $0.token == token }) {
+            buffer.remove(at: index)
+        }
         lock.unlock()
     }
 


### PR DESCRIPTION
The `EventRegistrationToken` seems to imply that appending the same Handler twice to an event would result in two subscriptions with the same token, which would hence get both removed with a single `remove` call. This change ensures that we'll only remove one handler, and saves an array reallocation.