### PR TITLE
WIN-741: fix no-except on classes and add test

### DIFF
--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -1838,9 +1838,10 @@ override public init<Factory: ComposableActivationFactory>(_ factory: Factory) {
         // typename Element must be Base? and not Base!,
         // and declaring GetAt(_: UInt32) -> Base! would not bind to GetAt(_: UInt32) -> Element.
         auto is_winrt_collection = is_winrt_generic_collection(iface.type);
+        auto is_no_except = is_winrt_collection || is_noexcept(function.def);
         auto&& type_params = is_winrt_collection
             ? write_type_params::swift : write_type_params::swift_allow_implicit_unwrap;
-        auto maybe_throws = is_winrt_collection ? "" : " throws";
+        auto maybe_throws = is_no_except ? "" : " throws";
         w.write("% func %(%)%% {\n",
             iface.overridable ? "open" : "public",
             get_swift_name(function),
@@ -1849,7 +1850,7 @@ override public init<Factory: ComposableActivationFactory>(_ factory: Factory) {
             bind<write_return_type_declaration>(function, type_params));
         {
             auto indent = w.push_indent();
-            write_class_func_body(w, function, iface, is_winrt_collection);
+            write_class_func_body(w, function, iface, is_no_except);
         }
         w.write("}\n\n");
     }

--- a/tests/test_app/main.swift
+++ b/tests/test_app/main.swift
@@ -293,7 +293,7 @@ class SwiftWinRTTests : XCTestCase {
     XCTAssertEqual(Class.staticPropertyFloat, 4.0)
     XCTAssertEqual(Class.staticTestReturnFloat(), 42.24)
     let classy = Class()
-    try classy.method()
+    classy.method()
   }
 
   public func testChar() throws {
@@ -321,10 +321,10 @@ class SwiftWinRTTests : XCTestCase {
     let classy = Class()
     let newBase = DoTheNewBase()
     classy.implementation = newBase
-    try classy.method()
+    classy.method()
 
     var implReturn = classy.implementation!
-    try implReturn.method()
+    implReturn.method()
 
     XCTAssertIdentical(implReturn, newBase, "incorrect swift object returned")
 
@@ -336,7 +336,7 @@ class SwiftWinRTTests : XCTestCase {
     classy.implementation = double
     try classy.setDelegate(double)
 
-    try classy.method()
+    classy.method()
 
     let delegate = try classy.getDelegate()!
     try delegate.doThis()
@@ -486,6 +486,14 @@ class SwiftWinRTTests : XCTestCase {
     } catch {
       XCTAssertEqual("\(error)", message)
     }
+  }
+
+  public func testNoExcept() throws {
+    let classy = Class()
+    classy.noexceptVoid()
+    classy.method()
+    XCTAssertEqual(classy.noexceptInt32(), 123)
+    XCTAssertEqual(classy.noexceptString(), "123")
   }
 }
 

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -1931,6 +1931,11 @@ struct __x_ABI_Ctest__component_CStructWithEnum
         enum __x_ABI_Ctest__component_CFruit* value);
     HRESULT (STDMETHODCALLTYPE* put_EnumProperty)(__x_ABI_Ctest__component_CIClass* This,
         enum __x_ABI_Ctest__component_CFruit value);
+    HRESULT (STDMETHODCALLTYPE* NoexceptVoid)(__x_ABI_Ctest__component_CIClass* This);
+    HRESULT (STDMETHODCALLTYPE* NoexceptInt32)(__x_ABI_Ctest__component_CIClass* This,
+        INT32* result);
+    HRESULT (STDMETHODCALLTYPE* NoexceptString)(__x_ABI_Ctest__component_CIClass* This,
+        HSTRING* result);
     HRESULT (STDMETHODCALLTYPE* ReturnChar)(__x_ABI_Ctest__component_CIClass* This,
         WCHAR* result);
     HRESULT (STDMETHODCALLTYPE* InChar)(__x_ABI_Ctest__component_CIClass* This,

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -26,7 +26,7 @@ private var IID___x_ABI_Ctest__component_CIBasic: IID {
 }
 
 private var IID___x_ABI_Ctest__component_CIClass: IID {
-    IID(Data1: 0x1E9F3DF1, Data2: 0xDB1E, Data3: 0x58F2, Data4: ( 0xBF,0xA1,0x6E,0x4B,0xC2,0x3F,0x11,0x5D ))// 1E9F3DF1-DB1E-58F2-BFA1-6E4BC23F115D
+    IID(Data1: 0x6C4D9280, Data2: 0xC652, Data3: 0x5CFE, Data4: ( 0xB6,0x94,0x77,0xE1,0xE8,0x7A,0xB4,0x00 ))// 6C4D9280-C652-5CFE-B694-77E1E87AB400
 }
 
 private var IID___x_ABI_Ctest__component_CIClassFactory: IID {
@@ -413,6 +413,28 @@ public enum __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_EnumProperty(pThis, value))
             }
+        }
+
+        internal func NoexceptVoidImpl() throws {
+            _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.NoexceptVoid(pThis))
+            }
+        }
+
+        internal func NoexceptInt32Impl() throws -> INT32 {
+            var result: INT32 = 0
+            _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.NoexceptInt32(pThis, &result))
+            }
+            return result
+        }
+
+        internal func NoexceptStringImpl() throws -> HSTRING? {
+            var result: HSTRING?
+            _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.NoexceptString(pThis, &result))
+            }
+            return result
         }
 
         internal func ReturnCharImpl() throws -> WCHAR {

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -20,8 +20,8 @@ public enum __IMPL_test_component {
             let vtblPtr = withUnsafeMutablePointer(to: &__ABI_test_component.IBasicVTable) { $0 }
             return .init(lpVtbl: vtblPtr)
         }
-        public func method() throws {
-            try _default.MethodImpl()
+        public func method() {
+            try! _default.MethodImpl()
         }
 
     }

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -517,6 +517,20 @@ public final class Class : WinRTClass, IBasic {
         return .init(ref: result)
     }
 
+    public func noexceptVoid() {
+        try! _default.NoexceptVoidImpl()
+    }
+
+    public func noexceptInt32() -> Int32 {
+        let result = try! _default.NoexceptInt32Impl()
+        return result
+    }
+
+    public func noexceptString() -> String {
+        let result = try! _default.NoexceptStringImpl()
+        return .init(from: result)
+    }
+
     public func returnChar() throws -> Character {
         let result = try _default.ReturnCharImpl()
         return .init(from: result)
@@ -606,8 +620,8 @@ public final class Class : WinRTClass, IBasic {
     }
 
     internal lazy var _IBasic: __ABI_test_component.IBasic = try! _default.QueryInterface()
-    public func method() throws {
-        try _IBasic.MethodImpl()
+    public func method() {
+        try! _IBasic.MethodImpl()
     }
 
 }
@@ -1389,7 +1403,7 @@ public struct StructWithEnum: Hashable, Codable {
 }
 
 public protocol IBasic : WinRTInterface {
-    func method() throws
+    func method()
 }
 
 extension IBasic {

--- a/tests/test_component/cpp/test_component.idl
+++ b/tests/test_component/cpp/test_component.idl
@@ -6,14 +6,14 @@
 import "Windows.Foundation.idl";
 // import "Windows.Foundation.Numerics.idl";
 
-//namespace Windows.Foundation.Metadata
-//{
-//    [attributeusage(target_method, target_property)]
-//    [attributename("noexcept2")]
-//    attribute NoExceptionAttribute
-//    {
-//    }
-//}
+namespace Windows.Foundation.Metadata
+{
+    [attributeusage(target_method, target_property)]
+    [attributename("noexcept2")]
+    attribute NoExceptionAttribute
+    {
+    }
+}
 
 
 namespace test_component
@@ -178,6 +178,7 @@ namespace test_component
 
         interface IBasic
         {
+            [noexcept2]
             void Method();
         }
 
@@ -267,9 +268,9 @@ namespace test_component
             // Struct[] ReturnStructArray();
             // Signed[] ReturnEnumArray();
 
-            // [noexcept2] void NoexceptVoid();
-            // [noexcept2] Int32 NoexceptInt32();
-            // [noexcept2] String NoexceptString();
+            [noexcept2] void NoexceptVoid();
+            [noexcept2] Int32 NoexceptInt32();
+            [noexcept2] String NoexceptString();
 
             // event Windows.Foundation.TypedEventHandler<Class, DeferrableEventArgs> DeferrableEvent;
             // Windows.Foundation.IAsyncOperation<Int32> RaiseDeferrableEventAsync();


### PR DESCRIPTION
`noexcept` was supported on interface methods but not classes