### PR TITLE
Rename the nuget package to make it more nuget-y

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,11 +17,11 @@ else()
     set(NUGET_VERSION_WITH_SUFFIX ${NUGET_VERSION}-local)
 endif()
 
-add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/nuget/company.thebrowser.swiftwinrt.nupkg
+add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/nuget/TheBrowserCompany.SwiftWinRT.nupkg
     COMMAND ${CMAKE_BINARY_DIR}/nuget pack ${CMAKE_CURRENT_SOURCE_DIR}\\nuget\\swiftwinrt.nuspec -Properties swiftwinrt_exe=${CMAKE_CURRENT_SOURCE_DIR}\\out\\${CMAKE_BUILD_TYPE}\\bin\\swiftwinrt.exe -Version ${NUGET_VERSION_WITH_SUFFIX}
 )
 
 add_custom_target(nuget
-    DEPENDS ${CMAKE_BINARY_DIR}/nuget/company.thebrowser.swiftwinrt.nupkg)
+    DEPENDS ${CMAKE_BINARY_DIR}/nuget/TheBrowserCompany.SwiftWinRT.nupkg)
 
 add_dependencies(nuget install)

--- a/nuget/readme.txt
+++ b/nuget/readme.txt
@@ -1,5 +1,5 @@
 ========================================================================
-The company.browser.swiftwinrt NuGet package automatically generates swift code, 
+The TheBrowserCompany.SwiftWinRT NuGet package automatically generates swift code, 
 enabling you consume Windows Runtime classes.
 ========================================================================
 

--- a/nuget/swiftwinrt.nuspec
+++ b/nuget/swiftwinrt.nuspec
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata minClientVersion="2.5">
-    <id>company.thebrowser.swiftwinrt</id>
+    <id>TheBrowserCompany.SwiftWinRT</id>
     <version>0.0.0.1</version>
     <title>Swift/WinRT Build Support</title>
     <authors>TheBrowserCompany</authors>


### PR DESCRIPTION
`Company.Product` is more typical of Nuget than the java-style reverse-domain format: https://www.nuget.org/packages