### PR TITLE
Support a prerelease identifier when manually publishing to nuget

### DIFF
--- a/.github/workflows/nuget-public.yml
+++ b/.github/workflows/nuget-public.yml
@@ -6,9 +6,9 @@ on:
 jobs:
   release-and-publish:
     env:
-      NUGET_VERSION_MAJOR: 0
-      NUGET_VERSION_MINOR: ${{ github.run_number }}
-      NUGET_VERSION_PATCH: 0
+      NUGET_PACKAGE_VERSION_MAJOR: 0
+      NUGET_PACKAGE_VERSION_MINOR: ${{ github.run_number }}
+      NUGET_PACKAGE_VERSION_PATCH: 0
     runs-on: windows-2022
     name: Swift/WinRT Release Build & Publish
     permissions:
@@ -21,7 +21,7 @@ jobs:
 
       - uses: ./.github/actions/windows-build
         env:
-            NUGET_VERSION: ${{ env.NUGET_VERSION_MAJOR}}.${{env.NUGET_VERSION_MINOR }}.${{env.NUGET_VERSION_PATCH }}
+            NUGET_PACKAGE_VERSION: ${{ env.NUGET_PACKAGE_VERSION_MAJOR}}.${{env.NUGET_PACKAGE_VERSION_MINOR }}.${{env.NUGET_PACKAGE_VERSION_PATCH }}
         with:
           config: release
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,19 @@ on:
   push:
     branches: [ "main" ]
   workflow_dispatch:
+    inputs:
+      version_prerelease_identifier:
+        description: 'Semantic versioning prerelease identifier (after hyphen)'
+        default: ''
+        type: string
 
 jobs:
   release-and-publish:
     env:
-      NUGET_VERSION_MAJOR: 0
-      NUGET_VERSION_MINOR: 1
-      NUGET_VERSION_PATCH: ${{ github.run_number }}
+      NUGET_PACKAGE_VERSION_MAJOR: 0
+      NUGET_PACKAGE_VERSION_MINOR: 1
+      NUGET_PACKAGE_VERSION_PATCH: ${{ github.run_number }}
+      NUGET_PACKAGE_VERSION_PRERELEASE_SUFFIX: ${{ github.event.inputs.version_prerelease_identifier && '' || '-' }}${{ github.event.inputs.version_prerelease_identifier }}
     runs-on: windows-2022
     name: Swift/WinRT Release Build & Publish
     permissions:
@@ -23,7 +29,7 @@ jobs:
 
       - uses: ./.github/actions/windows-build
         env:
-            NUGET_VERSION: ${{ env.NUGET_VERSION_MAJOR }}.${{ env.NUGET_VERSION_MINOR }}.${{ env.NUGET_VERSION_PATCH }}
+            NUGET_PACKAGE_VERSION: ${{ env.NUGET_PACKAGE_VERSION_MAJOR }}.${{ env.NUGET_PACKAGE_VERSION_MINOR }}.${{ env.NUGET_PACKAGE_VERSION_PATCH }}${{ env.NUGET_PACKAGE_VERSION_PRERELEASE_SUFFIX }}
         with:
           config: release
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,14 +10,14 @@ endif()
 add_subdirectory(swiftwinrt)
 add_subdirectory(tests)
 
-if (NOT DEFINED ENV{NUGET_VERSION})
-    set(NUGET_VERSION 0.1.0)
+if (NOT DEFINED ENV{NUGET_PACKAGE_VERSION})
+    set(NUGET_PACKAGE_VERSION 0.1.0)
 else()
-    set(NUGET_VERSION $ENV{NUGET_VERSION})
+    set(NUGET_PACKAGE_VERSION $ENV{NUGET_PACKAGE_VERSION})
 endif()
 
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/nuget/TheBrowserCompany.SwiftWinRT.nupkg
-    COMMAND ${CMAKE_BINARY_DIR}/nuget pack ${CMAKE_CURRENT_SOURCE_DIR}\\nuget\\swiftwinrt.nuspec -Properties swiftwinrt_exe=${CMAKE_CURRENT_SOURCE_DIR}\\out\\${CMAKE_BUILD_TYPE}\\bin\\swiftwinrt.exe -Version ${NUGET_VERSION}
+    COMMAND ${CMAKE_BINARY_DIR}/nuget pack ${CMAKE_CURRENT_SOURCE_DIR}\\nuget\\swiftwinrt.nuspec -Properties swiftwinrt_exe=${CMAKE_CURRENT_SOURCE_DIR}\\out\\${CMAKE_BUILD_TYPE}\\bin\\swiftwinrt.exe -Version ${NUGET_PACKAGE_VERSION}
 )
 
 add_custom_target(nuget


### PR DESCRIPTION
This is useful for one-off builds, so I can have `0.0.42-tryingthingsout`.

Also renamed `NUGET_VERSION[_*]` variables to `NUGET_PACKAGE_VERSION[_*]`, since in one file it's used to refer to the version of `nuget.exe` and in another to the version of the published package, leading to confusion.