### PR TITLE
Update .editorconfig to indent with 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,3 @@
 [*.swift]
 indent_style = space
-indent_size = 2
+indent_size = 4


### PR DESCRIPTION
We're inconsistent because tests were using 2 spaces and swiftwinrt resources were using 4 spaces. We should follow the swift-format default.