### PR TITLE
Fix syntax for release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       NUGET_PACKAGE_VERSION_MAJOR: 0
       NUGET_PACKAGE_VERSION_MINOR: 1
       NUGET_PACKAGE_VERSION_PATCH: ${{ github.run_number }}
-      NUGET_PACKAGE_VERSION_PRERELEASE_SUFFIX: ${{ github.event.inputs.version_prerelease_identifier && '' || '-' }}${{ github.event.inputs.version_prerelease_identifier }}
+      NUGET_PACKAGE_VERSION_PRERELEASE_SUFFIX: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.version_prerelease_identifier != '' && format('-{0}', github.event.inputs.version_prerelease_identifier) || '' }}
     runs-on: windows-2022
     name: Swift/WinRT Release Build & Publish
     permissions:


### PR DESCRIPTION
Fix tested here:
With suffix: https://github.com/thebrowsercompany/swift-winrt/actions/runs/6723802926/job/18275145871#step:5:229
Without suffir: https://github.com/thebrowsercompany/swift-winrt/actions/runs/6723802926/job/18275145871#step:5:229