### PR TITLE
Switch to using the GUID2 type as a workaround for C++ interop issues

### DIFF
--- a/swiftwinrt/Resources/Support/GUID.swift
+++ b/swiftwinrt/Resources/Support/GUID.swift
@@ -1,7 +1,7 @@
 import WinSDK
 import C_BINDINGS_MODULE
 
-#if WIN_855_GUID_WORKAROUND
+#if true // TODO(WIN-860): Remove workaround once C++ interop issues with WinSDK.GUID are fixed.
 public typealias GUID = C_BINDINGS_MODULE.GUID2
 public typealias IID = C_BINDINGS_MODULE.IID2
 public typealias CLSID = C_BINDINGS_MODULE.CLSID2

--- a/swiftwinrt/abi_writer.h
+++ b/swiftwinrt/abi_writer.h
@@ -312,7 +312,7 @@ namespace swiftwinrt
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmicrosoft-enum-forward-reference"
 
-#if WIN_855_GUID_WORKAROUND
+#if 1 // TODO(WIN-860): Remove workaround once C++ interop issues with WinSDK.GUID are fixed.
 #include "GUID2.h"
 
 // Preemptively include headers before swapping out the IID type


### PR DESCRIPTION
See WIN-855 for details.

Fixes WIN-855

Undoing this is tracked by WIN-860