### PR TITLE
don't try and get inner object for closures

### DIFF
--- a/swiftwinrt/Resources/Support/Events/EventSource.swift
+++ b/swiftwinrt/Resources/Support/Events/EventSource.swift
@@ -2,14 +2,6 @@ import Foundation
 import WinSDK
 import C_BINDINGS_MODULE
 
-public struct EventInvoker<Handler> {
-    public let handlers: [Handler]
-    public init?(_ handlers: [Handler]) {
-        guard !handlers.isEmpty else { return nil }
-        self.handlers = handlers
-    } 
-}
-
 /// EventSource is the class which implements handling event subscriptions, removals,
 /// and invoking events for authoring events in Swift
 @propertyWrapper public class EventSource<Handler> {
@@ -24,7 +16,10 @@ public struct EventInvoker<Handler> {
     }
     
     public var wrappedValue: Event<Handler> { event }
-    public var raise: EventInvoker<Handler>? { return .init(handlers.getInvocationList())}
+    
+    public func getInvocationList() -> [Handler] {
+      handlers.getInvocationList()
+    }
 } 
 
 extension C_BINDINGS_MODULE.EventRegistrationToken: Hashable {

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -1138,7 +1138,7 @@ public static func makeAbi() -> CABI {
         if (delegate_method.return_type)
         {
             invoke_implementation = w.write_temp(R"(var result:%%
-        for handler in handlers {
+        for handler in getInvocationList() {
             result = handler(%)
         }
         return result)",
@@ -1148,14 +1148,14 @@ public static func makeAbi() -> CABI {
         }
         else
         {
-            invoke_implementation = w.write_temp(R"(for handler in handlers {
+            invoke_implementation = w.write_temp(R"(for handler in getInvocationList() {
             handler(%)
         })", bind<write_comma_param_names>(delegate_method.params));
         }
         
         assert(delegate_method.def);
-        w.write(R"(% extension EventInvoker where Handler == % {
-    %func callAsFunction(%)% {
+        w.write(R"(% extension EventSource where Handler == % {
+    %func invoke(%)% {
         %
     }
 }

--- a/tests/test_app/EventTests.swift
+++ b/tests/test_app/EventTests.swift
@@ -129,23 +129,6 @@ public func testSwiftImplementedEventWithSwiftListener() throws {
   }
 }
 
-// simple type here to validate that we can ignore delegates with return values. This
-// just needs to build
-struct DummyToVerifyBuild {
-    @EventSource<ReturnInt32Delegate> var returnInt32Event: Event<ReturnInt32Delegate>
-    func fireEvent() {
-      _returnInt32Event.raise?()
-
-      guard let invoker = _returnInt32Event.raise else {
-        return
-      }
-
-      for handler in invoker.handlers {
-        handler()
-      }
-    }
-}
-
 var eventTests: [XCTestCaseEntry] = [
   testCase([
     ("EventsOnInstance", EventTests.testEventsOnInstance),

--- a/tests/test_app/WinRTInterfaceImplementations.swift
+++ b/tests/test_app/WinRTInterfaceImplementations.swift
@@ -83,7 +83,7 @@ class MyImplementableDelegate: IIAmImplementable {
 
     var id: WinSDK.UUID?
     func fireEvent(_ data: String) {
-      _implementableEvent.raise?(data)
+      _implementableEvent.invoke(data)
     }
 
     private var object: Any?

--- a/tests/test_component/Sources/test_component/Support/eventsource.swift
+++ b/tests/test_component/Sources/test_component/Support/eventsource.swift
@@ -2,14 +2,6 @@ import Foundation
 import WinSDK
 import Ctest_component
 
-public struct EventInvoker<Handler> {
-    public let handlers: [Handler]
-    public init?(_ handlers: [Handler]) {
-        guard !handlers.isEmpty else { return nil }
-        self.handlers = handlers
-    } 
-}
-
 /// EventSource is the class which implements handling event subscriptions, removals,
 /// and invoking events for authoring events in Swift
 @propertyWrapper public class EventSource<Handler> {
@@ -24,7 +16,10 @@ public struct EventInvoker<Handler> {
     }
     
     public var wrappedValue: Event<Handler> { event }
-    public var raise: EventInvoker<Handler>? { return .init(handlers.getInvocationList())}
+    
+    public func getInvocationList() -> [Handler] {
+      handlers.getInvocationList()
+    }
 } 
 
 extension Ctest_component.EventRegistrationToken: Hashable {

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -1363,9 +1363,9 @@ public protocol IIAmImplementable : WinRTInterface {
     var implementableEvent: Event<test_component.InDelegate> { get }
 }
 
-public extension EventInvoker where Handler == test_component.InDelegate {
-    func callAsFunction(_ value: String) {
-        for handler in handlers {
+public extension EventSource where Handler == test_component.InDelegate {
+    func invoke(_ value: String) {
+        for handler in getInvocationList() {
             handler(value)
         }
     }
@@ -1398,10 +1398,10 @@ public protocol InterfaceWithReturnDelegate : WinRTInterface {
     var eventWithReturn: Event<test_component.ReturnInt32Delegate> { get }
 }
 
-public extension EventInvoker where Handler == test_component.ReturnInt32Delegate {
-    @discardableResult func callAsFunction() -> Int32 {
+public extension EventSource where Handler == test_component.ReturnInt32Delegate {
+    @discardableResult func invoke() -> Int32 {
         var result:Int32 = 0
-        for handler in handlers {
+        for handler in getInvocationList() {
             result = handler()
         }
         return result


### PR DESCRIPTION
delegate wrappers are just holding onto a swift closure, so don't try and unwrap as any object since this will fail
