### PR TITLE
dont project overrides for non-composable types

### DIFF
--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -2137,7 +2137,7 @@ override public init<Factory: ComposableActivationFactory>(_ factory: Factory) {
             {
                 baseHasCustomQueryInterfaceConformance = true;
             }
-            if (info.overridable && !info.base)
+            if (info.overridable && !info.base && composable)
             {
                 // overridable interfaces are still considered exclusive, so check here before
                 // we skip this interface
@@ -2292,6 +2292,12 @@ private var _default: SwiftABI!
             // Don't reimplement P/M/E for interfaces which are implemented on a base class
             if (!info.base)
             {
+                // this is an overridable interface but the type can't actually
+                // be overriden, so skip it
+                if (info.overridable && !composable)
+                {
+                    continue;
+                }
                 write_interface_impl_members(w, info, /* type_definition: */ type);
             }
 

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -161,6 +161,12 @@ typedef interface __x_ABI_Ctest__component_CIVoidToVoidDelegate __x_ABI_Ctest__c
 
 #endif // ____x_ABI_Ctest__component_CISimpleDelegate_FWD_DEFINED__
 
+#ifndef ____x_ABI_Ctest__component_CISimpleOverrides_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CISimpleOverrides_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CISimpleOverrides __x_ABI_Ctest__component_CISimpleOverrides;
+
+#endif // ____x_ABI_Ctest__component_CISimpleOverrides_FWD_DEFINED__
+
 #ifndef ____x_ABI_Ctest__component_CISimpleStatics_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CISimpleStatics_FWD_DEFINED__
     typedef interface __x_ABI_Ctest__component_CISimpleStatics __x_ABI_Ctest__component_CISimpleStatics;
@@ -3288,6 +3294,38 @@ struct __x_ABI_Ctest__component_CStructWithEnum
     
     EXTERN_C const IID IID___x_ABI_Ctest__component_CISimpleDelegate;
 #endif /* !defined(____x_ABI_Ctest__component_CISimpleDelegate_INTERFACE_DEFINED__) */
+    
+#if !defined(____x_ABI_Ctest__component_CISimpleOverrides_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CISimpleOverrides_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CISimpleOverridesVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CISimpleOverrides* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CISimpleOverrides* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CISimpleOverrides* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CISimpleOverrides* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CISimpleOverrides* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CISimpleOverrides* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* CantActuallyOverrideBecauseNotComposable)(__x_ABI_Ctest__component_CISimpleOverrides* This);
+
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CISimpleOverridesVtbl;
+
+    interface __x_ABI_Ctest__component_CISimpleOverrides
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CISimpleOverridesVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CISimpleOverrides;
+#endif /* !defined(____x_ABI_Ctest__component_CISimpleOverrides_INTERFACE_DEFINED__) */
     
 #if !defined(____x_ABI_Ctest__component_CISimpleStatics_INTERFACE_DEFINED__)
     #define ____x_ABI_Ctest__component_CISimpleStatics_INTERFACE_DEFINED__

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -94,6 +94,10 @@ private var IID___x_ABI_Ctest__component_CISimpleDelegate: test_component.IID {
     .init(Data1: 0xB73AD784, Data2: 0xEADD, Data3: 0x54B7, Data4: ( 0xA6,0x8E,0x8A,0xC5,0x6E,0xAB,0x73,0x87 ))// B73AD784-EADD-54B7-A68E-8AC56EAB7387
 }
 
+private var IID___x_ABI_Ctest__component_CISimpleOverrides: test_component.IID {
+    .init(Data1: 0x2F772B66, Data2: 0xE6BE, Data3: 0x51E4, Data4: ( 0xB9,0x22,0x01,0x9D,0x56,0xF7,0xEF,0xD1 ))// 2F772B66-E6BE-51E4-B922-019D56F7EFD1
+}
+
 private var IID___x_ABI_Ctest__component_CISimpleStatics: test_component.IID {
     .init(Data1: 0xC8DCADA0, Data2: 0xFD8E, Data3: 0x5E27, Data4: ( 0x95,0x51,0xA3,0x68,0xFE,0x1D,0x11,0xB2 ))// C8DCADA0-FD8E-5E27-9551-A368FE1D11B2
 }
@@ -1675,6 +1679,17 @@ public enum __ABI_test_component {
     )
 
     public typealias ISimpleDelegateWrapper = InterfaceWrapperBase<__IMPL_test_component.ISimpleDelegateImpl>
+    open class ISimpleOverrides: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CISimpleOverrides }
+
+        internal func CantActuallyOverrideBecauseNotComposableImpl() throws {
+            _ = try perform(as: __x_ABI_Ctest__component_CISimpleOverrides.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.CantActuallyOverrideBecauseNotComposable(pThis))
+            }
+        }
+
+    }
+
     open class ISimpleStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CISimpleStatics }
 

