### PR TITLE
Don't assume wait/signal ordering in WaitableEvent

### DIFF
--- a/swiftwinrt/Resources/Support/WaitableEvent.swift
+++ b/swiftwinrt/Resources/Support/WaitableEvent.swift
@@ -10,14 +10,8 @@ actor WaitableEvent {
 
     /// Block until the signaled state is `true`.
     func wait() async {
-         guard !signaled else { 
-            #if DEBUG
-            preconditionFailure("message already signaled")
-            #else
-            return
-            #endif
-        }
-        guard observer == nil else { 
+        guard !signaled else { return }
+        guard observer == nil else {
             #if DEBUG
             preconditionFailure("message has already been waited on")
             #else
@@ -31,8 +25,9 @@ actor WaitableEvent {
         }
     }
 
+    /// Signals the event, unblocking any current or future waiter.
     func signal() async {
-        guard !signaled else { 
+        guard !signaled else {
             #if DEBUG
             preconditionFailure("message already signaled")
             #else

--- a/tests/test_component/Sources/test_component/Support/waitableevent.swift
+++ b/tests/test_component/Sources/test_component/Support/waitableevent.swift
@@ -10,14 +10,8 @@ actor WaitableEvent {
 
     /// Block until the signaled state is `true`.
     func wait() async {
-         guard !signaled else { 
-            #if DEBUG
-            preconditionFailure("message already signaled")
-            #else
-            return
-            #endif
-        }
-        guard observer == nil else { 
+        guard !signaled else { return }
+        guard observer == nil else {
             #if DEBUG
             preconditionFailure("message has already been waited on")
             #else
@@ -31,8 +25,9 @@ actor WaitableEvent {
         }
     }
 
+    /// Signals the event, unblocking any current or future waiter.
     func signal() async {
-        guard !signaled else { 
+        guard !signaled else {
             #if DEBUG
             preconditionFailure("message already signaled")
             #else


### PR DESCRIPTION
It's valid to start waiting after the `WaitableEvent` is already signaled, otherwise this is prone to race conditions.