### PR TITLE
add retroactive to suppress warnings

### DIFF
--- a/swiftwinrt/Resources/Support/Events/EventSource.swift
+++ b/swiftwinrt/Resources/Support/Events/EventSource.swift
@@ -14,15 +14,15 @@ import C_BINDINGS_MODULE
           remove: { self.handlers.remove(token: $0) }
         )
     }
-    
+
     public var wrappedValue: Event<Handler> { event }
-    
+
     public func getInvocationList() -> [Handler] {
       handlers.getInvocationList()
     }
-} 
+}
 
-extension C_BINDINGS_MODULE.EventRegistrationToken: Hashable {
+extension C_BINDINGS_MODULE.EventRegistrationToken: @retroactive Hashable {
   public static func == (lhs: C_BINDINGS_MODULE.EventRegistrationToken, rhs: C_BINDINGS_MODULE.EventRegistrationToken) -> Bool {
     return lhs.value == rhs.value
   }

--- a/swiftwinrt/Resources/Support/GUID.swift
+++ b/swiftwinrt/Resources/Support/GUID.swift
@@ -1,6 +1,6 @@
 import C_BINDINGS_MODULE
 
-extension GUID: CustomStringConvertible {
+extension GUID: @retroactive CustomStringConvertible {
    public var description: String {
       withUnsafePointer(to: self) { pGUID in
          Array<WCHAR>(unsafeUninitializedCapacity: 40) {
@@ -27,7 +27,7 @@ extension GUID {
    }
 }
 
-extension GUID: Equatable {
+extension GUID: @retroactive Equatable {
    public static func ==(_ lhs: GUID, _ rhs: GUID) -> Bool {
       return lhs.Data1 == rhs.Data1 &&
          lhs.Data2 == rhs.Data2 &&

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -48,7 +48,7 @@ namespace swiftwinrt
         }
         w.write("}\n");
 
-        w.write("extension %: Hashable, Codable {}\n\n", get_full_swift_type_name(w, type));
+        w.write("extension %: @retroactive Hashable, @retroactive Codable {}\n\n", get_full_swift_type_name(w, type));
     }
 
     static void write_guid_value(writer& w, std::vector<FixedArgSig> const& args)

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -48,7 +48,7 @@ namespace swiftwinrt
         }
         w.write("}\n");
 
-        w.write("extension %: @retroactive Hashable, @retroactive Codable {}\n\n", get_full_swift_type_name(w, type));
+        w.write("extension %: ^@retroactive Hashable, ^@retroactive Codable {}\n\n", get_full_swift_type_name(w, type));
     }
 
     static void write_guid_value(writer& w, std::vector<FixedArgSig> const& args)

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
@@ -512,5 +512,5 @@ extension test_component.CollectionChange {
         CollectionChange_ItemChanged
     }
 }
-extension test_component.CollectionChange: Hashable, Codable {}
+extension test_component.CollectionChange: @retroactive Hashable, @retroactive Codable {}
 

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -365,7 +365,7 @@ extension test_component.AsyncStatus {
         __x_ABI_CWindows_CFoundation_CAsyncStatus_Started
     }
 }
-extension test_component.AsyncStatus: Hashable, Codable {}
+extension test_component.AsyncStatus: @retroactive Hashable, @retroactive Codable {}
 
 extension test_component.PropertyType {
     public static var empty : test_component.PropertyType {
@@ -492,5 +492,5 @@ extension test_component.PropertyType {
         __x_ABI_CWindows_CFoundation_CPropertyType_OtherTypeArray
     }
 }
-extension test_component.PropertyType: Hashable, Codable {}
+extension test_component.PropertyType: @retroactive Hashable, @retroactive Codable {}
 

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -1879,7 +1879,7 @@ extension test_component.Fruit {
         __x_ABI_Ctest__component_CFruit_Pineapple
     }
 }
-extension test_component.Fruit: Hashable, Codable {}
+extension test_component.Fruit: @retroactive Hashable, @retroactive Codable {}
 
 extension test_component.Keywords {
     public static var `as` : test_component.Keywords {
@@ -2006,7 +2006,7 @@ extension test_component.Keywords {
         __x_ABI_Ctest__component_CKeywords_While
     }
 }
-extension test_component.Keywords: Hashable, Codable {}
+extension test_component.Keywords: @retroactive Hashable, @retroactive Codable {}
 
 extension test_component.Signed {
     public static var first : test_component.Signed {
@@ -2019,7 +2019,7 @@ extension test_component.Signed {
         __x_ABI_Ctest__component_CSigned_Third
     }
 }
-extension test_component.Signed: Hashable, Codable {}
+extension test_component.Signed: @retroactive Hashable, @retroactive Codable {}
 
 extension test_component.SwiftifiableNames {
     public static var camelCase : test_component.SwiftifiableNames {
@@ -2041,7 +2041,7 @@ extension test_component.SwiftifiableNames {
         __x_ABI_Ctest__component_CSwiftifiableNames_UUID
     }
 }
-extension test_component.SwiftifiableNames: Hashable, Codable {}
+extension test_component.SwiftifiableNames: @retroactive Hashable, @retroactive Codable {}
 
 extension test_component.Unsigned {
     public static var first : test_component.Unsigned {
@@ -2054,5 +2054,5 @@ extension test_component.Unsigned {
         __x_ABI_Ctest__component_CUnsigned_Third
     }
 }
-extension test_component.Unsigned: Hashable, Codable {}
+extension test_component.Unsigned: @retroactive Hashable, @retroactive Codable {}
 


### PR DESCRIPTION
with the latest swift toolchain, there are a bunch of warnings for retroactive protocol conformance. while there are valid concerns with this usage, for the bindings it isn't a problem because we own the whole type system.