--- a/tests/test_component/cpp/Simple.h
+++ b/tests/test_component/cpp/Simple.h
@@ -89,6 +89,7 @@ namespace winrt::test_component::implementation
 
         winrt::event_token SimpleEvent(Windows::Foundation::TypedEventHandler<test_component::Simple, test_component::SimpleEventArgs> const& handler);
         void SimpleEvent(winrt::event_token const& token) noexcept;
+        void CantActuallyOverrideBecauseNotComposable(){}
         private:
         hstring m_stringProp{};
         test_component::BlittableStruct m_blittableStruct{};

--- a/tests/test_component/cpp/test_component.idl
+++ b/tests/test_component/cpp/test_component.idl
@@ -28,7 +28,7 @@ namespace test_component
             R8G8B8A8Typeless, // Should become r8g8b8a8Typeless (from D3D)
             UUID, // Should become uuid
         };
-        
+
         struct BlittableStruct
         {
             Int32 First;
@@ -68,7 +68,7 @@ namespace test_component
             //  delegate void OutStringArrayDelegate(out String[] value);
             //  delegate void RefStringArrayDelegate(ref String[] value);
             //  delegate test_component.Struct[] StructDelegate();
-        }   
+        }
 
         enum Signed
         {
@@ -99,7 +99,7 @@ namespace test_component
         };
 
         /* just here to make sure things compile, get weird C++ linker error if try to put this on a class:
-        Simple.cpp.obj : error LNK2001: unresolved external symbol 
+        Simple.cpp.obj : error LNK2001: unresolved external symbol
         "public: struct winrt::Windows::Foundation::IAsyncOperationWithProgress<int,double> __cdecl winrt::test_component::implementation::Simple::OperationWithProgress(class std::chrono::time_point<struct winrt::clock,class std::chrono::duration<__int64,struct std::ratio<1,10000000> > >)"
         (?OperationWithProgress@Simple@implementation@test_component@winrt@@QEAA?AU?$IAsyncOperationWithProgress@HN@Foundation@Windows@4@V?$time_point@Uclock@winrt@@V?$duration@_JU?$ratio@$00$0JIJGIA@@std@@@chrono@std@@@chrono@std@@@Z)
         */
@@ -118,7 +118,7 @@ namespace test_component
         {
             Simple();
             void Method();
-            
+
             //Windows.Foundation.IReference<Int32> Reference(Windows.Foundation.DateTime value);
             Windows.Foundation.IAsyncOperation<Int32> Operation(Windows.Foundation.DateTime value);
 
@@ -141,6 +141,8 @@ namespace test_component
             event test_component.Delegates.InDelegate InEvent;
             event Windows.Foundation.TypedEventHandler<Simple, SimpleEventArgs> SimpleEvent;
             void FireEvent();
+
+            overridable void CantActuallyOverrideBecauseNotComposable();
         }
 
         runtimeclass DeferrableEventArgs
@@ -207,12 +209,12 @@ namespace test_component
             static void StaticTest();
             static Int32 StaticTestReturn();
             static Int32 StaticProperty{ get; };
- 
+
             IBasic Implementation;
             // This is used to mimic API contract behavior, such that this will enforce separate types be generated
             [
               constructor_name("test_component.IClassFactory2"),
-              static_name("test_component.IClassStatics2") 
+              static_name("test_component.IClassStatics2")
             ]
             {
                Class(String name, Fruit fruit, IIAmImplementable implementation);
@@ -306,7 +308,7 @@ namespace test_component
             Base BaseProperty;
             BaseNoOverrides BaseNoOverridesProperty;
         }
-        
+
         static runtimeclass StaticClass
         {
             static Fruit EnumProperty;
@@ -371,7 +373,7 @@ namespace test_component
 
             // namespace Parent
             // {
-            //     // This validates namespace inclusion rules. The "...Three.h" header must include the 
+            //     // This validates namespace inclusion rules. The "...Three.h" header must include the
             //     // "...Parent.h" header but skip over the intermediate namespaces as they are empty
             //     // and won't be generated and those won't exist.
 
@@ -432,7 +434,7 @@ namespace test_component
             void Method();
         }
 
-        
+
         runtimeclass BaseCollection : [default] IVector<Base>
         {
         }


### PR DESCRIPTION
In WinRT it's valid to specify methods as overridable on a type which isn't composable. Since these methods can't actually be overridden just skip over them

Added a test to make sure things build

Fixes WIN-912