### PR TITLE
Don't require the MainActor for awaiting IAsync[Action/Operation]'s

### DIFF
--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -1367,26 +1367,20 @@ vtable);
             if (type.generic_params.size() > 0) {
                 return_clause = w.write_temp(" -> %", type.generic_params[0]);
             }
-            w.write("public extension % {\n", bind<write_swift_type_identifier>(type));
-            {
-                auto extension_indent{ w.push_indent() };
-                w.write("func get() async throws% {\n", return_clause);
-                {
-                    auto get_indent{ w.push_indent() };
-                    w.write(R"(if status == .started {
-    let event = WaitableEvent()
-    completed = { _, _ in
-        Task { await event.signal() }
-    }
-    await event.wait()
-}
-)");
-                    // Let getResults propagate errors or cancelation
-                    w.write("return try getResults()\n");
-                }
-                w.write("}\n");
+            w.write(R"(public extension % {
+    func get() async throws% {
+        if status == .started {
+            let event = WaitableEvent()
+            completed = { _, _ in
+                Task { await event.signal() }
             }
-            w.write("}\n\n");
+            await event.wait()
+        }
+        return try getResults()
+    }
+}
+
+)", bind<write_swift_type_identifier>(type), return_clause);
         }
     }
 

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -1368,7 +1368,7 @@ vtable);
                 return_clause = w.write_temp(" -> %", type.generic_params[0]);
             }
             w.write(R"(public extension % {
-    func getWithAnyThread() async throws% {
+    func get() async throws% {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in
@@ -1380,7 +1380,7 @@ vtable);
     }
 
     ^@MainActor
-    func getWithMainActor() async throws% {
+    func getOnMainActor() async throws% {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -1378,21 +1378,9 @@ vtable);
         }
         return try getResults()
     }
-
-    ^@MainActor
-    func getOnMainActor() async throws% {
-        if status == .started {
-            let event = WaitableEvent()
-            completed = { _, _ in
-                Task { await event.signal() }
-            }
-            await event.wait()
-        }
-        return try getResults()
-    }
 }
 
-)", bind<write_swift_type_identifier>(type), return_clause, return_clause);
+)", bind<write_swift_type_identifier>(type), return_clause);
         }
     }
 

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -1368,7 +1368,19 @@ vtable);
                 return_clause = w.write_temp(" -> %", type.generic_params[0]);
             }
             w.write(R"(public extension % {
-    func get() async throws% {
+    func getWithAnyThread() async throws% {
+        if status == .started {
+            let event = WaitableEvent()
+            completed = { _, _ in
+                Task { await event.signal() }
+            }
+            await event.wait()
+        }
+        return try getResults()
+    }
+
+    ^@MainActor
+    func getWithMainActor() async throws% {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in
@@ -1380,7 +1392,7 @@ vtable);
     }
 }
 
-)", bind<write_swift_type_identifier>(type), return_clause);
+)", bind<write_swift_type_identifier>(type), return_clause, return_clause);
         }
     }
 

--- a/tests/test_app/AsyncTests.swift
+++ b/tests/test_app/AsyncTests.swift
@@ -1,0 +1,62 @@
+import WinSDK
+import XCTest
+import test_component
+import Foundation
+
+class AsyncTests : XCTestCase {
+  public func testAwaitAlreadyCompleted() throws {
+    try runSync {
+      let asyncOperation = AsyncMethods.getCompletedAsync(42)!
+      XCTAssertEqual(asyncOperation.status, .completed)
+      let result = try await asyncOperation.get()
+      XCTAssertEqual(result, 42)
+    }
+  }
+
+  public func testAwaitAlreadyFailed() throws {
+    try runSync {
+      let asyncOperation = AsyncMethods.getCompletedWithErrorAsync(-42)!
+      XCTAssertEqual(asyncOperation.status, .error)
+      do {
+        let _ = try await asyncOperation.get()
+        XCTFail("Expected an error to be thrown")
+      }
+      catch {}
+    }
+  }
+
+  func runSync(body: @escaping () async throws -> Void) throws {
+    guard let event = WinSDK.CreateEventA(nil, false, false, nil) else {
+      XCTFail("Failed to create event")
+      return
+    }
+    defer { WinSDK.CloseHandle(event) }
+
+    class Result { var error: (any Swift.Error)? = nil }
+    let result = Result()
+    Task {
+      do { try await body() }
+      catch let caught { result.error = caught }
+      WinSDK.SetEvent(event)
+    }
+
+    switch WinSDK.WaitForSingleObject(event, /* dwMilliseconds: */ 1000) {
+      case WAIT_OBJECT_0: break
+      case DWORD(WAIT_TIMEOUT):
+        XCTFail("Timed out waiting for async task to complete")
+        return
+      default:
+        XCTFail("Failed to wait for async task to complete")
+        return
+    }
+
+    if let error = result.error { throw error }
+  }
+}
+
+var asyncTests: [XCTestCaseEntry] = [
+  testCase([
+    ("testAwaitAlreadyCompleted", AsyncTests.testAwaitAlreadyCompleted),
+    ("testAwaitAlreadyFailed", AsyncTests.testAwaitAlreadyFailed),
+  ])
+]

