### PR TITLE
don't special case generic collections over other generics

### DIFF
--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -966,7 +966,7 @@ bind_impl_fullname(type));
         else if (!info.is_default || (!is_class && info.base))
         {
             auto swiftAbi = w.write_temp("%.%", abi_namespace(info.type->swift_logical_namespace()), info.type->swift_type_name());
-            if (is_winrt_generic_collection(info.type))
+            if (is_generic_inst(info.type))
             {
                 auto guard{ w.push_generic_params(info) };
                 swiftAbi = w.write_temp("%", bind_type_abi(info.type));
@@ -2161,7 +2161,7 @@ override public init<Factory: ComposableActivationFactory>(_ factory: Factory) {
             auto [ns, name] = get_type_namespace_and_name(*default_interface);
             auto swiftAbi = w.write_temp("%.%", abi_namespace(ns), name);
             std::string defaultVal = "";
-            if (is_winrt_generic_collection(default_interface))
+            if (is_generic_inst(default_interface))
             {
                 auto generic_type = dynamic_cast<const generic_inst*>(default_interface);
                 guard = w.push_generic_params(*generic_type);

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -6,6 +6,90 @@ public typealias Keywords = __x_ABI_Ctest__component_CKeywords
 public typealias Signed = __x_ABI_Ctest__component_CSigned
 public typealias SwiftifiableNames = __x_ABI_Ctest__component_CSwiftifiableNames
 public typealias Unsigned = __x_ABI_Ctest__component_CUnsigned
+public final class AsyncOperationInt : WinRTClass, IAsyncOperation, test_component.IAsyncInfo {
+    public typealias TResult = Int32
+    private typealias SwiftABI = IAsyncOperationInt32
+    private typealias CABI = __x_ABI_C__FIAsyncOperation_1_int
+    private var _default: SwiftABI!
+    public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }   
+        if T.self == Ctest_component.IInspectable.self {
+            return RawPointer(_default)
+        }
+        if T.self == WinSDK.IUnknown.self {
+            return RawPointer(_default)
+        }
+        return nil
+    }
+
+    public var thisPtr: test_component.IInspectable { _default }
+
+    public static func from(abi: UnsafeMutablePointer<__x_ABI_C__FIAsyncOperation_1_int>?) -> AsyncOperationInt? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: .init(abi))
+    }
+
+    public init(fromAbi: test_component.IInspectable) {
+        _default = try! fromAbi.QueryInterface()
+    }
+
+    public func queryInterface(_ iid: IID) -> IUnknownRef? {
+        return test_component.queryInterface(sealed: self, iid)}
+    public func getResults() throws -> Int32 {
+        let result = try _default.GetResultsImpl()
+        return result
+    }
+
+    public var completed : AsyncOperationCompletedHandler<Int32>? {
+        get {
+            let result = try! _default.get_CompletedImpl()
+            return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper.unwrapFrom(abi: result)
+        }
+
+        set {
+            let wrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper(newValue)
+            let _newValue = try! wrapper?.toABI { $0 }
+            try! _default.put_CompletedImpl(_newValue)
+        }
+    }
+
+    internal lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo = try! _default.QueryInterface()
+    public func cancel() throws {
+        try _IAsyncInfo.CancelImpl()
+    }
+
+    public func close() throws {
+        try _IAsyncInfo.CloseImpl()
+    }
+
+    public var errorCode : HRESULT {
+        get {
+            let result = try! _IAsyncInfo.get_ErrorCodeImpl()
+            return result
+        }
+
+    }
+
+    public var id : UInt32 {
+        get {
+            let result = try! _IAsyncInfo.get_IdImpl()
+            return result
+        }
+
+    }
+
+    public var status : test_component.AsyncStatus {
+        get {
+            let result = try! _IAsyncInfo.get_StatusImpl()
+            return result
+        }
+
+    }
+
+}
+
 open class Base : UnsealedWinRTClass {
     private (set) public var _inner: IUnknownRef?
     private typealias SwiftABI = __ABI_test_component.IBase

--- a/tests/test_component/cpp/AsyncOperationInt.cpp
+++ b/tests/test_component/cpp/AsyncOperationInt.cpp
@@ -1,0 +1,39 @@
+#include "pch.h"
+#include "AsyncOperationInt.h"
+#include "AsyncOperationInt.g.cpp"
+
+namespace winrt::test_component::implementation
+{
+    uint32_t AsyncOperationInt::Id()
+    {
+        throw hresult_not_implemented();
+    }
+    winrt::Windows::Foundation::AsyncStatus AsyncOperationInt::Status()
+    {
+        throw hresult_not_implemented();
+    }
+    winrt::hresult AsyncOperationInt::ErrorCode()
+    {
+        throw hresult_not_implemented();
+    }
+    void AsyncOperationInt::Cancel()
+    {
+        throw hresult_not_implemented();
+    }
+    void AsyncOperationInt::Close()
+    {
+        throw hresult_not_implemented();
+    }
+    void AsyncOperationInt::Completed(winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> const& handler)
+    {
+        throw hresult_not_implemented();
+    }
+    winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> AsyncOperationInt::Completed()
+    {
+        throw hresult_not_implemented();
+    }
+    int32_t AsyncOperationInt::GetResults()
+    {
+        throw hresult_not_implemented();
+    }
+}

--- a/tests/test_component/cpp/AsyncOperationInt.h
+++ b/tests/test_component/cpp/AsyncOperationInt.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "AsyncOperationInt.g.h"
+
+namespace winrt::test_component::implementation
+{
+    struct AsyncOperationInt : AsyncOperationIntT<AsyncOperationInt>
+    {
+        AsyncOperationInt() = default;
+
+        uint32_t Id();
+        winrt::Windows::Foundation::AsyncStatus Status();
+        winrt::hresult ErrorCode();
+        void Cancel();
+        void Close();
+        void Completed(winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> const& handler);
+        winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> Completed();
+        int32_t GetResults();
+    };
+}

--- a/tests/test_component/cpp/CMakeLists.txt
+++ b/tests/test_component/cpp/CMakeLists.txt
@@ -106,6 +106,8 @@ install(TARGETS test_component_cpp
   COMPONENT lib)
 
 target_sources(test_component_cpp PRIVATE
+    AsyncOperationInt.cpp
+    AsyncOperationInt.h
     StaticClass.cpp
     StaticClass.h
     Base.h

--- a/tests/test_component/cpp/test_component.idl
+++ b/tests/test_component/cpp/test_component.idl
@@ -444,4 +444,8 @@ namespace test_component
         runtimeclass BaseObservableCollection: [default] IObservableVector<Base>
         {
         }
+
+        runtimeclass AsyncOperationInt : [default] Windows.Foundation.IAsyncOperation<Int32>
+        {
+        }
     }


### PR DESCRIPTION
a class can inherit from any generic interface, don't special case collections

fixes errors which look like this:

![image](https://github.com/thebrowsercompany/swiftwinrt/assets/9649518/5243c9e6-b860-4b11-a420-c8b631d30946)

Fixes WPP-209