### PR TITLE
respect excludes given to the generator

### DIFF
--- a/swiftwinrt/metadata_filter.cpp
+++ b/swiftwinrt/metadata_filter.cpp
@@ -197,6 +197,14 @@ namespace swiftwinrt
 
     bool include_only_used_filter::includes(winmd::reader::TypeDef const& type) const
     {
+        if (settings.exclude.contains(std::string(type.TypeNamespace())))
+        {
+            return false;
+        }
+        else if (settings.exclude.contains(get_full_type_name(type)))
+        {
+            return false;
+        }
         auto ns = types.find(type.TypeNamespace());
         if (ns != types.end())
         {


### PR DESCRIPTION
there is a typename collision with `PackageStatus` types.. since we don't need the enum type, we can tell the generator to exclude it. However, the generator isn't properly respecting the excludes, so let's fix that