--- a/tests/test_app/AsyncTests.swift
+++ b/tests/test_app/AsyncTests.swift
@@ -7,7 +7,7 @@ class AsyncTests : XCTestCase {
   public func testAwaitAlreadyCompleted() throws {
     let asyncOperation = AsyncMethods.getCompletedAsync(42)!
     XCTAssertEqual(asyncOperation.status, .completed)
-    let result = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
+    let result = try asyncBlock(timeout: 0.1) { try await asyncOperation.getWithAnyThread() }
     XCTAssertEqual(result, 42)
   }
 
@@ -15,7 +15,7 @@ class AsyncTests : XCTestCase {
     let asyncOperation = AsyncMethods.getCompletedWithErrorAsync(E_LAYOUTCYCLE)!
     XCTAssertEqual(asyncOperation.status, .error)
     do {
-      _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
+      _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.getWithAnyThread() }
       XCTFail("Expected an error to be thrown")
     } catch let error as test_component.Error {
       XCTAssertEqual(error.hr, E_LAYOUTCYCLE)
@@ -25,7 +25,7 @@ class AsyncTests : XCTestCase {
   public func testAwaitCompletionWithSuspension() throws {
     let asyncOperation = AsyncMethods.getPendingAsync()!
     runAfter(delay: 0.05) { try? asyncOperation.complete(42) }
-    let result = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
+    let result = try asyncBlock(timeout: 0.1) { try await asyncOperation.getWithAnyThread() }
     XCTAssertEqual(asyncOperation.status, .completed)
     XCTAssertEqual(result, 42)
   }
@@ -34,7 +34,7 @@ class AsyncTests : XCTestCase {
     let asyncOperation = AsyncMethods.getPendingAsync()!
     runAfter(delay: 0.05) { try? asyncOperation.completeWithError(E_LAYOUTCYCLE) }
     do {
-      _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
+      _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.getWithAnyThread() }
       XCTFail("Expected an error to be thrown")
     } catch let error as test_component.Error {
       XCTAssertEqual(error.hr, E_LAYOUTCYCLE)

--- a/tests/test_app/AsyncTests.swift
+++ b/tests/test_app/AsyncTests.swift
@@ -17,8 +17,7 @@ class AsyncTests : XCTestCase {
     do {
       _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
       XCTFail("Expected an error to be thrown")
-    }
-    catch let error as test_component.Error {
+    } catch let error as test_component.Error {
       XCTAssertEqual(error.hr, E_LAYOUTCYCLE)
     }
   }
@@ -37,8 +36,7 @@ class AsyncTests : XCTestCase {
     do {
       _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
       XCTFail("Expected an error to be thrown")
-    }
-    catch let error as test_component.Error {
+    } catch let error as test_component.Error {
       XCTAssertEqual(error.hr, E_LAYOUTCYCLE)
     }
   }
@@ -65,8 +63,11 @@ class AsyncTests : XCTestCase {
 
     let asyncResult = BoxedResult<Result>()
     Task {
-      do { asyncResult.result = .success(try await body()) }
-      catch { asyncResult.result = .failure(error) }
+      do {
+        asyncResult.result = .success(try await body())
+      } catch {
+        asyncResult.result = .failure(error)
+      }
       WinSDK.SetEvent(event)
     }
 

--- a/tests/test_app/AsyncTests.swift
+++ b/tests/test_app/AsyncTests.swift
@@ -5,52 +5,82 @@ import Foundation
 
 class AsyncTests : XCTestCase {
   public func testAwaitAlreadyCompleted() throws {
-    try runSync {
-      let asyncOperation = AsyncMethods.getCompletedAsync(42)!
-      XCTAssertEqual(asyncOperation.status, .completed)
-      let result = try await asyncOperation.get()
-      XCTAssertEqual(result, 42)
-    }
+    let asyncOperation = AsyncMethods.getCompletedAsync(42)!
+    XCTAssertEqual(asyncOperation.status, .completed)
+    let result = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
+    XCTAssertEqual(result, 42)
   }
 
   public func testAwaitAlreadyFailed() throws {
-    try runSync {
-      let asyncOperation = AsyncMethods.getCompletedWithErrorAsync(-42)!
-      XCTAssertEqual(asyncOperation.status, .error)
-      do {
-        let _ = try await asyncOperation.get()
-        XCTFail("Expected an error to be thrown")
-      }
-      catch {}
+    let asyncOperation = AsyncMethods.getCompletedWithErrorAsync(E_LAYOUTCYCLE)!
+    XCTAssertEqual(asyncOperation.status, .error)
+    do {
+      _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
+      XCTFail("Expected an error to be thrown")
+    }
+    catch let error as test_component.Error {
+      XCTAssertEqual(error.hr, E_LAYOUTCYCLE)
     }
   }
 
-  func runSync(body: @escaping () async throws -> Void) throws {
+  public func testAwaitCompletionWithSuspension() throws {
+    let asyncOperation = AsyncMethods.getPendingAsync()!
+    runAfter(delay: 0.05) { try? asyncOperation.complete(42) }
+    let result = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
+    XCTAssertEqual(asyncOperation.status, .completed)
+    XCTAssertEqual(result, 42)
+  }
+
+  public func testAwaitFailureWithSuspension() throws {
+    let asyncOperation = AsyncMethods.getPendingAsync()!
+    runAfter(delay: 0.05) { try? asyncOperation.completeWithError(E_LAYOUTCYCLE) }
+    do {
+      _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
+      XCTFail("Expected an error to be thrown")
+    }
+    catch let error as test_component.Error {
+      XCTAssertEqual(error.hr, E_LAYOUTCYCLE)
+    }
+  }
+
+  /// Runs a block asynchronously after a delay has elapsed
+  private func runAfter(delay: TimeInterval, body: @escaping () -> Void) {
+    Task {
+      try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+      body()
+    }
+  }
+
+  private class BoxedResult<T> {
+    var result: Result<T, any Swift.Error>? = nil
+  } 
+
+  /// Synchronously runs an async block with a timeout
+  private func asyncBlock<Result>(timeout: TimeInterval, body: @escaping () async throws -> Result) throws -> Result {
     guard let event = WinSDK.CreateEventA(nil, false, false, nil) else {
       XCTFail("Failed to create event")
-      return
+      throw test_component.Error(hr: E_FAIL)
     }
     defer { WinSDK.CloseHandle(event) }
 
-    class Result { var error: (any Swift.Error)? = nil }
-    let result = Result()
+    let asyncResult = BoxedResult<Result>()
     Task {
-      do { try await body() }
-      catch let caught { result.error = caught }
+      do { asyncResult.result = .success(try await body()) }
+      catch { asyncResult.result = .failure(error) }
       WinSDK.SetEvent(event)
     }
 
-    switch WinSDK.WaitForSingleObject(event, /* dwMilliseconds: */ 1000) {
+    switch WinSDK.WaitForSingleObject(event, /* dwMilliseconds: */ DWORD(timeout * 1000)) {
       case WAIT_OBJECT_0: break
       case DWORD(WAIT_TIMEOUT):
         XCTFail("Timed out waiting for async task to complete")
-        return
+        throw test_component.Error(hr: E_FAIL)
       default:
         XCTFail("Failed to wait for async task to complete")
-        return
+        throw test_component.Error(hr: E_FAIL)
     }
 
-    if let error = result.error { throw error }
+    return try asyncResult.result!.get()
   }
 }
 
@@ -58,5 +88,7 @@ var asyncTests: [XCTestCaseEntry] = [
   testCase([
     ("testAwaitAlreadyCompleted", AsyncTests.testAwaitAlreadyCompleted),
     ("testAwaitAlreadyFailed", AsyncTests.testAwaitAlreadyFailed),
+    ("testAwaitCompletionWithSuspension", AsyncTests.testAwaitCompletionWithSuspension),
+    ("testAwaitFailureWithSuspension", AsyncTests.testAwaitFailureWithSuspension),
   ])
 ]

--- a/tests/test_app/AsyncTests.swift
+++ b/tests/test_app/AsyncTests.swift
@@ -7,7 +7,7 @@ class AsyncTests : XCTestCase {
   public func testAwaitAlreadyCompleted() throws {
     let asyncOperation = AsyncMethods.getCompletedAsync(42)!
     XCTAssertEqual(asyncOperation.status, .completed)
-    let result = try asyncBlock(timeout: 0.1) { try await asyncOperation.getWithAnyThread() }
+    let result = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
     XCTAssertEqual(result, 42)
   }
 
@@ -15,7 +15,7 @@ class AsyncTests : XCTestCase {
     let asyncOperation = AsyncMethods.getCompletedWithErrorAsync(E_LAYOUTCYCLE)!
     XCTAssertEqual(asyncOperation.status, .error)
     do {
-      _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.getWithAnyThread() }
+      _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
       XCTFail("Expected an error to be thrown")
     } catch let error as test_component.Error {
       XCTAssertEqual(error.hr, E_LAYOUTCYCLE)
@@ -25,7 +25,7 @@ class AsyncTests : XCTestCase {
   public func testAwaitCompletionWithSuspension() throws {
     let asyncOperation = AsyncMethods.getPendingAsync()!
     runAfter(delay: 0.05) { try? asyncOperation.complete(42) }
-    let result = try asyncBlock(timeout: 0.1) { try await asyncOperation.getWithAnyThread() }
+    let result = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
     XCTAssertEqual(asyncOperation.status, .completed)
     XCTAssertEqual(result, 42)
   }
@@ -34,7 +34,7 @@ class AsyncTests : XCTestCase {
     let asyncOperation = AsyncMethods.getPendingAsync()!
     runAfter(delay: 0.05) { try? asyncOperation.completeWithError(E_LAYOUTCYCLE) }
     do {
-      _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.getWithAnyThread() }
+      _ = try asyncBlock(timeout: 0.1) { try await asyncOperation.get() }
       XCTFail("Expected an error to be thrown")
     } catch let error as test_component.Error {
       XCTAssertEqual(error.hr, E_LAYOUTCYCLE)

--- a/tests/test_app/main.swift
+++ b/tests/test_app/main.swift
@@ -433,7 +433,7 @@ var tests: [XCTestCaseEntry] = [
     ("testUnicode", SwiftWinRTTests.testUnicode),
     ("testErrorInfo", SwiftWinRTTests.testErrorInfo),
   ])
-] + valueBoxingTests + eventTests + collectionTests + aggregationTests
+] + valueBoxingTests + eventTests + collectionTests + aggregationTests + asyncTests
 
 RoInitialize(RO_INIT_MULTITHREADED)
-XCTMain(tests)
+XCTMain(asyncTests) // Don't let me complete the pull request with this!

--- a/tests/test_app/main.swift
+++ b/tests/test_app/main.swift
@@ -436,4 +436,4 @@ var tests: [XCTestCaseEntry] = [
 ] + valueBoxingTests + eventTests + collectionTests + aggregationTests + asyncTests
 
 RoInitialize(RO_INIT_MULTITHREADED)
-XCTMain(asyncTests) // Don't let me complete the pull request with this!
+XCTMain(tests)

--- a/tests/test_app/test_app.exe.manifest
+++ b/tests/test_app/test_app.exe.manifest
@@ -58,5 +58,9 @@
                   name="test_component.CollectionTester"
                   threadingModel="both"
                   xmlns="urn:schemas-microsoft-com:winrt.v1" />
+            <activatableClass
+                  name="test_component.AsyncMethods"
+                  threadingModel="both"
+                  xmlns="urn:schemas-microsoft-com:winrt.v1" />
       </file>
 </assembly>

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -23,11 +23,23 @@ typedef interface __x_ABI_Ctest__component_CIVoidToVoidDelegate __x_ABI_Ctest__c
 
 #endif // ____x_ABI_Ctest__component_CIVoidToVoidDelegate_FWD_DEFINED__
 
-    #ifndef ____x_ABI_Ctest__component_CIAsyncMethods_FWD_DEFINED__
-#define ____x_ABI_Ctest__component_CIAsyncMethods_FWD_DEFINED__
-    typedef interface __x_ABI_Ctest__component_CIAsyncMethods __x_ABI_Ctest__component_CIAsyncMethods;
+    #ifndef ____x_ABI_Ctest__component_CIAsyncMethodsStatics_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CIAsyncMethodsStatics_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CIAsyncMethodsStatics __x_ABI_Ctest__component_CIAsyncMethodsStatics;
 
-#endif // ____x_ABI_Ctest__component_CIAsyncMethods_FWD_DEFINED__
+#endif // ____x_ABI_Ctest__component_CIAsyncMethodsStatics_FWD_DEFINED__
+
+#ifndef ____x_ABI_Ctest__component_CIAsyncMethodsWithProgress_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CIAsyncMethodsWithProgress_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CIAsyncMethodsWithProgress __x_ABI_Ctest__component_CIAsyncMethodsWithProgress;
+
+#endif // ____x_ABI_Ctest__component_CIAsyncMethodsWithProgress_FWD_DEFINED__
+
+#ifndef ____x_ABI_Ctest__component_CIAsyncOperationInt_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CIAsyncOperationInt_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CIAsyncOperationInt __x_ABI_Ctest__component_CIAsyncOperationInt;
+
+#endif // ____x_ABI_Ctest__component_CIAsyncOperationInt_FWD_DEFINED__
 
 #ifndef ____x_ABI_Ctest__component_CIBase_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CIBase_FWD_DEFINED__
@@ -2315,39 +2327,113 @@ struct __x_ABI_Ctest__component_CStructWithEnum
     EXTERN_C const IID IID___x_ABI_Ctest__component_CIVoidToVoidDelegate;
     #endif /* !defined(____x_ABI_Ctest__component_CIVoidToVoidDelegate_INTERFACE_DEFINED__) */
     
-#if !defined(____x_ABI_Ctest__component_CIAsyncMethods_INTERFACE_DEFINED__)
-    #define ____x_ABI_Ctest__component_CIAsyncMethods_INTERFACE_DEFINED__
-    typedef struct __x_ABI_Ctest__component_CIAsyncMethodsVtbl
+#if !defined(____x_ABI_Ctest__component_CIAsyncMethodsStatics_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CIAsyncMethodsStatics_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CIAsyncMethodsStaticsVtbl
     {
         BEGIN_INTERFACE
 
-        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIAsyncMethods* This,
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIAsyncMethodsStatics* This,
             REFIID riid,
             void** ppvObject);
-        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIAsyncMethods* This);
-        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIAsyncMethods* This);
-        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIAsyncMethods* This,
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIAsyncMethodsStatics* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIAsyncMethodsStatics* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIAsyncMethodsStatics* This,
             ULONG* iidCount,
             IID** iids);
-        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIAsyncMethods* This,
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIAsyncMethodsStatics* This,
             HSTRING* className);
-        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIAsyncMethods* This,
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIAsyncMethodsStatics* This,
             TrustLevel* trustLevel);
-        HRESULT (STDMETHODCALLTYPE* OperationWithProgress)(__x_ABI_Ctest__component_CIAsyncMethods* This,
+        HRESULT (STDMETHODCALLTYPE* GetCompletedAsync)(__x_ABI_Ctest__component_CIAsyncMethodsStatics* This,
+        INT32 result,
+        __x_ABI_C__FIAsyncOperation_1_int** operation);
+    HRESULT (STDMETHODCALLTYPE* GetCompletedWithErrorAsync)(__x_ABI_Ctest__component_CIAsyncMethodsStatics* This,
+        HRESULT errorCode,
+        __x_ABI_C__FIAsyncOperation_1_int** operation);
+    HRESULT (STDMETHODCALLTYPE* GetPendingAsync)(__x_ABI_Ctest__component_CIAsyncMethodsStatics* This,
+        __x_ABI_C__FIAsyncOperation_1_int** operation);
+
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CIAsyncMethodsStaticsVtbl;
+
+    interface __x_ABI_Ctest__component_CIAsyncMethodsStatics
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CIAsyncMethodsStaticsVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CIAsyncMethodsStatics;
+#endif /* !defined(____x_ABI_Ctest__component_CIAsyncMethodsStatics_INTERFACE_DEFINED__) */
+    
+#if !defined(____x_ABI_Ctest__component_CIAsyncMethodsWithProgress_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CIAsyncMethodsWithProgress_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CIAsyncMethodsWithProgressVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIAsyncMethodsWithProgress* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIAsyncMethodsWithProgress* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIAsyncMethodsWithProgress* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIAsyncMethodsWithProgress* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIAsyncMethodsWithProgress* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIAsyncMethodsWithProgress* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* OperationWithProgress)(__x_ABI_Ctest__component_CIAsyncMethodsWithProgress* This,
         struct __x_ABI_CWindows_CFoundation_CDateTime value,
         __x_ABI_C__FIAsyncOperationWithProgress_2_int_double** operation);
 
         END_INTERFACE
-    } __x_ABI_Ctest__component_CIAsyncMethodsVtbl;
+    } __x_ABI_Ctest__component_CIAsyncMethodsWithProgressVtbl;
 
-    interface __x_ABI_Ctest__component_CIAsyncMethods
+    interface __x_ABI_Ctest__component_CIAsyncMethodsWithProgress
     {
-        CONST_VTBL struct __x_ABI_Ctest__component_CIAsyncMethodsVtbl* lpVtbl;
+        CONST_VTBL struct __x_ABI_Ctest__component_CIAsyncMethodsWithProgressVtbl* lpVtbl;
     };
 
     
-    EXTERN_C const IID IID___x_ABI_Ctest__component_CIAsyncMethods;
-#endif /* !defined(____x_ABI_Ctest__component_CIAsyncMethods_INTERFACE_DEFINED__) */
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CIAsyncMethodsWithProgress;
+#endif /* !defined(____x_ABI_Ctest__component_CIAsyncMethodsWithProgress_INTERFACE_DEFINED__) */
+    
+#if !defined(____x_ABI_Ctest__component_CIAsyncOperationInt_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CIAsyncOperationInt_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CIAsyncOperationIntVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIAsyncOperationInt* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIAsyncOperationInt* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIAsyncOperationInt* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIAsyncOperationInt* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIAsyncOperationInt* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIAsyncOperationInt* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* Complete)(__x_ABI_Ctest__component_CIAsyncOperationInt* This,
+        INT32 result);
+    HRESULT (STDMETHODCALLTYPE* CompleteWithError)(__x_ABI_Ctest__component_CIAsyncOperationInt* This,
+        HRESULT errorCode);
+
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CIAsyncOperationIntVtbl;
+
+    interface __x_ABI_Ctest__component_CIAsyncOperationInt
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CIAsyncOperationIntVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CIAsyncOperationInt;
+#endif /* !defined(____x_ABI_Ctest__component_CIAsyncOperationInt_INTERFACE_DEFINED__) */
     
 #if !defined(____x_ABI_Ctest__component_CIBase_INTERFACE_DEFINED__)
     #define ____x_ABI_Ctest__component_CIBase_INTERFACE_DEFINED__

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -2352,7 +2352,7 @@ struct __x_ABI_Ctest__component_CStructWithEnum
         HRESULT errorCode,
         __x_ABI_C__FIAsyncOperation_1_int** operation);
     HRESULT (STDMETHODCALLTYPE* GetPendingAsync)(__x_ABI_Ctest__component_CIAsyncMethodsStatics* This,
-        __x_ABI_C__FIAsyncOperation_1_int** operation);
+        __x_ABI_Ctest__component_CIAsyncOperationInt** result);
 
         END_INTERFACE
     } __x_ABI_Ctest__component_CIAsyncMethodsStaticsVtbl;

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -172,7 +172,7 @@ extension IAsyncAction {
 public typealias AnyIAsyncAction = any IAsyncAction
 
 public extension IAsyncAction {
-    func getWithAnyThread() async throws {
+    func get() async throws {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in
@@ -184,7 +184,7 @@ public extension IAsyncAction {
     }
 
     @MainActor
-    func getWithMainActor() async throws {
+    func getOnMainActor() async throws {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in
@@ -237,7 +237,7 @@ public protocol IAsyncOperationWithProgress<TResult,TProgress> : IAsyncInfo {
 public typealias AnyIAsyncOperationWithProgress<TResult,TProgress> = any IAsyncOperationWithProgress<TResult,TProgress>
 
 public extension IAsyncOperationWithProgress {
-    func getWithAnyThread() async throws -> TResult {
+    func get() async throws -> TResult {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in
@@ -249,7 +249,7 @@ public extension IAsyncOperationWithProgress {
     }
 
     @MainActor
-    func getWithMainActor() async throws -> TResult {
+    func getOnMainActor() async throws -> TResult {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in
@@ -273,7 +273,7 @@ public protocol IAsyncOperation<TResult> : IAsyncInfo {
 public typealias AnyIAsyncOperation<TResult> = any IAsyncOperation<TResult>
 
 public extension IAsyncOperation {
-    func getWithAnyThread() async throws -> TResult {
+    func get() async throws -> TResult {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in
@@ -285,7 +285,7 @@ public extension IAsyncOperation {
     }
 
     @MainActor
-    func getWithMainActor() async throws -> TResult {
+    func getOnMainActor() async throws -> TResult {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -172,7 +172,6 @@ extension IAsyncAction {
 public typealias AnyIAsyncAction = any IAsyncAction
 
 public extension IAsyncAction {
-    @MainActor
     func get() async throws {
         if status == .started {
             let event = WaitableEvent()
@@ -181,8 +180,10 @@ public extension IAsyncAction {
             }
             await event.wait()
         }
+        return try getResults()
     }
 }
+
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncinfo)
 public protocol IAsyncInfo : WinRTInterface {
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncinfo.cancel)
@@ -224,7 +225,6 @@ public protocol IAsyncOperationWithProgress<TResult,TProgress> : IAsyncInfo {
 public typealias AnyIAsyncOperationWithProgress<TResult,TProgress> = any IAsyncOperationWithProgress<TResult,TProgress>
 
 public extension IAsyncOperationWithProgress {
-    @MainActor
     func get() async throws -> TResult {
         if status == .started {
             let event = WaitableEvent()
@@ -236,6 +236,7 @@ public extension IAsyncOperationWithProgress {
         return try getResults()
     }
 }
+
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1)
 public protocol IAsyncOperation<TResult> : IAsyncInfo {
     associatedtype TResult
@@ -248,7 +249,6 @@ public protocol IAsyncOperation<TResult> : IAsyncInfo {
 public typealias AnyIAsyncOperation<TResult> = any IAsyncOperation<TResult>
 
 public extension IAsyncOperation {
-    @MainActor
     func get() async throws -> TResult {
         if status == .started {
             let event = WaitableEvent()
@@ -260,6 +260,7 @@ public extension IAsyncOperation {
         return try getResults()
     }
 }
+
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iclosable)
 public protocol IClosable : WinRTInterface {
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iclosable.close)

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -182,18 +182,6 @@ public extension IAsyncAction {
         }
         return try getResults()
     }
-
-    @MainActor
-    func getOnMainActor() async throws {
-        if status == .started {
-            let event = WaitableEvent()
-            completed = { _, _ in
-                Task { await event.signal() }
-            }
-            await event.wait()
-        }
-        return try getResults()
-    }
 }
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncinfo)
@@ -247,18 +235,6 @@ public extension IAsyncOperationWithProgress {
         }
         return try getResults()
     }
-
-    @MainActor
-    func getOnMainActor() async throws -> TResult {
-        if status == .started {
-            let event = WaitableEvent()
-            completed = { _, _ in
-                Task { await event.signal() }
-            }
-            await event.wait()
-        }
-        return try getResults()
-    }
 }
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1)
@@ -274,18 +250,6 @@ public typealias AnyIAsyncOperation<TResult> = any IAsyncOperation<TResult>
 
 public extension IAsyncOperation {
     func get() async throws -> TResult {
-        if status == .started {
-            let event = WaitableEvent()
-            completed = { _, _ in
-                Task { await event.signal() }
-            }
-            await event.wait()
-        }
-        return try getResults()
-    }
-
-    @MainActor
-    func getOnMainActor() async throws -> TResult {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -172,7 +172,19 @@ extension IAsyncAction {
 public typealias AnyIAsyncAction = any IAsyncAction
 
 public extension IAsyncAction {
-    func get() async throws {
+    func getWithAnyThread() async throws {
+        if status == .started {
+            let event = WaitableEvent()
+            completed = { _, _ in
+                Task { await event.signal() }
+            }
+            await event.wait()
+        }
+        return try getResults()
+    }
+
+    @MainActor
+    func getWithMainActor() async throws {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in
@@ -225,7 +237,19 @@ public protocol IAsyncOperationWithProgress<TResult,TProgress> : IAsyncInfo {
 public typealias AnyIAsyncOperationWithProgress<TResult,TProgress> = any IAsyncOperationWithProgress<TResult,TProgress>
 
 public extension IAsyncOperationWithProgress {
-    func get() async throws -> TResult {
+    func getWithAnyThread() async throws -> TResult {
+        if status == .started {
+            let event = WaitableEvent()
+            completed = { _, _ in
+                Task { await event.signal() }
+            }
+            await event.wait()
+        }
+        return try getResults()
+    }
+
+    @MainActor
+    func getWithMainActor() async throws -> TResult {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in
@@ -249,7 +273,19 @@ public protocol IAsyncOperation<TResult> : IAsyncInfo {
 public typealias AnyIAsyncOperation<TResult> = any IAsyncOperation<TResult>
 
 public extension IAsyncOperation {
-    func get() async throws -> TResult {
+    func getWithAnyThread() async throws -> TResult {
+        if status == .started {
+            let event = WaitableEvent()
+            completed = { _, _ in
+                Task { await event.signal() }
+            }
+            await event.wait()
+        }
+        return try getResults()
+    }
+
+    @MainActor
+    func getWithMainActor() async throws -> TResult {
         if status == .started {
             let event = WaitableEvent()
             completed = { _, _ in

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -3,7 +3,7 @@
 import Ctest_component
 
 private var IID___x_ABI_Ctest__component_CIAsyncMethodsStatics: test_component.IID {
-    .init(Data1: 0x4CA9C2EA, Data2: 0x9C2E, Data3: 0x5688, Data4: ( 0x90,0x32,0xC5,0x65,0x78,0x6C,0x72,0x05 ))// 4CA9C2EA-9C2E-5688-9032-C565786C7205
+    .init(Data1: 0x5FAAD8F4, Data2: 0x29D7, Data3: 0x5C26, Data4: ( 0xA8,0x72,0x35,0x42,0xE3,0xE1,0x86,0x7A ))// 5FAAD8F4-29D7-5C26-A872-3542E3E1867A
 }
 
 private var IID___x_ABI_Ctest__component_CIAsyncMethodsWithProgress: test_component.IID {

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -187,12 +187,41 @@ private var IID___x_ABI_Ctest__component_CIVoidToVoidDelegate: test_component.II
 }
 
 public enum __ABI_test_component {
-    public class IAsyncMethods: test_component.IInspectable {
-        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIAsyncMethods }
+    public class IAsyncMethodsStatics: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIAsyncMethodsStatics }
+
+        internal func GetCompletedAsyncImpl(_ result: Int32) throws -> test_component.AnyIAsyncOperation<Int32>? {
+            var operation: UnsafeMutablePointer<__x_ABI_C__FIAsyncOperation_1_int>?
+            _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethodsStatics.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.GetCompletedAsync(pThis, result, &operation))
+            }
+            return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
+        }
+
+        internal func GetCompletedWithErrorAsyncImpl(_ errorCode: HRESULT) throws -> test_component.AnyIAsyncOperation<Int32>? {
+            var operation: UnsafeMutablePointer<__x_ABI_C__FIAsyncOperation_1_int>?
+            _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethodsStatics.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.GetCompletedWithErrorAsync(pThis, errorCode, &operation))
+            }
+            return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
+        }
+
+        internal func GetPendingAsyncImpl() throws -> test_component.AsyncOperationInt? {
+            var result: UnsafeMutablePointer<__x_ABI_Ctest__component_CIAsyncOperationInt>?
+            _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethodsStatics.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.GetPendingAsync(pThis, &result))
+            }
+            return .from(abi: result)
+        }
+
+    }
+
+    public class IAsyncMethodsWithProgress: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIAsyncMethodsWithProgress }
 
         open func OperationWithProgressImpl(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncOperationWithProgress<Int32, Double>? {
             var operation: UnsafeMutablePointer<__x_ABI_C__FIAsyncOperationWithProgress_2_int_double>?
-            _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethods.self) { pThis in
+            _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethodsWithProgress.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OperationWithProgress(pThis, .from(swift: value), &operation))
             }
             return test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper.unwrapFrom(abi: operation)
@@ -253,7 +282,98 @@ public enum __ABI_test_component {
         }
     )
 
-    public typealias IAsyncMethodsWrapper = InterfaceWrapperBase<__IMPL_test_component.IAsyncMethodsBridge>
+    public typealias IAsyncMethodsWithProgressWrapper = InterfaceWrapperBase<__IMPL_test_component.IAsyncMethodsWithProgressBridge>
+    public class IAsyncOperationInt: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIAsyncOperationInt }
+
+        open func CompleteImpl(_ result: Int32) throws {
+            _ = try perform(as: __x_ABI_Ctest__component_CIAsyncOperationInt.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.Complete(pThis, result))
+            }
+        }
+
+        open func CompleteWithErrorImpl(_ errorCode: HRESULT) throws {
+            _ = try perform(as: __x_ABI_Ctest__component_CIAsyncOperationInt.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.CompleteWithError(pThis, errorCode))
+            }
+        }
+
+    }
+
+    internal static var IAsyncOperationIntVTable: __x_ABI_Ctest__component_CIAsyncOperationIntVtbl = .init(
+        QueryInterface: {
+            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
+            ppvObject.pointee = nil
+
+            switch riid.pointee {
+                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IAsyncOperationIntWrapper.IID:
+                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
+                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
+                    return S_OK
+                default:
+                    guard let instance = IAsyncOperationIntWrapper.tryUnwrapFrom(raw: pUnk),
+                          let iUnknownRef = instance.queryInterface(riid.pointee) else { return failWith(err: E_NOINTERFACE )}
+                    ppvObject.pointee = UnsafeMutableRawPointer(iUnknownRef.ref)
+                    return S_OK
+
+            }
+        },
+
+        AddRef: {
+             guard let wrapper = IAsyncOperationIntWrapper.fromRaw($0) else { return 1 }
+             _ = wrapper.retain()
+             return ULONG(_getRetainCount(wrapper.takeUnretainedValue()))
+        },
+
+        Release: {
+            guard let wrapper = IAsyncOperationIntWrapper.fromRaw($0) else { return 1 }
+            return ULONG(_getRetainCount(wrapper.takeRetainedValue()))
+        },
+
+        GetIids: {
+            let size = MemoryLayout<test_component.IID>.size
+            let iids = CoTaskMemAlloc(UInt64(size) * 3).assumingMemoryBound(to: test_component.IID.self)
+            iids[0] = IUnknown.IID
+            iids[1] = IInspectable.IID
+            iids[2] = __ABI_test_component.IAsyncOperationIntWrapper.IID
+            $1!.pointee = 3
+            $2!.pointee = iids
+            return S_OK
+        },
+
+        GetRuntimeClassName: {
+            _ = $0
+            let hstring = try! HString("test_component.IAsyncOperationInt").detach()
+            $1!.pointee = hstring
+            return S_OK
+        },
+
+        GetTrustLevel: {
+            _ = $0
+            $1!.pointee = TrustLevel(rawValue: 0)
+            return S_OK
+        },
+
+        Complete: {
+            do {
+                guard let __unwrapped__instance = IAsyncOperationIntWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+                let result: Int32 = $1
+                try __unwrapped__instance.complete(result)
+                return S_OK
+            } catch { return failWith(err: E_FAIL) } 
+        },
+
+        CompleteWithError: {
+            do {
+                guard let __unwrapped__instance = IAsyncOperationIntWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+                let errorCode: HRESULT = $1
+                try __unwrapped__instance.completeWithError(errorCode)
+                return S_OK
+            } catch { return failWith(err: E_FAIL) } 
+        }
+    )
+
+    public typealias IAsyncOperationIntWrapper = InterfaceWrapperBase<__IMPL_test_component.IAsyncOperationIntBridge>
     public class IBase: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBase }
 
@@ -2530,3 +2650,4 @@ public extension WinRTDelegateBridge where CABI == __x_ABI_Ctest__component_CIVo
         return .init(lpVtbl:vtblPtr)
     }
 }
+

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -2,8 +2,16 @@
 // swiftlint:disable all
 import Ctest_component
 
-private var IID___x_ABI_Ctest__component_CIAsyncMethods: test_component.IID {
-    .init(Data1: 0xC76E7341, Data2: 0xF54D, Data3: 0x502B, Data4: ( 0xAA,0x8F,0xF2,0xAD,0x9A,0x48,0xC1,0x3F ))// C76E7341-F54D-502B-AA8F-F2AD9A48C13F
+private var IID___x_ABI_Ctest__component_CIAsyncMethodsStatics: test_component.IID {
+    .init(Data1: 0x4CA9C2EA, Data2: 0x9C2E, Data3: 0x5688, Data4: ( 0x90,0x32,0xC5,0x65,0x78,0x6C,0x72,0x05 ))// 4CA9C2EA-9C2E-5688-9032-C565786C7205
+}
+
+private var IID___x_ABI_Ctest__component_CIAsyncMethodsWithProgress: test_component.IID {
+    .init(Data1: 0xD782777A, Data2: 0xBE43, Data3: 0x55FA, Data4: ( 0x92,0x6E,0x51,0xE6,0x40,0x23,0xD5,0xEC ))// D782777A-BE43-55FA-926E-51E64023D5EC
+}
+
+private var IID___x_ABI_Ctest__component_CIAsyncOperationInt: test_component.IID {
+    .init(Data1: 0x1D730A19, Data2: 0xCD91, Data3: 0x5A59, Data4: ( 0x96,0x83,0x51,0xA6,0x11,0xFA,0x48,0x08 ))// 1D730A19-CD91-5A59-9683-51A611FA4808
 }
 
 private var IID___x_ABI_Ctest__component_CIBase: test_component.IID {
@@ -192,13 +200,13 @@ public enum __ABI_test_component {
 
     }
 
-    internal static var IAsyncMethodsVTable: __x_ABI_Ctest__component_CIAsyncMethodsVtbl = .init(
+    internal static var IAsyncMethodsWithProgressVTable: __x_ABI_Ctest__component_CIAsyncMethodsWithProgressVtbl = .init(
         QueryInterface: {
             guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
             ppvObject.pointee = nil
 
             switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IAsyncMethodsWrapper.IID:
+                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IAsyncMethodsWithProgressWrapper.IID:
                     _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
                     ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
                     return S_OK
@@ -214,7 +222,7 @@ public enum __ABI_test_component {
             let iids = CoTaskMemAlloc(UInt64(size) * 3).assumingMemoryBound(to: test_component.IID.self)
             iids[0] = IUnknown.IID
             iids[1] = IInspectable.IID
-            iids[2] = __ABI_test_component.IAsyncMethodsWrapper.IID
+            iids[2] = __ABI_test_component.IAsyncMethodsWithProgressWrapper.IID
             $1!.pointee = 3
             $2!.pointee = iids
             return S_OK
@@ -222,7 +230,7 @@ public enum __ABI_test_component {
 
         GetRuntimeClassName: {
             _ = $0
-            let hstring = try! HString("test_component.IAsyncMethods").detach()
+            let hstring = try! HString("test_component.IAsyncMethodsWithProgress").detach()
             $1!.pointee = hstring
             return S_OK
         },
@@ -235,7 +243,7 @@ public enum __ABI_test_component {
 
         OperationWithProgress: {
             do {
-                guard let __unwrapped__instance = IAsyncMethodsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+                guard let __unwrapped__instance = IAsyncMethodsWithProgressWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 let value: test_component.DateTime = .from(abi: $1)
                 let operation = try __unwrapped__instance.operationWithProgress(value)
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper(operation)
@@ -2522,4 +2530,3 @@ public extension WinRTDelegateBridge where CABI == __x_ABI_Ctest__component_CIVo
         return .init(lpVtbl:vtblPtr)
     }
 }
-

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -240,12 +240,12 @@ public enum __ABI_test_component {
                     ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
                     return S_OK
                 default:
-                    return IAsyncMethodsWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
+                    return IAsyncMethodsWithProgressWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
             }
         },
 
-        AddRef: { IAsyncMethodsWrapper.addRef($0) },
-        Release: { IAsyncMethodsWrapper.release($0) },
+        AddRef: { IAsyncMethodsWithProgressWrapper.addRef($0) },
+        Release: { IAsyncMethodsWithProgressWrapper.release($0) },
         GetIids: {
             let size = MemoryLayout<test_component.IID>.size
             let iids = CoTaskMemAlloc(UInt64(size) * 3).assumingMemoryBound(to: test_component.IID.self)
@@ -311,25 +311,12 @@ public enum __ABI_test_component {
                     ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
                     return S_OK
                 default:
-                    guard let instance = IAsyncOperationIntWrapper.tryUnwrapFrom(raw: pUnk),
-                          let iUnknownRef = instance.queryInterface(riid.pointee) else { return failWith(err: E_NOINTERFACE )}
-                    ppvObject.pointee = UnsafeMutableRawPointer(iUnknownRef.ref)
-                    return S_OK
-
+                    return IAsyncOperationIntWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
             }
         },
 
-        AddRef: {
-             guard let wrapper = IAsyncOperationIntWrapper.fromRaw($0) else { return 1 }
-             _ = wrapper.retain()
-             return ULONG(_getRetainCount(wrapper.takeUnretainedValue()))
-        },
-
-        Release: {
-            guard let wrapper = IAsyncOperationIntWrapper.fromRaw($0) else { return 1 }
-            return ULONG(_getRetainCount(wrapper.takeRetainedValue()))
-        },
-
+        AddRef: { IAsyncOperationIntWrapper.addRef($0) },
+        Release: { IAsyncOperationIntWrapper.release($0) },
         GetIids: {
             let size = MemoryLayout<test_component.IID>.size
             let iids = CoTaskMemAlloc(UInt64(size) * 3).assumingMemoryBound(to: test_component.IID.self)

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -3,10 +3,10 @@
 import Ctest_component
 
 public enum __IMPL_test_component {
-    public class IAsyncMethodsBridge : AbiInterfaceBridge {
-        public typealias CABI = __x_ABI_Ctest__component_CIAsyncMethods
-        public typealias SwiftABI = __ABI_test_component.IAsyncMethods
-        public typealias SwiftProjection = AnyIAsyncMethods
+    public class IAsyncMethodsWithProgressBridge : AbiInterfaceBridge {
+        public typealias CABI = __x_ABI_Ctest__component_CIAsyncMethodsWithProgress
+        public typealias SwiftABI = __ABI_test_component.IAsyncMethodsWithProgress
+        public typealias SwiftProjection = AnyIAsyncMethodsWithProgress
         public static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IAsyncMethodsWithProgressImpl(abi)
@@ -18,8 +18,8 @@ public enum __IMPL_test_component {
         }
     }
 
-    fileprivate class IAsyncMethodsImpl: IAsyncMethods, WinRTAbiImpl {
-        fileprivate typealias Bridge = IAsyncMethodsBridge
+    fileprivate class IAsyncMethodsWithProgressImpl: IAsyncMethodsWithProgress, WinRTAbiImpl {
+        fileprivate typealias Bridge = IAsyncMethodsWithProgressBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: test_component.IInspectable { _default }
         fileprivate init(_ fromAbi: UnsafeMutablePointer<Bridge.CABI>) {
@@ -28,6 +28,39 @@ public enum __IMPL_test_component {
 
         fileprivate func operationWithProgress(_ value: test_component.DateTime) throws -> AnyIAsyncOperationWithProgress<Int32, Double>! {
             try _default.OperationWithProgressImpl(value)
+        }
+
+    }
+
+    public class IAsyncOperationIntBridge : AbiInterfaceBridge {
+        public typealias CABI = __x_ABI_Ctest__component_CIAsyncOperationInt
+        public typealias SwiftABI = __ABI_test_component.IAsyncOperationInt
+        public typealias SwiftProjection = AnyIAsyncOperationInt
+        public static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+            guard let abi = abi else { return nil }
+            return IAsyncOperationIntImpl(abi)
+        }
+
+        public static func makeAbi() -> CABI {
+            let vtblPtr = withUnsafeMutablePointer(to: &__ABI_test_component.IAsyncOperationIntVTable) { $0 }
+            return .init(lpVtbl: vtblPtr)
+        }
+    }
+
+    fileprivate class IAsyncOperationIntImpl: IAsyncOperationInt, WinRTAbiImpl {
+        fileprivate typealias Bridge = IAsyncOperationIntBridge
+        fileprivate let _default: Bridge.SwiftABI
+        fileprivate var thisPtr: test_component.IInspectable { _default }
+        fileprivate init(_ fromAbi: UnsafeMutablePointer<Bridge.CABI>) {
+            _default = Bridge.SwiftABI(fromAbi)
+        }
+
+        fileprivate func complete(_ result: Int32) throws {
+            try _default.CompleteImpl(result)
+        }
+
+        fileprivate func completeWithError(_ errorCode: HRESULT) throws {
+            try _default.CompleteWithErrorImpl(errorCode)
         }
 
     }

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -9,11 +9,11 @@ public enum __IMPL_test_component {
         public typealias SwiftProjection = AnyIAsyncMethods
         public static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
-            return IAsyncMethodsImpl(abi)
+            return IAsyncMethodsWithProgressImpl(abi)
         }
 
         public static func makeAbi() -> CABI {
-            let vtblPtr = withUnsafeMutablePointer(to: &__ABI_test_component.IAsyncMethodsVTable) { $0 }
+            let vtblPtr = withUnsafeMutablePointer(to: &__ABI_test_component.IAsyncMethodsWithProgressVTable) { $0 }
             return .init(lpVtbl: vtblPtr)
         }
     }

--- a/tests/test_component/Sources/test_component/test_component+MakeFromAbi.swift
+++ b/tests/test_component/Sources/test_component/test_component+MakeFromAbi.swift
@@ -32,9 +32,14 @@ fileprivate func makeIVectorChangedEventArgsFrom(abi: test_component.IInspectabl
     return __IMPL_Windows_Foundation_Collections.IVectorChangedEventArgsBridge.from(abi: RawPointer(swiftAbi))!
 }
 
-fileprivate func makeIAsyncMethodsFrom(abi: test_component.IInspectable) -> Any {
-    let swiftAbi: __ABI_test_component.IAsyncMethods = try! abi.QueryInterface()
-    return __IMPL_test_component.IAsyncMethodsBridge.from(abi: RawPointer(swiftAbi))!
+fileprivate func makeIAsyncMethodsWithProgressFrom(abi: test_component.IInspectable) -> Any {
+    let swiftAbi: __ABI_test_component.IAsyncMethodsWithProgress = try! abi.QueryInterface()
+    return __IMPL_test_component.IAsyncMethodsWithProgressBridge.from(abi: RawPointer(swiftAbi))!
+}
+
+fileprivate func makeIAsyncOperationIntFrom(abi: test_component.IInspectable) -> Any {
+    let swiftAbi: __ABI_test_component.IAsyncOperationInt = try! abi.QueryInterface()
+    return __IMPL_test_component.IAsyncOperationIntBridge.from(abi: RawPointer(swiftAbi))!
 }
 
 fileprivate func makeIBasicFrom(abi: test_component.IInspectable) -> Any {
@@ -169,7 +174,8 @@ public class __MakeFromAbi: MakeFromAbi {
             case "IStringable": return makeIStringableFrom(abi: abi)
             case "IPropertySet": return makeIPropertySetFrom(abi: abi)
             case "IVectorChangedEventArgs": return makeIVectorChangedEventArgsFrom(abi: abi)
-            case "IAsyncMethods": return makeIAsyncMethodsFrom(abi: abi)
+            case "IAsyncMethodsWithProgress": return makeIAsyncMethodsWithProgressFrom(abi: abi)
+            case "IAsyncOperationInt": return makeIAsyncOperationIntFrom(abi: abi)
             case "IBasic": return makeIBasicFrom(abi: abi)
             case "IIAmImplementable": return makeIIAmImplementableFrom(abi: abi)
             case "IInterfaceWithObservableVector": return makeIInterfaceWithObservableVectorFrom(abi: abi)

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -10,28 +10,25 @@ public typealias Unsigned = __x_ABI_Ctest__component_CUnsigned
 public final class AsyncMethods {
     private static let _IAsyncMethodsStatics: __ABI_test_component.IAsyncMethodsStatics = try! RoGetActivationFactory(HString("test_component.AsyncMethods"))
     public static func getCompletedAsync(_ result: Int32) -> AnyIAsyncOperation<Int32>! {
-        let operation = try! _IAsyncMethodsStatics.GetCompletedAsyncImpl(result)
-        return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
+        return try! _IAsyncMethodsStatics.GetCompletedAsyncImpl(result)
     }
 
     public static func getCompletedWithErrorAsync(_ errorCode: HRESULT) -> AnyIAsyncOperation<Int32>! {
-        let operation = try! _IAsyncMethodsStatics.GetCompletedWithErrorAsyncImpl(errorCode)
-        return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
+        return try! _IAsyncMethodsStatics.GetCompletedWithErrorAsyncImpl(errorCode)
     }
 
     public static func getPendingAsync() -> AsyncOperationInt! {
-        let result = try! _IAsyncMethodsStatics.GetPendingAsyncImpl()
-        return .from(abi: result)
+        return try! _IAsyncMethodsStatics.GetPendingAsyncImpl()
     }
 
 }
 
-public final class AsyncOperationInt : WinRTClass, IAsyncOperation, test_component.IAsyncInfo {
+public final class AsyncOperationInt : WinRTClass, IAsyncOperationInt, IAsyncOperation, test_component.IAsyncInfo {
     @_spi(WinRTInternal)
     private (set) public var _inner: test_component.IInspectable!
     public typealias TResult = Int32
-    private typealias SwiftABI = IAsyncOperationInt32
-    private typealias CABI = __x_ABI_C__FIAsyncOperation_1_int
+    private typealias SwiftABI = __ABI_test_component.IAsyncOperationInt
+    private typealias CABI = __x_ABI_Ctest__component_CIAsyncOperationInt
     private lazy var _default: SwiftABI! = try! _inner.QueryInterface()
     @_spi(WinRTInternal)
     public func _getABI<T>() -> UnsafeMutablePointer<T>? {
@@ -50,7 +47,7 @@ public final class AsyncOperationInt : WinRTClass, IAsyncOperation, test_compone
     public var thisPtr: test_component.IInspectable { try! _inner.QueryInterface() }
 
     @_spi(WinRTInternal)
-    public static func from(abi: UnsafeMutablePointer<__x_ABI_C__FIAsyncOperation_1_int>?) -> AsyncOperationInt? {
+    public static func from(abi: UnsafeMutablePointer<__x_ABI_Ctest__component_CIAsyncOperationInt>?) -> AsyncOperationInt? {
         guard let abi = abi else { return nil }
         return .init(fromAbi: test_component.IInspectable(consuming: abi))
     }
@@ -63,13 +60,22 @@ public final class AsyncOperationInt : WinRTClass, IAsyncOperation, test_compone
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? {
         return test_component.queryInterface(self, iid)
     }
+    public func complete(_ result: Int32) throws {
+        try _default.CompleteImpl(result)
+    }
+
+    public func completeWithError(_ errorCode: HRESULT) throws {
+        try _default.CompleteWithErrorImpl(errorCode)
+    }
+
+    internal lazy var _IAsyncOperation: IAsyncOperationInt32 = try! _inner.QueryInterface()
     public func getResults() throws -> Int32 {
-        try _default.GetResultsImpl()
+        try _IAsyncOperation.GetResultsImpl()
     }
 
     public var completed : AsyncOperationCompletedHandler<Int32>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _IAsyncOperation.get_CompletedImpl() }
+        set { try! _IAsyncOperation.put_CompletedImpl(newValue) }
     }
 
     internal lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo = try! _inner.QueryInterface()
@@ -2091,3 +2097,4 @@ extension test_component.Unsigned {
     }
 }
 extension test_component.Unsigned: @retroactive Hashable, @retroactive Codable {}
+

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -19,9 +19,9 @@ public final class AsyncMethods {
         return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
     }
 
-    public static func getPendingAsync() -> AnyIAsyncOperation<Int32>! {
-        let operation = try! _IAsyncMethodsStatics.GetPendingAsyncImpl()
-        return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
+    public static func getPendingAsync() -> AsyncOperationInt! {
+        let result = try! _IAsyncMethodsStatics.GetPendingAsyncImpl()
+        return .from(abi: result)
     }
 
 }
@@ -1751,6 +1751,23 @@ extension IAsyncMethodsWithProgress {
     }
 }
 public typealias AnyIAsyncMethodsWithProgress = any IAsyncMethodsWithProgress
+
+public protocol IAsyncOperationInt : WinRTInterface {
+    func complete(_ result: Int32) throws
+    func completeWithError(_ errorCode: HRESULT) throws
+}
+
+extension IAsyncOperationInt {
+    public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? {
+        switch iid {
+            case __ABI_test_component.IAsyncOperationIntWrapper.IID:
+                let wrapper = __ABI_test_component.IAsyncOperationIntWrapper(self)
+                return wrapper!.queryInterface(iid)
+            default: return nil
+        }
+    }
+}
+public typealias AnyIAsyncOperationInt = any IAsyncOperationInt
 
 public protocol IBasic : WinRTInterface {
     func method()

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -7,6 +7,25 @@ public typealias Keywords = __x_ABI_Ctest__component_CKeywords
 public typealias Signed = __x_ABI_Ctest__component_CSigned
 public typealias SwiftifiableNames = __x_ABI_Ctest__component_CSwiftifiableNames
 public typealias Unsigned = __x_ABI_Ctest__component_CUnsigned
+public final class AsyncMethods {
+    private static let _IAsyncMethodsStatics: __ABI_test_component.IAsyncMethodsStatics = try! RoGetActivationFactory(HString("test_component.AsyncMethods"))
+    public static func getCompletedAsync(_ result: Int32) -> AnyIAsyncOperation<Int32>! {
+        let operation = try! _IAsyncMethodsStatics.GetCompletedAsyncImpl(result)
+        return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
+    }
+
+    public static func getCompletedWithErrorAsync(_ errorCode: HRESULT) -> AnyIAsyncOperation<Int32>! {
+        let operation = try! _IAsyncMethodsStatics.GetCompletedWithErrorAsyncImpl(errorCode)
+        return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
+    }
+
+    public static func getPendingAsync() -> AnyIAsyncOperation<Int32>! {
+        let operation = try! _IAsyncMethodsStatics.GetPendingAsyncImpl()
+        return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
+    }
+
+}
+
 public final class AsyncOperationInt : WinRTClass, IAsyncOperation, test_component.IAsyncInfo {
     @_spi(WinRTInternal)
     private (set) public var _inner: test_component.IInspectable!
@@ -1717,21 +1736,21 @@ public struct StructWithEnum: Hashable, Codable {
     }
 }
 
-public protocol IAsyncMethods : WinRTInterface {
+public protocol IAsyncMethodsWithProgress : WinRTInterface {
     func operationWithProgress(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncOperationWithProgress<Int32, Double>!
 }
 
-extension IAsyncMethods {
+extension IAsyncMethodsWithProgress {
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? {
         switch iid {
-            case __ABI_test_component.IAsyncMethodsWrapper.IID:
-                let wrapper = __ABI_test_component.IAsyncMethodsWrapper(self)
+            case __ABI_test_component.IAsyncMethodsWithProgressWrapper.IID:
+                let wrapper = __ABI_test_component.IAsyncMethodsWithProgressWrapper(self)
                 return wrapper!.queryInterface(iid)
             default: return nil
         }
     }
 }
-public typealias AnyIAsyncMethods = any IAsyncMethods
+public typealias AnyIAsyncMethodsWithProgress = any IAsyncMethodsWithProgress
 
 public protocol IBasic : WinRTInterface {
     func method()
@@ -2055,4 +2074,3 @@ extension test_component.Unsigned {
     }
 }
 extension test_component.Unsigned: @retroactive Hashable, @retroactive Codable {}
-

--- a/tests/test_component/cpp/AsyncMethods.cpp
+++ b/tests/test_component/cpp/AsyncMethods.cpp
@@ -19,7 +19,7 @@ namespace winrt::test_component::implementation
         return asyncOp;
     }
 
-    winrt::Windows::Foundation::IAsyncOperation<int32_t> AsyncMethods::GetPendingAsync()
+    winrt::test_component::AsyncOperationInt AsyncMethods::GetPendingAsync()
     {
         return winrt::make<AsyncOperationInt>();
     }

--- a/tests/test_component/cpp/AsyncMethods.cpp
+++ b/tests/test_component/cpp/AsyncMethods.cpp
@@ -1,0 +1,26 @@
+#include "pch.h"
+#include "AsyncOperationInt.h"
+#include "AsyncMethods.h"
+#include "AsyncMethods.g.cpp"
+
+namespace winrt::test_component::implementation
+{
+    winrt::Windows::Foundation::IAsyncOperation<int32_t> AsyncMethods::GetCompletedAsync(int32_t result)
+    {
+        auto asyncOp = winrt::make<AsyncOperationInt>();
+        asyncOp.Complete(result);
+        return asyncOp;
+    }
+
+    winrt::Windows::Foundation::IAsyncOperation<int32_t> AsyncMethods::GetCompletedWithErrorAsync(winrt::hresult errorCode)
+    {
+        auto asyncOp = winrt::make<AsyncOperationInt>();
+        asyncOp.CompleteWithError(errorCode);
+        return asyncOp;
+    }
+
+    winrt::Windows::Foundation::IAsyncOperation<int32_t> AsyncMethods::GetPendingAsync()
+    {
+        return winrt::make<AsyncOperationInt>();
+    }
+}

--- a/tests/test_component/cpp/AsyncMethods.h
+++ b/tests/test_component/cpp/AsyncMethods.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "AsyncMethods.g.h"
+
+namespace winrt::test_component::implementation
+{
+    struct AsyncMethods
+    {
+        AsyncMethods() = default;
+
+        static winrt::Windows::Foundation::IAsyncOperation<int32_t> GetCompletedAsync(int32_t result);
+        static winrt::Windows::Foundation::IAsyncOperation<int32_t> GetCompletedWithErrorAsync(winrt::hresult errorCode);
+        static winrt::Windows::Foundation::IAsyncOperation<int32_t> GetPendingAsync();
+    };
+}
+
+namespace winrt::test_component::factory_implementation
+{
+    struct AsyncMethods : AsyncMethodsT<AsyncMethods, implementation::AsyncMethods>
+    {
+    };
+}

--- a/tests/test_component/cpp/AsyncMethods.h
+++ b/tests/test_component/cpp/AsyncMethods.h
@@ -9,7 +9,7 @@ namespace winrt::test_component::implementation
 
         static winrt::Windows::Foundation::IAsyncOperation<int32_t> GetCompletedAsync(int32_t result);
         static winrt::Windows::Foundation::IAsyncOperation<int32_t> GetCompletedWithErrorAsync(winrt::hresult errorCode);
-        static winrt::Windows::Foundation::IAsyncOperation<int32_t> GetPendingAsync();
+        static winrt::test_component::AsyncOperationInt GetPendingAsync();
     };
 }
 

--- a/tests/test_component/cpp/AsyncMethods.idl
+++ b/tests/test_component/cpp/AsyncMethods.idl
@@ -1,0 +1,27 @@
+import "Windows.Foundation.idl";
+
+namespace test_component
+{
+    runtimeclass AsyncOperationInt : Windows.Foundation.IAsyncOperation<Int32>
+    {
+        void Complete(Int32 result);
+        void CompleteWithError(HRESULT errorCode);
+    }
+
+    runtimeclass AsyncMethods
+    {
+        static Windows.Foundation.IAsyncOperation<Int32> GetCompletedAsync(Int32 result);
+        static Windows.Foundation.IAsyncOperation<Int32> GetCompletedWithErrorAsync(HRESULT errorCode);
+        static Windows.Foundation.IAsyncOperation<Int32> GetPendingAsync();
+    }
+    
+    /* just here to make sure things compile, get weird C++ linker error if try to put this on a class:
+    Simple.cpp.obj : error LNK2001: unresolved external symbol 
+    "public: struct winrt::Windows::Foundation::IAsyncOperationWithProgress<int,double> __cdecl winrt::test_component::implementation::Simple::OperationWithProgress(class std::chrono::time_point<struct winrt::clock,class std::chrono::duration<__int64,struct std::ratio<1,10000000> > >)"
+    (?OperationWithProgress@Simple@implementation@test_component@winrt@@QEAA?AU?$IAsyncOperationWithProgress@HN@Foundation@Windows@4@V?$time_point@Uclock@winrt@@V?$duration@_JU?$ratio@$00$0JIJGIA@@std@@@chrono@std@@@chrono@std@@@Z)
+    */
+    interface IAsyncMethodsWithProgress
+    {
+        Windows.Foundation.IAsyncOperationWithProgress<Int32, Double> OperationWithProgress(Windows.Foundation.DateTime value);
+    }
+}

--- a/tests/test_component/cpp/AsyncMethods.idl
+++ b/tests/test_component/cpp/AsyncMethods.idl
@@ -2,17 +2,19 @@ import "Windows.Foundation.idl";
 
 namespace test_component
 {
-    runtimeclass AsyncOperationInt : Windows.Foundation.IAsyncOperation<Int32>
+    interface IAsyncOperationInt
     {
         void Complete(Int32 result);
         void CompleteWithError(HRESULT errorCode);
     }
 
+    runtimeclass AsyncOperationInt : [default]IAsyncOperationInt, Windows.Foundation.IAsyncOperation<Int32> {}
+
     runtimeclass AsyncMethods
     {
         static Windows.Foundation.IAsyncOperation<Int32> GetCompletedAsync(Int32 result);
         static Windows.Foundation.IAsyncOperation<Int32> GetCompletedWithErrorAsync(HRESULT errorCode);
-        static Windows.Foundation.IAsyncOperation<Int32> GetPendingAsync();
+        static AsyncOperationInt GetPendingAsync();
     }
     
     /* just here to make sure things compile, get weird C++ linker error if try to put this on a class:

--- a/tests/test_component/cpp/AsyncOperationInt.cpp
+++ b/tests/test_component/cpp/AsyncOperationInt.cpp
@@ -1,39 +1,40 @@
 #include "pch.h"
 #include "AsyncOperationInt.h"
-#include "AsyncOperationInt.g.cpp"
+#include "AsyncOperationInt.g.h"
 
 namespace winrt::test_component::implementation
 {
-    uint32_t AsyncOperationInt::Id()
-    {
-        throw hresult_not_implemented();
-    }
-    winrt::Windows::Foundation::AsyncStatus AsyncOperationInt::Status()
-    {
-        throw hresult_not_implemented();
-    }
-    winrt::hresult AsyncOperationInt::ErrorCode()
-    {
-        throw hresult_not_implemented();
-    }
     void AsyncOperationInt::Cancel()
     {
-        throw hresult_not_implemented();
+        if (status == winrt::Windows::Foundation::AsyncStatus::Started)
+        {
+            status = winrt::Windows::Foundation::AsyncStatus::Canceled;
+            if (completedHandler) completedHandler(*this, status);
+        }
     }
-    void AsyncOperationInt::Close()
+
+    void AsyncOperationInt::Complete(int32_t result)
     {
-        throw hresult_not_implemented();
+        if (status != winrt::Windows::Foundation::AsyncStatus::Started) throw winrt::hresult_illegal_method_call();
+        this->result = result;
+        status = winrt::Windows::Foundation::AsyncStatus::Completed;
+        if (completedHandler)
+            completedHandler(*this, status);
     }
+
+    void AsyncOperationInt::CompleteWithError(winrt::hresult errorCode)
+    {
+        if (status != winrt::Windows::Foundation::AsyncStatus::Started) throw winrt::hresult_illegal_method_call();
+        this->errorCode = errorCode;
+        status = winrt::Windows::Foundation::AsyncStatus::Error;
+        if (completedHandler)
+            completedHandler(*this, status);
+    }
+
     void AsyncOperationInt::Completed(winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> const& handler)
     {
-        throw hresult_not_implemented();
-    }
-    winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> AsyncOperationInt::Completed()
-    {
-        throw hresult_not_implemented();
-    }
-    int32_t AsyncOperationInt::GetResults()
-    {
-        throw hresult_not_implemented();
+        completedHandler = handler;
+        if (handler && status != winrt::Windows::Foundation::AsyncStatus::Started)
+            handler(*this, status);
     }
 }

--- a/tests/test_component/cpp/AsyncOperationInt.cpp
+++ b/tests/test_component/cpp/AsyncOperationInt.cpp
@@ -37,4 +37,15 @@ namespace winrt::test_component::implementation
         if (handler && status != winrt::Windows::Foundation::AsyncStatus::Started)
             handler(*this, status);
     }
+
+    int32_t AsyncOperationInt::GetResults()
+    {
+        switch (status)
+        {
+            case winrt::Windows::Foundation::AsyncStatus::Completed: return result;
+            case winrt::Windows::Foundation::AsyncStatus::Canceled: throw winrt::hresult_canceled();
+            case winrt::Windows::Foundation::AsyncStatus::Error: throw winrt::hresult_error(errorCode);
+            default: throw winrt::hresult_illegal_method_call();
+        }
+    }
 }

--- a/tests/test_component/cpp/AsyncOperationInt.h
+++ b/tests/test_component/cpp/AsyncOperationInt.h
@@ -1,19 +1,28 @@
 #pragma once
+
 #include "AsyncOperationInt.g.h"
 
 namespace winrt::test_component::implementation
 {
-    struct AsyncOperationInt : AsyncOperationIntT<AsyncOperationInt>
+    class AsyncOperationInt : public AsyncOperationIntT<AsyncOperationInt>
     {
-        AsyncOperationInt() = default;
+        winrt::Windows::Foundation::AsyncStatus status = winrt::Windows::Foundation::AsyncStatus::Started;
+        winrt::hresult errorCode = S_OK;
+        int32_t result = 0;
+        winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> completedHandler;
+    
+    public:
+        AsyncOperationInt()= default;
 
-        uint32_t Id();
-        winrt::Windows::Foundation::AsyncStatus Status();
-        winrt::hresult ErrorCode();
+        uint32_t Id() { return 42; }
+        winrt::Windows::Foundation::AsyncStatus Status() { return status; }
+        winrt::hresult ErrorCode() { return errorCode; }
         void Cancel();
-        void Close();
+        void Close() {}
+        void Complete(int32_t result);
+        void CompleteWithError(winrt::hresult errorCode);
         void Completed(winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> const& handler);
-        winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> Completed();
-        int32_t GetResults();
+        winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> Completed() { return completedHandler; }
+        int32_t GetResults() { return result; }
     };
 }

--- a/tests/test_component/cpp/AsyncOperationInt.h
+++ b/tests/test_component/cpp/AsyncOperationInt.h
@@ -12,7 +12,7 @@ namespace winrt::test_component::implementation
         winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> completedHandler;
     
     public:
-        AsyncOperationInt()= default;
+        AsyncOperationInt() = default;
 
         uint32_t Id() { return 42; }
         winrt::Windows::Foundation::AsyncStatus Status() { return status; }
@@ -23,6 +23,6 @@ namespace winrt::test_component::implementation
         void CompleteWithError(winrt::hresult errorCode);
         void Completed(winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> const& handler);
         winrt::Windows::Foundation::AsyncOperationCompletedHandler<int32_t> Completed() { return completedHandler; }
-        int32_t GetResults() { return result; }
+        int32_t GetResults();
     };
 }

--- a/tests/test_component/cpp/CMakeLists.txt
+++ b/tests/test_component/cpp/CMakeLists.txt
@@ -106,6 +106,7 @@ install(TARGETS test_component_cpp
   COMPONENT lib)
 
 target_sources(test_component_cpp PRIVATE
+    AsyncMethods.cpp
     AsyncOperationInt.cpp
     StaticClass.cpp
     Base.cpp

--- a/tests/test_component/cpp/test_component.idl
+++ b/tests/test_component/cpp/test_component.idl
@@ -1,3 +1,4 @@
+#include "AsyncMethods.idl"
 #include "NullValues.idl"
 #include "Keywords.idl"
 #include "EventTester.idl"
@@ -97,16 +98,6 @@ namespace test_component
         {
             Int32 Value;
         };
-
-        /* just here to make sure things compile, get weird C++ linker error if try to put this on a class:
-        Simple.cpp.obj : error LNK2001: unresolved external symbol
-        "public: struct winrt::Windows::Foundation::IAsyncOperationWithProgress<int,double> __cdecl winrt::test_component::implementation::Simple::OperationWithProgress(class std::chrono::time_point<struct winrt::clock,class std::chrono::duration<__int64,struct std::ratio<1,10000000> > >)"
-        (?OperationWithProgress@Simple@implementation@test_component@winrt@@QEAA?AU?$IAsyncOperationWithProgress@HN@Foundation@Windows@4@V?$time_point@Uclock@winrt@@V?$duration@_JU?$ratio@$00$0JIJGIA@@std@@@chrono@std@@@chrono@std@@@Z)
-        */
-        interface IAsyncMethods
-        {
-            Windows.Foundation.IAsyncOperationWithProgress<Int32, Double> OperationWithProgress(Windows.Foundation.DateTime value);
-        }
 
         // Just ensure that IObservableVector compiles
         interface IInterfaceWithObservableVector
@@ -460,10 +451,6 @@ namespace test_component
         }
 
         runtimeclass BaseObservableCollection: [default] IObservableVector<Base>
-        {
-        }
-
-        runtimeclass AsyncOperationInt : [default] Windows.Foundation.IAsyncOperation<Int32>
         {
         }
     }


### PR DESCRIPTION
`IAsync***.get()` enforced execution on the `MainActor`, but this breaks unit tests where there might not be a `MainActor` running a message loop. WinRT `IAsync***` don't have a built-in requirement that they need to be invoked on the main thread, so we shouldn't implicitly do that. If we find an async API returning a ui-thread bound object which misbehaves with the completion handler and `getResults()` call happening on a background thread, we can add an additional method that enforces that these happen on the MainActor.

Also fixes errors/cancelations not being surfaced on `IAsyncAction`s after awaiting

Adds tests for awaiting `IAsyncOperation`s: success vs failure cases, and "already completed" vs suspension cases.

Fixes WIN-842