### PR TITLE
revert back to ninja which works with Nuget

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,7 +9,7 @@
         {
             "name": "base",
             "hidden": true,
-            "generator": "NMake Makefiles",
+            "generator": "Ninja",
             "architecture": {
                 "value": "x64",
                 "strategy": "external"


### PR DESCRIPTION
with my latest change (#69) i moved to using NMake, which broke nuget packaging. there is no real reason to use nmake so just undo that part for now. i verified that the publish pipeline now works again: https://github.com/thebrowsercompany/swiftwinrt/actions/runs/5537805740