### PR TITLE
consolidate bridge and wrapper implementations

### DIFF
--- a/swiftwinrt/Resources/Support/Aggregation.swift
+++ b/swiftwinrt/Resources/Support/Aggregation.swift
@@ -61,7 +61,7 @@ public class UnsealedWinRTClassWrapper<Composable: ComposableImpl> : WinRTWrappe
     }
 }
 
-extension ComposableImpl {
+public extension ComposableImpl {
     static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
         guard let abi else { return nil }
         let baseInsp = SUPPORT_MODULE.IInspectable(abi)

--- a/swiftwinrt/Resources/Support/Aggregation.swift
+++ b/swiftwinrt/Resources/Support/Aggregation.swift
@@ -40,7 +40,7 @@ public func MakeComposed<Composable: ComposableImpl>(
     return aggregated ? innerInsp : base
 }
 
-public class UnsealedWinRTClassWrapper<Composable: ComposableImpl> : WinRTWrapperBase2<Composable> {
+public class UnsealedWinRTClassWrapper<Composable: ComposableImpl> : WinRTAbiBridgeWrapper<Composable> {
     override public class var IID: SUPPORT_MODULE.IID { Composable.SwiftABI.IID }
     public init?(_ impl: Composable.SwiftProjection?) {
         guard let impl = impl else { return nil }

--- a/swiftwinrt/Resources/Support/Aggregation.swift
+++ b/swiftwinrt/Resources/Support/Aggregation.swift
@@ -1,12 +1,8 @@
 import C_BINDINGS_MODULE
 import Foundation
 
-public protocol MakeComposedAbi : AbiInterface where SwiftABI: SUPPORT_MODULE.IInspectable {
-    associatedtype SwiftProjection : WinRTClass
-}
-
-public protocol ComposableImpl : AbiInterface where SwiftABI: IInspectable  {
-    associatedtype Default : MakeComposedAbi
+public protocol ComposableImpl : AbiInterfaceBridge where SwiftABI: IInspectable, SwiftProjection: WinRTClass  {
+    associatedtype Default : AbiInterface where Default.SwiftABI: SUPPORT_MODULE.IInspectable
     static func makeAbi() -> CABI
 }
 
@@ -30,9 +26,9 @@ public protocol ComposableImpl : AbiInterface where SwiftABI: IInspectable  {
 // |  No           |  nil                      |  ignored                |  stored on swift object  |
 public func MakeComposed<Composable: ComposableImpl>(
     composing: Composable.Type,
-    _ this: Composable.Default.SwiftProjection,
+    _ this: Composable.SwiftProjection,
     _ createCallback: (UnsealedWinRTClassWrapper<Composable>?, inout SUPPORT_MODULE.IInspectable?) -> Composable.Default.SwiftABI) -> SUPPORT_MODULE.IInspectable {
-    let aggregated = type(of: this) != Composable.Default.SwiftProjection.self
+    let aggregated = type(of: this) != Composable.SwiftProjection.self
     let wrapper:UnsealedWinRTClassWrapper<Composable>? = .init(aggregated ? this : nil)
 
     var innerInsp: SUPPORT_MODULE.IInspectable? = nil
@@ -44,34 +40,35 @@ public func MakeComposed<Composable: ComposableImpl>(
     return aggregated ? innerInsp : base
 }
 
-public class UnsealedWinRTClassWrapper<Composable: ComposableImpl> : WinRTWrapperBase<Composable.CABI, Composable.Default.SwiftProjection> {
+public class UnsealedWinRTClassWrapper<Composable: ComposableImpl> : WinRTWrapperBase2<Composable> {
     override public class var IID: SUPPORT_MODULE.IID { Composable.SwiftABI.IID }
-
-    public init?(_ impl: Composable.Default.SwiftProjection?) {
+    public init?(_ impl: Composable.SwiftProjection?) {
         guard let impl = impl else { return nil }
         let abi = Composable.makeAbi()
         super.init(abi, impl)
     }
-
-    public static func unwrapFrom(base: UnsafeMutablePointer<Composable.Default.CABI>) -> Composable.Default.SwiftProjection {
+    public static func unwrapFrom(base: UnsafeMutablePointer<Composable.Default.CABI>) -> Composable.SwiftProjection? {
         let baseInsp = SUPPORT_MODULE.IInspectable(consuming: base)
         let overrides: Composable.SwiftABI = try! baseInsp.QueryInterface()
+        return unwrapFrom(abi: RawPointer(overrides))
 
-        // Try to unwrap an app implemented object. If one doesn't exist then we'll create the proper WinRT type below
-        if let instance = tryUnwrapFrom(abi: RawPointer(overrides)) {
-            return instance
-        }
-
-        guard let instance = makeFrom(abi: baseInsp) else {
-            // the derived class doesn't exist, which is fine, just return the type the API specifies.
-            return make(type: Composable.Default.SwiftProjection.self, from: baseInsp)!
-        }
-        return instance as! Composable.Default.SwiftProjection
     }
 
     public func toIInspectableABI<ResultType>(_ body: (UnsafeMutablePointer<C_IInspectable>) throws -> ResultType)
         rethrows -> ResultType {
         let abi = try! toABI { $0 }
         return try abi.withMemoryRebound(to: C_IInspectable.self, capacity: 1) { try body($0) }
+    }
+}
+
+extension ComposableImpl {
+    static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+        guard let abi else { return nil }
+        let baseInsp = SUPPORT_MODULE.IInspectable(abi)
+        guard let instance = makeFrom(abi: baseInsp) else {
+            // the derived class doesn't exist, which is fine, just return the type the API specifies.
+            return make(type: Self.SwiftProjection.self, from: baseInsp)
+        }
+        return instance as? Self.SwiftProjection
     }
 }

--- a/swiftwinrt/Resources/Support/Marshaler.swift
+++ b/swiftwinrt/Resources/Support/Marshaler.swift
@@ -25,7 +25,7 @@ fileprivate class MarshalWrapper: WinRTWrapperBase2<IMarshalBridge> {
 
 fileprivate struct IMarshalBridge: AbiBridge {
     static func makeAbi() -> C_IMarshal {
-        return IMarshal(lpVtbl: &IMarshalVTable)
+        return C_IMarshal(lpVtbl: &IMarshalVTable)
     }
 
     static func from(abi: UnsafeMutablePointer<C_IMarshal>?) -> Marshaler? {

--- a/swiftwinrt/Resources/Support/Marshaler.swift
+++ b/swiftwinrt/Resources/Support/Marshaler.swift
@@ -23,7 +23,7 @@ fileprivate class MarshalWrapper: WinRTAbiBridgeWrapper<IMarshalBridge> {
     }
 }
 
-fileprivate struct IMarshalBridge: AbiBridge {
+fileprivate enum IMarshalBridge: AbiBridge {
     static func makeAbi() -> C_IMarshal {
         return C_IMarshal(lpVtbl: &IMarshalVTable)
     }

--- a/swiftwinrt/Resources/Support/Marshaler.swift
+++ b/swiftwinrt/Resources/Support/Marshaler.swift
@@ -17,7 +17,7 @@ func makeMarshaler(_ outer: IUnknownRef, _ result: UnsafeMutablePointer<UnsafeMu
     }
 }
 
-fileprivate class MarshalWrapper: WinRTWrapperBase2<IMarshalBridge> {
+fileprivate class MarshalWrapper: WinRTAbiBridgeWrapper<IMarshalBridge> {
     init(_ marshaler: Marshaler){
         super.init(IMarshalBridge.makeAbi(), marshaler)
     }

--- a/swiftwinrt/Resources/Support/Marshaler.swift
+++ b/swiftwinrt/Resources/Support/Marshaler.swift
@@ -23,14 +23,20 @@ fileprivate class MarshalWrapper: WinRTWrapperBase2<IMarshalBridge> {
     }
 }
 
-fileprivate class IMarshalBridge: AbiBridge {
+fileprivate struct IMarshalBridge: AbiBridge {
     static func makeAbi() -> C_IMarshal {
-        return C_IMarshal(lpVtbl: &IMarshalVTable)
+        return IMarshal(lpVtbl: &IMarshalVTable)
+    }
+
+    static func from(abi: UnsafeMutablePointer<C_IMarshal>?) -> Marshaler? {
+        guard let abi = abi else { return nil }
+        return try? Marshaler(IUnknownRef(consuming: abi))
     }
 
     typealias CABI = C_IMarshal
     typealias SwiftProjection = Marshaler
 }
+
 private var IMarshalVTable: C_IMarshalVtbl = .init(
     QueryInterface: { pUnk, riid, ppvObject in
         guard let pUnk, let riid, let ppvObject else { return E_INVALIDARG }

--- a/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
+++ b/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
@@ -136,7 +136,7 @@ open class WinRTWrapperBase<CInterface, Prototype> {
         guard let instance = tryUnwrapFrom(raw: pUnk) else { return E_FAIL }
         do
         {
-            switch iid {
+            switch riid.pointee {
                 case IID_IMarshal:
                     try makeMarshaler(IUnknownRef(pUnk), result)
                 default:

--- a/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
+++ b/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
@@ -151,7 +151,7 @@ open class WinRTWrapperBase<CInterface, Prototype> {
     }
 }
 
-open class WinRTWrapperBase2<I: AbiBridge> : WinRTWrapperBase<I.CABI, I.SwiftProjection> {
+open class WinRTAbiBridgeWrapper<I: AbiBridge> : WinRTWrapperBase<I.CABI, I.SwiftProjection> {
 
     public static func unwrapFrom(abi pointer: UnsafeMutablePointer<I.CABI>?) -> I.SwiftProjection? {
         guard let pointer = pointer else { return nil }
@@ -173,7 +173,7 @@ open class WinRTWrapperBase2<I: AbiBridge> : WinRTWrapperBase<I.CABI, I.SwiftPro
     }
 }
 
-open class InterfaceWrapperBase<I: AbiInterfaceBridge> : WinRTWrapperBase2<I> {
+open class InterfaceWrapperBase<I: AbiInterfaceBridge> : WinRTAbiBridgeWrapper<I> {
     override public class var IID: SUPPORT_MODULE.IID { I.SwiftABI.IID }
     public init?(_ impl: I.SwiftProjection?) {
         guard let impl = impl else { return nil }
@@ -200,7 +200,7 @@ open class InterfaceWrapperBase<I: AbiInterfaceBridge> : WinRTWrapperBase2<I> {
     }
 }
 
-public class ReferenceWrapperBase<I: ReferenceBridge>: WinRTWrapperBase2<I> {
+public class ReferenceWrapperBase<I: ReferenceBridge>: WinRTAbiBridgeWrapper<I> {
     override public class var IID: SUPPORT_MODULE.IID { I.IID }
 
     public init?(_ value: I.SwiftProjection?) {

--- a/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
+++ b/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
@@ -203,7 +203,7 @@ open class InterfaceWrapperBase<I: AbiInterfaceBridge> : WinRTWrapperBase2<I> {
 public class ReferenceWrapperBase<I: ReferenceBridge>: WinRTWrapperBase2<I> {
     override public class var IID: SUPPORT_MODULE.IID { I.IID }
 
-    init?(_ value: I.SwiftProjection?) {
+    public init?(_ value: I.SwiftProjection?) {
         guard let value = value else { return nil }
         let abi = I.makeAbi()
         super.init(abi, value)
@@ -220,7 +220,7 @@ public class ReferenceWrapperBase<I: ReferenceBridge>: WinRTWrapperBase2<I> {
                 ppvObject.pointee = UnsafeMutableRawPointer(iUnk.ref)
                 return S_OK
             default:
-                return super.queryInterfaceBase(pUnk, riid, ppvObject)
+                return super.queryInterface(pUnk, riid, ppvObject)
         }
     }
 }

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -479,7 +479,7 @@ bind<write_abi_args>(function));
             generic_param->mangled_name() :
             generic_param->cpp_abi_name();
 
-        w.write(R"(internal struct %: ReferenceBridge {
+        w.write(R"(internal enum %: ReferenceBridge {
     typealias CABI = %
     typealias SwiftProjection = %
     static var IID: %.IID { IID_% }
@@ -1070,7 +1070,7 @@ bind_bridge_fullname(type));
         }
 
         auto modifier = is_generic ? "internal" : "public";
-        w.write(R"(% class % : AbiInterfaceBridge {
+        w.write(R"(% enum % : AbiInterfaceBridge {
     % typealias CABI = %
     % typealias SwiftABI = %
     % typealias SwiftProjection = %
@@ -2109,11 +2109,11 @@ public init<Composable: ComposableImpl>(
 
         bool use_iinspectable_vtable = type_name(overrides) == type_name(*default_interface);
 
-        auto format = R"(internal struct % : ComposableImpl {
+        auto format = R"(internal enum % : ComposableImpl {
     internal typealias CABI = %
     internal typealias SwiftABI = %
     internal typealias SwiftProjection = %
-    internal struct Default : AbiInterface {
+    internal enum Default : AbiInterface {
         internal typealias CABI = %
         internal typealias SwiftABI = %.%
     }

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -482,7 +482,7 @@ bind<write_abi_args>(function));
         w.write(R"(internal struct %: ReferenceBridge {
     typealias CABI = %
     typealias SwiftProjection = %
-    static var IID: test_component.IID { IID_% }
+    static var IID: %.IID { IID_% }
 
     static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
         guard let val = abi else { return nil }
@@ -499,6 +499,7 @@ bind<write_abi_args>(function));
 )", bind_bridge_name(type),
     type.mangled_name(),
     get_full_swift_type_name(w, generic_param),
+    w.support,
     type.mangled_name(),
     c_name,
     bind<write_default_init_assignment>(*generic_param, projection_layer::c_abi),

--- a/swiftwinrt/code_writers/common_writers.h
+++ b/swiftwinrt/code_writers/common_writers.h
@@ -55,18 +55,8 @@ namespace swiftwinrt
     template<typename T>
     inline void write_generic_bridge_name(writer& w, T const& type)
     {
-        // for IReference<> types we use the same IPropertyValueImpl class that is
-        // specially generated. this type can hold any value type and implements
-        // the appropriate interface
-        if (is_winrt_ireference(type))
-        {
-            w.write("%.%", impl_namespace("Windows.Foundation"), "IPropertyValueBridge");
-        }
-        else
-        {
-            write_generic_impl_name_base(w, type);
-            w.write("Bridge");
-        }
+        write_generic_impl_name_base(w, type);
+        w.write("Bridge");
     }
 
     template<typename T>
@@ -322,16 +312,9 @@ namespace swiftwinrt
         }
         else if (category == param_category::generic_type)
         {
-            if (is_winrt_ireference(type))
-            {
-                w.write(".init(ref: %)", name);
-            }
-            else
-            {
-                w.write("%.unwrapFrom(abi: %)",
-                    bind_wrapper_fullname(type),
-                    name);
-            }
+            w.write("%.unwrapFrom(abi: %)",
+                bind_wrapper_fullname(type),
+                name);
         }
         else
         {

--- a/swiftwinrt/helpers.h
+++ b/swiftwinrt/helpers.h
@@ -447,7 +447,7 @@ namespace swiftwinrt
     {
         return has_attribute(type.type(), "Windows.Foundation.Metadata", "ExclusiveToAttribute");
     }
-    
+
     inline const class_type* try_get_exclusive_to(writer& w, typedef_base const& type)
     {
         auto attribute = get_attribute(type.type(), metadata_namespace, "ExclusiveToAttribute");
@@ -936,5 +936,10 @@ namespace swiftwinrt
         }
 
         return true;
+    }
+
+    inline bool is_struct(metadata_type const& type)
+    {
+        return dynamic_cast<const struct_type*>(&type) != nullptr;
     }
 }

--- a/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
@@ -99,20 +99,7 @@ public enum __ABI_Windows_Foundation {
     }
 
     internal static var IAsyncActionVTable: __x_ABI_CWindows_CFoundation_CIAsyncActionVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IAsyncActionWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IAsyncActionWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IAsyncActionWrapper.queryInterface($0, $1, $2) },
         AddRef: { IAsyncActionWrapper.addRef($0) },
         Release: { IAsyncActionWrapper.release($0) },
         GetIids: {
@@ -207,20 +194,7 @@ public enum __ABI_Windows_Foundation {
     }
 
     internal static var IAsyncInfoVTable: __x_ABI_CWindows_CFoundation_CIAsyncInfoVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IAsyncInfoWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IAsyncInfoWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IAsyncInfoWrapper.queryInterface($0, $1, $2) },
         AddRef: { IAsyncInfoWrapper.addRef($0) },
         Release: { IAsyncInfoWrapper.release($0) },
         GetIids: {
@@ -298,20 +272,7 @@ public enum __ABI_Windows_Foundation {
     }
 
     internal static var IClosableVTable: __x_ABI_CWindows_CFoundation_CIClosableVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IClosableWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IClosableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IClosableWrapper.queryInterface($0, $1, $2) },
         AddRef: { IClosableWrapper.addRef($0) },
         Release: { IClosableWrapper.release($0) },
         GetIids: {
@@ -540,20 +501,7 @@ public enum __ABI_Windows_Foundation {
     }
 
     internal static var IPropertyValueVTable: __x_ABI_CWindows_CFoundation_CIPropertyValueVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IPropertyValueWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IPropertyValueWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IPropertyValueWrapper.queryInterface($0, $1, $2) },
         AddRef: { IPropertyValueWrapper.addRef($0) },
         Release: { IPropertyValueWrapper.release($0) },
         GetIids: {
@@ -794,24 +742,8 @@ public enum __ABI_Windows_Foundation {
 
         GetRectArray: { _, _, _ in return failWith(err: E_NOTIMPL) }
     )
-    public class IPropertyValueWrapper : WinRTWrapperBase<__x_ABI_CWindows_CFoundation_CIPropertyValue, test_component.IPropertyValue>
-    {
-        override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIPropertyValue }
-        public init(_ value: Any) {
-            let abi = withUnsafeMutablePointer(to: &IPropertyValueVTable) {
-                __x_ABI_CWindows_CFoundation_CIPropertyValue(lpVtbl: $0)
-            }
-            super.init(abi, __IMPL_Windows_Foundation.IPropertyValueImpl(value: value))
-        }
 
-        public init?(_ impl: test_component.IPropertyValue?) {
-            guard let impl = impl else { return nil }
-            let abi = withUnsafeMutablePointer(to: &IPropertyValueVTable) {
-                __x_ABI_CWindows_CFoundation_CIPropertyValue(lpVtbl: $0)
-            }
-            super.init(abi, impl)
-        }
-    }
+    public typealias IPropertyValueWrapper = InterfaceWrapperBase<__IMPL_Windows_Foundation.IPropertyValueBridge>
     public class IStringable: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIStringable }
 
@@ -826,20 +758,7 @@ public enum __ABI_Windows_Foundation {
     }
 
     internal static var IStringableVTable: __x_ABI_CWindows_CFoundation_CIStringableVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IStringableWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IStringableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IStringableWrapper.queryInterface($0, $1, $2) },
         AddRef: { IStringableWrapper.addRef($0) },
         Release: { IStringableWrapper.release($0) },
         GetIids: {
@@ -921,20 +840,7 @@ extension __ABI_Windows_Foundation {
 
     typealias AsyncActionCompletedHandlerWrapper = InterfaceWrapperBase<__IMPL_Windows_Foundation.AsyncActionCompletedHandlerBridge>
     internal static var AsyncActionCompletedHandlerVTable: __x_ABI_CWindows_CFoundation_CIAsyncActionCompletedHandlerVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, AsyncActionCompletedHandlerWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return failWith(err: E_NOINTERFACE)
-            }
-        },
-
+        QueryInterface: { AsyncActionCompletedHandlerWrapper.queryInterface($0, $1, $2) },
         AddRef: { AsyncActionCompletedHandlerWrapper.addRef($0) },
         Release: { AsyncActionCompletedHandlerWrapper.release($0) },
         Invoke: {
@@ -969,20 +875,7 @@ extension __ABI_Windows_Foundation {
 
     typealias DeferralCompletedHandlerWrapper = InterfaceWrapperBase<__IMPL_Windows_Foundation.DeferralCompletedHandlerBridge>
     internal static var DeferralCompletedHandlerVTable: __x_ABI_CWindows_CFoundation_CIDeferralCompletedHandlerVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, DeferralCompletedHandlerWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return failWith(err: E_NOINTERFACE)
-            }
-        },
-
+        QueryInterface: { DeferralCompletedHandlerWrapper.queryInterface($0, $1, $2) },
         AddRef: { DeferralCompletedHandlerWrapper.addRef($0) },
         Release: { DeferralCompletedHandlerWrapper.release($0) },
         Invoke: {

--- a/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
@@ -3,7 +3,7 @@
 import Ctest_component
 
 public enum __IMPL_Windows_Foundation {
-    public class IAsyncActionBridge : AbiInterfaceBridge {
+    public enum IAsyncActionBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIAsyncAction
         public typealias SwiftABI = __ABI_Windows_Foundation.IAsyncAction
         public typealias SwiftProjection = AnyIAsyncAction
@@ -65,7 +65,7 @@ public enum __IMPL_Windows_Foundation {
 
     }
 
-    public class IAsyncInfoBridge : AbiInterfaceBridge {
+    public enum IAsyncInfoBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIAsyncInfo
         public typealias SwiftABI = __ABI_Windows_Foundation.IAsyncInfo
         public typealias SwiftProjection = AnyIAsyncInfo
@@ -115,7 +115,7 @@ public enum __IMPL_Windows_Foundation {
 
     }
 
-    public class IClosableBridge : AbiInterfaceBridge {
+    public enum IClosableBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIClosable
         public typealias SwiftABI = __ABI_Windows_Foundation.IClosable
         public typealias SwiftProjection = AnyIClosable
@@ -145,7 +145,7 @@ public enum __IMPL_Windows_Foundation {
 
     }
 
-    public class IPropertyValueBridge : AbiInterfaceBridge {
+    public enum IPropertyValueBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIPropertyValue
         public typealias SwiftABI = __ABI_Windows_Foundation.IPropertyValue
         public typealias SwiftProjection = AnyIPropertyValue
@@ -238,7 +238,7 @@ public enum __IMPL_Windows_Foundation {
 
     }
 
-    public class IStringableBridge : AbiInterfaceBridge {
+    public enum IStringableBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIStringable
         public typealias SwiftABI = __ABI_Windows_Foundation.IStringable
         public typealias SwiftProjection = AnyIStringable

--- a/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
@@ -145,11 +145,27 @@ public enum __IMPL_Windows_Foundation {
 
     }
 
+    public class IPropertyValueBridge : AbiInterfaceBridge {
+        public typealias CABI = __x_ABI_CWindows_CFoundation_CIPropertyValue
+        public typealias SwiftABI = __ABI_Windows_Foundation.IPropertyValue
+        public typealias SwiftProjection = AnyIPropertyValue
+        public static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+            guard let abi = abi else { return nil }
+            return IPropertyValueImpl(abi)
+        }
+
+        public static func makeAbi() -> CABI {
+            let vtblPtr = withUnsafeMutablePointer(to: &__ABI_Windows_Foundation.IPropertyValueVTable) { $0 }
+            return .init(lpVtbl: vtblPtr)
+        }
+    }
+
     public class IPropertyValueImpl : IPropertyValue, IReference {
         public typealias T = Any
         var _value: Any
         var propertyType : PropertyType
 
+        fileprivate init(_ abi: UnsafeMutablePointer<__x_ABI_CWindows_CFoundation_CIPropertyValue>) { fatalError("not implemented") }
         public init(value: Any) {
             _value = value
             if _value is Int32 {
@@ -257,7 +273,7 @@ public enum __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIAsyncActionCompletedHandler
         public typealias SwiftABI = __ABI_Windows_Foundation.AsyncActionCompletedHandler
 
-        public static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+        public static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -271,7 +287,7 @@ public enum __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIDeferralCompletedHandler
         public typealias SwiftABI = __ABI_Windows_Foundation.DeferralCompletedHandler
 
-        public static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+        public static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections+ABI.swift
@@ -65,20 +65,7 @@ public enum __ABI_Windows_Foundation_Collections {
     }
 
     internal static var IPropertySetVTable: __x_ABI_CWindows_CFoundation_CCollections_CIPropertySetVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IPropertySetWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IPropertySetWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IPropertySetWrapper.queryInterface($0, $1, $2) },
         AddRef: { IPropertySetWrapper.addRef($0) },
         Release: { IPropertySetWrapper.release($0) },
         GetIids: {
@@ -132,20 +119,7 @@ public enum __ABI_Windows_Foundation_Collections {
     }
 
     internal static var IVectorChangedEventArgsVTable: __x_ABI_CWindows_CFoundation_CCollections_CIVectorChangedEventArgsVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IVectorChangedEventArgsWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IVectorChangedEventArgsWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IVectorChangedEventArgsWrapper.queryInterface($0, $1, $2) },
         AddRef: { IVectorChangedEventArgsWrapper.addRef($0) },
         Release: { IVectorChangedEventArgsWrapper.release($0) },
         GetIids: {

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
@@ -3,7 +3,7 @@
 import Ctest_component
 
 public enum __IMPL_Windows_Foundation_Collections {
-    public class IPropertySetBridge : AbiInterfaceBridge {
+    public enum IPropertySetBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CCollections_CIPropertySet
         public typealias SwiftABI = __ABI_Windows_Foundation_Collections.IPropertySet
         public typealias SwiftProjection = AnyIPropertySet
@@ -87,7 +87,7 @@ public enum __IMPL_Windows_Foundation_Collections {
 
     }
 
-    public class IVectorChangedEventArgsBridge : AbiInterfaceBridge {
+    public enum IVectorChangedEventArgsBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CCollections_CIVectorChangedEventArgs
         public typealias SwiftABI = __ABI_Windows_Foundation_Collections.IVectorChangedEventArgs
         public typealias SwiftProjection = AnyIVectorChangedEventArgs

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -246,6 +246,10 @@ public enum __ABI_test_component {
 
         AddRef: { IAsyncMethodsWithProgressWrapper.addRef($0) },
         Release: { IAsyncMethodsWithProgressWrapper.release($0) },
+    internal static var IAsyncMethodsVTable: __x_ABI_Ctest__component_CIAsyncMethodsVtbl = .init(
+        QueryInterface: { IAsyncMethodsWrapper.queryInterface($0, $1, $2) },
+        AddRef: { IAsyncMethodsWrapper.addRef($0) },
+        Release: { IAsyncMethodsWrapper.release($0) },
         GetIids: {
             let size = MemoryLayout<test_component.IID>.size
             let iids = CoTaskMemAlloc(UInt64(size) * 3).assumingMemoryBound(to: test_component.IID.self)
@@ -278,7 +282,7 @@ public enum __ABI_test_component {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         }
     )
 
@@ -347,7 +351,7 @@ public enum __ABI_test_component {
                 let result: Int32 = $1
                 try __unwrapped__instance.complete(result)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         CompleteWithError: {
@@ -356,7 +360,7 @@ public enum __ABI_test_component {
                 let errorCode: HRESULT = $1
                 try __unwrapped__instance.completeWithError(errorCode)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         }
     )
 
@@ -432,20 +436,7 @@ public enum __ABI_test_component {
     }
 
     internal static var IBasicVTable: __x_ABI_Ctest__component_CIBasicVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IBasicWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IBasicWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IBasicWrapper.queryInterface($0, $1, $2) },
         AddRef: { IBasicWrapper.addRef($0) },
         Release: { IBasicWrapper.release($0) },
         GetIids: {
@@ -477,7 +468,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IBasicWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.method()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         }
     )
 
@@ -633,7 +624,7 @@ public enum __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnReferenceEnum(pThis, &result))
             }
-            return .init(ref: result)
+            return test_component.__x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedWrapper.unwrapFrom(abi: result)
         }
 
         internal func get_EnumPropertyImpl() throws -> test_component.Fruit {
@@ -725,7 +716,7 @@ public enum __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StartValue(pThis, &value))
             }
-            return .init(ref: value)
+            return test_component.__x_ABI_C__FIReference_1_intWrapper.unwrapFrom(abi: value)
         }
 
         internal func put_StartValueImpl(_ value: Int32?) throws {
@@ -741,7 +732,7 @@ public enum __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Id(pThis, &value))
             }
-            return .init(ref: value)
+            return test_component.__x_ABI_C__FIReference_1_GUIDWrapper.unwrapFrom(abi: value)
         }
 
         internal func put_IdImpl(_ value: test_component.GUID?) throws {
@@ -1206,7 +1197,7 @@ public enum __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Id(pThis, &value))
             }
-            return .init(ref: value)
+            return test_component.__x_ABI_C__FIReference_1_GUIDWrapper.unwrapFrom(abi: value)
         }
 
         open func put_IdImpl(_ value: test_component.GUID?) throws {
@@ -1243,20 +1234,7 @@ public enum __ABI_test_component {
     }
 
     internal static var IIAmImplementableVTable: __x_ABI_Ctest__component_CIIAmImplementableVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IIAmImplementableWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IIAmImplementableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IIAmImplementableWrapper.queryInterface($0, $1, $2) },
         AddRef: { IIAmImplementableWrapper.addRef($0) },
         Release: { IIAmImplementableWrapper.release($0) },
         GetIids: {
@@ -1290,7 +1268,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inInt32(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         InString: {
@@ -1300,7 +1278,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inString(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         InObject: {
@@ -1310,7 +1288,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inObject(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         InEnum: {
@@ -1320,7 +1298,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inEnum(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         OutInt32: {
@@ -1330,7 +1308,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outInt32(&value)
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         OutString: {
@@ -1340,7 +1318,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outString(&value)
                 $1?.initialize(to: try! HString(value).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         OutObject: {
@@ -1351,7 +1329,7 @@ public enum __ABI_test_component {
                 let valueWrapper = __ABI_.AnyWrapper(value)
                 valueWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         OutBlittableStruct: {
@@ -1361,7 +1339,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outBlittableStruct(&value)
                 $1?.initialize(to: .from(swift: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         OutNonBlittableStruct: {
@@ -1372,7 +1350,7 @@ public enum __ABI_test_component {
                 let _value = __ABI_test_component._ABI_NonBlittableStruct(from: value)
                 	$1?.initialize(to: _value.detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         OutEnum: {
@@ -1382,7 +1360,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outEnum(&value)
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         ReturnObject: {
@@ -1392,7 +1370,7 @@ public enum __ABI_test_component {
                 let resultWrapper = __ABI_.AnyWrapper(result)
                 resultWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         ReturnEnum: {
@@ -1401,7 +1379,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.returnEnum()
                 $1?.initialize(to: result)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         get_EnumProperty: {
@@ -1428,7 +1406,7 @@ public enum __ABI_test_component {
 
         put_Id: {
             guard let __unwrapped__instance = IIAmImplementableWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-            let value: test_component.GUID? = .init(ref: $1)
+            let value: test_component.GUID? = test_component.__x_ABI_C__FIReference_1_GUIDWrapper.unwrapFrom(abi: $1)
             __unwrapped__instance.id = value
             return S_OK
         },
@@ -1454,7 +1432,7 @@ public enum __ABI_test_component {
                 let data: String = .init(from: $1)
                 try __unwrapped__instance.fireEvent(data)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         }
     )
 
@@ -1473,20 +1451,7 @@ public enum __ABI_test_component {
     }
 
     internal static var IInterfaceWithObservableVectorVTable: __x_ABI_Ctest__component_CIInterfaceWithObservableVectorVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IInterfaceWithObservableVectorWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IInterfaceWithObservableVectorWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IInterfaceWithObservableVectorWrapper.queryInterface($0, $1, $2) },
         AddRef: { IInterfaceWithObservableVectorWrapper.addRef($0) },
         Release: { IInterfaceWithObservableVectorWrapper.release($0) },
         GetIids: {
@@ -1519,7 +1484,7 @@ public enum __ABI_test_component {
                 let basics: test_component.AnyIObservableVector<test_component.AnyIBasic?>? = test_component.__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.unwrapFrom(abi: $1)
                 try __unwrapped__instance.takeObservable(basics)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         }
     )
 
@@ -1797,20 +1762,7 @@ public enum __ABI_test_component {
     }
 
     internal static var ISimpleDelegateVTable: __x_ABI_Ctest__component_CISimpleDelegateVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, ISimpleDelegateWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return ISimpleDelegateWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { ISimpleDelegateWrapper.queryInterface($0, $1, $2) },
         AddRef: { ISimpleDelegateWrapper.addRef($0) },
         Release: { ISimpleDelegateWrapper.release($0) },
         GetIids: {
@@ -1842,7 +1794,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = ISimpleDelegateWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.doThis()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         DoThat: {
@@ -1851,7 +1803,7 @@ public enum __ABI_test_component {
                 let val: Int32 = $1
                 try __unwrapped__instance.doThat(val)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         }
     )
 
@@ -2133,20 +2085,7 @@ public enum __ABI_test_component {
     }
 
     internal static var InterfaceWithReturnDelegateVTable: __x_ABI_Ctest__component_CInterfaceWithReturnDelegateVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, InterfaceWithReturnDelegateWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return InterfaceWithReturnDelegateWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { InterfaceWithReturnDelegateWrapper.queryInterface($0, $1, $2) },
         AddRef: { InterfaceWithReturnDelegateWrapper.addRef($0) },
         Release: { InterfaceWithReturnDelegateWrapper.release($0) },
         GetIids: {
@@ -2234,20 +2173,7 @@ public enum __ABI_test_component {
     }
 
     internal static var WithKeywordVTable: __x_ABI_Ctest__component_CWithKeywordVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, WithKeywordWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return WithKeywordWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { WithKeywordWrapper.queryInterface($0, $1, $2) },
         AddRef: { WithKeywordWrapper.addRef($0) },
         Release: { WithKeywordWrapper.release($0) },
         GetIids: {
@@ -2280,7 +2206,7 @@ public enum __ABI_test_component {
                 let `extension`: String = .init(from: $1)
                 try __unwrapped__instance.`enum`(`extension`)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         },
 
         get_Struct: {
@@ -2358,20 +2284,7 @@ public enum __ABI_test_component {
     }
     internal typealias IBaseOverridesWrapper = UnsealedWinRTClassWrapper<test_component.Base.IBaseOverrides>
     internal static var IBaseOverridesVTable: __x_ABI_Ctest__component_CIBaseOverridesVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IBaseOverridesWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IBaseOverridesWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IBaseOverridesWrapper.queryInterface($0, $1, $2) },
         AddRef: { IBaseOverridesWrapper.addRef($0) },
         Release: { IBaseOverridesWrapper.release($0) },
         GetIids: {
@@ -2403,25 +2316,12 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IBaseOverridesWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.onDoTheThing()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         }
     )
     internal typealias IUnsealedDerivedOverridesWrapper = UnsealedWinRTClassWrapper<test_component.UnsealedDerived.IUnsealedDerivedOverrides>
     internal static var IUnsealedDerivedOverridesVTable: __x_ABI_Ctest__component_CIUnsealedDerivedOverridesVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IUnsealedDerivedOverridesWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IUnsealedDerivedOverridesWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IUnsealedDerivedOverridesWrapper.queryInterface($0, $1, $2) },
         AddRef: { IUnsealedDerivedOverridesWrapper.addRef($0) },
         Release: { IUnsealedDerivedOverridesWrapper.release($0) },
         GetIids: {
@@ -2454,25 +2354,12 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IUnsealedDerivedOverridesWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.onBeforeDoTheThing()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         }
     )
     internal typealias IUnsealedDerivedOverloads2Wrapper = UnsealedWinRTClassWrapper<test_component.UnsealedDerived.IUnsealedDerivedOverloads2>
     internal static var IUnsealedDerivedOverloads2VTable: __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2Vtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IUnsealedDerivedOverloads2Wrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IUnsealedDerivedOverloads2Wrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IUnsealedDerivedOverloads2Wrapper.queryInterface($0, $1, $2) },
         AddRef: { IUnsealedDerivedOverloads2Wrapper.addRef($0) },
         Release: { IUnsealedDerivedOverloads2Wrapper.release($0) },
         GetIids: {
@@ -2506,7 +2393,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IUnsealedDerivedOverloads2Wrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.onAfterDoTheThing()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(err: E_FAIL) }
         }
     )
 }
@@ -2561,20 +2448,7 @@ extension __ABI_test_component {
 
     typealias ObjectHandlerWrapper = InterfaceWrapperBase<__IMPL_test_component.ObjectHandlerBridge>
     internal static var ObjectHandlerVTable: __x_ABI_Ctest__component_CIObjectHandlerVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, ObjectHandlerWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return failWith(err: E_NOINTERFACE)
-            }
-        },
-
+        QueryInterface: { ObjectHandlerWrapper.queryInterface($0, $1, $2) },
         AddRef: { ObjectHandlerWrapper.addRef($0) },
         Release: { ObjectHandlerWrapper.release($0) },
         Invoke: {
@@ -2608,20 +2482,7 @@ extension __ABI_test_component {
 
     typealias VoidToVoidDelegateWrapper = InterfaceWrapperBase<__IMPL_test_component.VoidToVoidDelegateBridge>
     internal static var VoidToVoidDelegateVTable: __x_ABI_Ctest__component_CIVoidToVoidDelegateVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, VoidToVoidDelegateWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return failWith(err: E_NOINTERFACE)
-            }
-        },
-
+        QueryInterface: { VoidToVoidDelegateWrapper.queryInterface($0, $1, $2) },
         AddRef: { VoidToVoidDelegateWrapper.addRef($0) },
         Release: { VoidToVoidDelegateWrapper.release($0) },
         Invoke: {
@@ -2637,4 +2498,3 @@ public extension WinRTDelegateBridge where CABI == __x_ABI_Ctest__component_CIVo
         return .init(lpVtbl:vtblPtr)
     }
 }
-

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -230,26 +230,9 @@ public enum __ABI_test_component {
     }
 
     internal static var IAsyncMethodsWithProgressVTable: __x_ABI_Ctest__component_CIAsyncMethodsWithProgressVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IAsyncMethodsWithProgressWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IAsyncMethodsWithProgressWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IAsyncMethodsWithProgressWrapper.queryInterface($0, $1, $2) },
         AddRef: { IAsyncMethodsWithProgressWrapper.addRef($0) },
         Release: { IAsyncMethodsWithProgressWrapper.release($0) },
-    internal static var IAsyncMethodsVTable: __x_ABI_Ctest__component_CIAsyncMethodsVtbl = .init(
-        QueryInterface: { IAsyncMethodsWrapper.queryInterface($0, $1, $2) },
-        AddRef: { IAsyncMethodsWrapper.addRef($0) },
-        Release: { IAsyncMethodsWrapper.release($0) },
         GetIids: {
             let size = MemoryLayout<test_component.IID>.size
             let iids = CoTaskMemAlloc(UInt64(size) * 3).assumingMemoryBound(to: test_component.IID.self)
@@ -282,7 +265,7 @@ public enum __ABI_test_component {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         }
     )
 
@@ -305,20 +288,7 @@ public enum __ABI_test_component {
     }
 
     internal static var IAsyncOperationIntVTable: __x_ABI_Ctest__component_CIAsyncOperationIntVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, IAsyncOperationIntWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return IAsyncOperationIntWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-            }
-        },
-
+        QueryInterface: { IAsyncOperationIntWrapper.queryInterface($0, $1, $2) },
         AddRef: { IAsyncOperationIntWrapper.addRef($0) },
         Release: { IAsyncOperationIntWrapper.release($0) },
         GetIids: {
@@ -351,7 +321,7 @@ public enum __ABI_test_component {
                 let result: Int32 = $1
                 try __unwrapped__instance.complete(result)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         CompleteWithError: {
@@ -360,7 +330,7 @@ public enum __ABI_test_component {
                 let errorCode: HRESULT = $1
                 try __unwrapped__instance.completeWithError(errorCode)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         }
     )
 
@@ -468,7 +438,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IBasicWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.method()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         }
     )
 
@@ -1268,7 +1238,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inInt32(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         InString: {
@@ -1278,7 +1248,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inString(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         InObject: {
@@ -1288,7 +1258,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inObject(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         InEnum: {
@@ -1298,7 +1268,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inEnum(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         OutInt32: {
@@ -1308,7 +1278,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outInt32(&value)
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         OutString: {
@@ -1318,7 +1288,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outString(&value)
                 $1?.initialize(to: try! HString(value).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         OutObject: {
@@ -1329,7 +1299,7 @@ public enum __ABI_test_component {
                 let valueWrapper = __ABI_.AnyWrapper(value)
                 valueWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         OutBlittableStruct: {
@@ -1339,7 +1309,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outBlittableStruct(&value)
                 $1?.initialize(to: .from(swift: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         OutNonBlittableStruct: {
@@ -1350,7 +1320,7 @@ public enum __ABI_test_component {
                 let _value = __ABI_test_component._ABI_NonBlittableStruct(from: value)
                 	$1?.initialize(to: _value.detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         OutEnum: {
@@ -1360,7 +1330,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outEnum(&value)
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         ReturnObject: {
@@ -1370,7 +1340,7 @@ public enum __ABI_test_component {
                 let resultWrapper = __ABI_.AnyWrapper(result)
                 resultWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         ReturnEnum: {
@@ -1379,7 +1349,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.returnEnum()
                 $1?.initialize(to: result)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         get_EnumProperty: {
@@ -1432,7 +1402,7 @@ public enum __ABI_test_component {
                 let data: String = .init(from: $1)
                 try __unwrapped__instance.fireEvent(data)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         }
     )
 
@@ -1484,7 +1454,7 @@ public enum __ABI_test_component {
                 let basics: test_component.AnyIObservableVector<test_component.AnyIBasic?>? = test_component.__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.unwrapFrom(abi: $1)
                 try __unwrapped__instance.takeObservable(basics)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         }
     )
 
@@ -1794,7 +1764,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = ISimpleDelegateWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.doThis()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         DoThat: {
@@ -1803,7 +1773,7 @@ public enum __ABI_test_component {
                 let val: Int32 = $1
                 try __unwrapped__instance.doThat(val)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         }
     )
 
@@ -2206,7 +2176,7 @@ public enum __ABI_test_component {
                 let `extension`: String = .init(from: $1)
                 try __unwrapped__instance.`enum`(`extension`)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         },
 
         get_Struct: {
@@ -2316,7 +2286,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IBaseOverridesWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.onDoTheThing()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         }
     )
     internal typealias IUnsealedDerivedOverridesWrapper = UnsealedWinRTClassWrapper<test_component.UnsealedDerived.IUnsealedDerivedOverrides>
@@ -2354,7 +2324,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IUnsealedDerivedOverridesWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.onBeforeDoTheThing()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         }
     )
     internal typealias IUnsealedDerivedOverloads2Wrapper = UnsealedWinRTClassWrapper<test_component.UnsealedDerived.IUnsealedDerivedOverloads2>
@@ -2393,7 +2363,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IUnsealedDerivedOverloads2Wrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.onAfterDoTheThing()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) }
+            } catch { return failWith(err: E_FAIL) } 
         }
     )
 }
@@ -2498,3 +2468,4 @@ public extension WinRTDelegateBridge where CABI == __x_ABI_Ctest__component_CIVo
         return .init(lpVtbl:vtblPtr)
     }
 }
+

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -209,7 +209,7 @@ internal class IIterableAny: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterable_1_IInspectableBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterable_1_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterable_1_IInspectable
     internal typealias SwiftABI = IIterableAny
     internal typealias SwiftProjection = AnyIIterable<Any?>
@@ -295,7 +295,7 @@ internal class IIterableString: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterable_1_HSTRINGBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterable_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterable_1_HSTRING
     internal typealias SwiftABI = IIterableString
     internal typealias SwiftProjection = AnyIIterable<String>
@@ -381,7 +381,7 @@ internal class IIterableIKeyValuePairString_Any: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable
     internal typealias SwiftABI = IIterableIKeyValuePairString_Any
     internal typealias SwiftProjection = AnyIIterable<AnyIKeyValuePair<String, Any?>?>
@@ -467,7 +467,7 @@ internal class IIterableIKeyValuePairString_String: test_component.IInspectable 
 
 }
 
-internal class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
     internal typealias SwiftABI = IIterableIKeyValuePairString_String
     internal typealias SwiftProjection = AnyIIterable<AnyIKeyValuePair<String, String>?>
@@ -553,7 +553,7 @@ internal class IIterableIKeyValuePairString_Base: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IIterableIKeyValuePairString_Base
     internal typealias SwiftProjection = AnyIIterable<AnyIKeyValuePair<String, Base?>?>
@@ -639,7 +639,7 @@ internal class IIterableBase: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IIterableBase
     internal typealias SwiftProjection = AnyIIterable<Base?>
@@ -725,7 +725,7 @@ internal class IIterableIBasic: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = IIterableIBasic
     internal typealias SwiftProjection = AnyIIterable<AnyIBasic?>
@@ -843,7 +843,7 @@ internal class IIteratorAny: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterator_1_IInspectableBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterator_1_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterator_1_IInspectable
     internal typealias SwiftABI = IIteratorAny
     internal typealias SwiftProjection = AnyIIterator<Any?>
@@ -970,7 +970,7 @@ internal class IIteratorString: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterator_1_HSTRINGBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterator_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterator_1_HSTRING
     internal typealias SwiftABI = IIteratorString
     internal typealias SwiftProjection = AnyIIterator<String>
@@ -1098,7 +1098,7 @@ internal class IIteratorIKeyValuePairString_Any: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable
     internal typealias SwiftABI = IIteratorIKeyValuePairString_Any
     internal typealias SwiftProjection = AnyIIterator<AnyIKeyValuePair<String, Any?>?>
@@ -1226,7 +1226,7 @@ internal class IIteratorIKeyValuePairString_String: test_component.IInspectable 
 
 }
 
-internal class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
     internal typealias SwiftABI = IIteratorIKeyValuePairString_String
     internal typealias SwiftProjection = AnyIIterator<AnyIKeyValuePair<String, String>?>
@@ -1354,7 +1354,7 @@ internal class IIteratorIKeyValuePairString_Base: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IIteratorIKeyValuePairString_Base
     internal typealias SwiftProjection = AnyIIterator<AnyIKeyValuePair<String, Base?>?>
@@ -1481,7 +1481,7 @@ internal class IIteratorBase: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IIteratorBase
     internal typealias SwiftProjection = AnyIIterator<Base?>
@@ -1609,7 +1609,7 @@ internal class IIteratorIBasic: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = IIteratorIBasic
     internal typealias SwiftProjection = AnyIIterator<AnyIBasic?>
@@ -1720,7 +1720,7 @@ internal class IKeyValuePairString_Any: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable
     internal typealias SwiftABI = IKeyValuePairString_Any
     internal typealias SwiftProjection = AnyIKeyValuePair<String, Any?>
@@ -1826,7 +1826,7 @@ internal class IKeyValuePairString_String: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
     internal typealias SwiftABI = IKeyValuePairString_String
     internal typealias SwiftProjection = AnyIKeyValuePair<String, String>
@@ -1932,7 +1932,7 @@ internal class IKeyValuePairString_Base: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IKeyValuePairString_Base
     internal typealias SwiftProjection = AnyIKeyValuePair<String, Base?>
@@ -2038,7 +2038,7 @@ internal class IMapChangedEventArgsString: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIMapChangedEventArgs_1_HSTRING
     internal typealias SwiftABI = IMapChangedEventArgsString
     internal typealias SwiftProjection = AnyIMapChangedEventArgs<String>
@@ -2186,7 +2186,7 @@ internal class IMapViewString_Any: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIMapView_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIMapView_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIMapView_2_HSTRING_IInspectable
     internal typealias SwiftABI = IMapViewString_Any
     internal typealias SwiftProjection = AnyIMapView<String, Any?>
@@ -2351,7 +2351,7 @@ internal class IMapViewString_String: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIMapView_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIMapView_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIMapView_2_HSTRING_HSTRING
     internal typealias SwiftABI = IMapViewString_String
     internal typealias SwiftProjection = AnyIMapView<String, String>
@@ -2516,7 +2516,7 @@ internal class IMapViewString_Base: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IMapViewString_Base
     internal typealias SwiftProjection = AnyIMapView<String, Base?>
@@ -2722,7 +2722,7 @@ internal class IMapString_Any: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIMap_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIMap_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIMap_2_HSTRING_IInspectable
     internal typealias SwiftABI = IMapString_Any
     internal typealias SwiftProjection = AnyIMap<String, Any?>
@@ -2941,7 +2941,7 @@ internal class IMapString_String: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIMap_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIMap_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIMap_2_HSTRING_HSTRING
     internal typealias SwiftABI = IMapString_String
     internal typealias SwiftProjection = AnyIMap<String, String>
@@ -3159,7 +3159,7 @@ internal class IMapString_Base: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IMapString_Base
     internal typealias SwiftProjection = AnyIMap<String, Base?>
@@ -3300,7 +3300,7 @@ internal class IObservableMapString_Any: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIObservableMap_2_HSTRING_IInspectable
     internal typealias SwiftABI = IObservableMapString_Any
     internal typealias SwiftProjection = AnyIObservableMap<String, Any?>
@@ -3455,7 +3455,7 @@ internal class IObservableMapString_String: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIObservableMap_2_HSTRING_HSTRING
     internal typealias SwiftABI = IObservableMapString_String
     internal typealias SwiftProjection = AnyIObservableMap<String, String>
@@ -3610,7 +3610,7 @@ internal class IObservableVectorBase: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IObservableVectorBase
     internal typealias SwiftProjection = AnyIObservableVector<Base?>
@@ -3808,7 +3808,7 @@ internal class IObservableVectorIBasic: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = IObservableVectorIBasic
     internal typealias SwiftProjection = AnyIObservableVector<AnyIBasic?>
@@ -4028,7 +4028,7 @@ internal class IVectorViewAny: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIVectorView_1_IInspectableBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIVectorView_1_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVectorView_1_IInspectable
     internal typealias SwiftABI = IVectorViewAny
     internal typealias SwiftProjection = AnyIVectorView<Any?>
@@ -4188,7 +4188,7 @@ internal class IVectorViewString: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIVectorView_1_HSTRINGBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIVectorView_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVectorView_1_HSTRING
     internal typealias SwiftABI = IVectorViewString
     internal typealias SwiftProjection = AnyIVectorView<String>
@@ -4347,7 +4347,7 @@ internal class IVectorViewBase: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IVectorViewBase
     internal typealias SwiftProjection = AnyIVectorView<Base?>
@@ -4509,7 +4509,7 @@ internal class IVectorViewIBasic: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = IVectorViewIBasic
     internal typealias SwiftProjection = AnyIVectorView<AnyIBasic?>
@@ -4773,7 +4773,7 @@ internal class IVectorAny: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIVector_1_IInspectableBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIVector_1_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVector_1_IInspectable
     internal typealias SwiftABI = IVectorAny
     internal typealias SwiftProjection = AnyIVector<Any?>
@@ -5076,7 +5076,7 @@ internal class IVectorString: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIVector_1_HSTRINGBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIVector_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVector_1_HSTRING
     internal typealias SwiftABI = IVectorString
     internal typealias SwiftProjection = AnyIVector<String>
@@ -5375,7 +5375,7 @@ internal class IVectorBase: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IVectorBase
     internal typealias SwiftProjection = AnyIVector<Base?>
@@ -5683,7 +5683,7 @@ internal class IVectorIBasic: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = IVectorIBasic
     internal typealias SwiftProjection = AnyIVector<AnyIBasic?>
@@ -6179,7 +6179,7 @@ internal class IAsyncOperationWithProgressInt32_Double: test_component.IInspecta
 
 }
 
-internal class __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIAsyncOperationWithProgress_2_int_double
     internal typealias SwiftABI = IAsyncOperationWithProgressInt32_Double
     internal typealias SwiftProjection = AnyIAsyncOperationWithProgress<Int32, Double>
@@ -6337,7 +6337,7 @@ internal class IAsyncOperationInt32: test_component.IInspectable {
 
 }
 
-internal class __x_ABI_C__FIAsyncOperation_1_intBridge : AbiInterfaceBridge {
+internal enum __x_ABI_C__FIAsyncOperation_1_intBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1_int
     internal typealias SwiftABI = IAsyncOperationInt32
     internal typealias SwiftProjection = AnyIAsyncOperation<Int32>
@@ -6405,7 +6405,7 @@ private var IID___x_ABI_C__FIReference_1_GUID: test_component.IID {
     .init(Data1: 0x7d50f649, Data2: 0x632c, Data3: 0x51f9, Data4: ( 0x84,0x9a,0xee,0x49,0x42,0x89,0x33,0xea ))// 7d50f649-632c-51f9-849a-ee49428933ea
 }
 
-internal struct __x_ABI_C__FIReference_1_GUIDBridge: ReferenceBridge {
+internal enum __x_ABI_C__FIReference_1_GUIDBridge: ReferenceBridge {
     typealias CABI = __x_ABI_C__FIReference_1_GUID
     typealias SwiftProjection = GUID
     static var IID: test_component.IID { IID___x_ABI_C__FIReference_1_GUID }
@@ -6463,7 +6463,7 @@ private var IID___x_ABI_C__FIReference_1_int: test_component.IID {
     .init(Data1: 0x548cefbd, Data2: 0xbc8a, Data3: 0x5fa0, Data4: ( 0x8d,0xf2,0x95,0x74,0x40,0xfc,0x8b,0xf4 ))// 548cefbd-bc8a-5fa0-8df2-957440fc8bf4
 }
 
-internal struct __x_ABI_C__FIReference_1_intBridge: ReferenceBridge {
+internal enum __x_ABI_C__FIReference_1_intBridge: ReferenceBridge {
     typealias CABI = __x_ABI_C__FIReference_1_int
     typealias SwiftProjection = Int32
     static var IID: test_component.IID { IID___x_ABI_C__FIReference_1_int }
@@ -6521,7 +6521,7 @@ private var IID___x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSigned: tes
     .init(Data1: 0x5888a1ed, Data2: 0xabae, Data3: 0x584f, Data4: ( 0xbf,0x08,0x13,0x1b,0x25,0x42,0x80,0x6b ))// 5888a1ed-abae-584f-bf08-131b2542806b
 }
 
-internal struct __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedBridge: ReferenceBridge {
+internal enum __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedBridge: ReferenceBridge {
     typealias CABI = __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSigned
     typealias SwiftProjection = test_component.Signed
     static var IID: test_component.IID { IID___x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSigned }

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -14,20 +14,7 @@ internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FIAsyncOperation
 }
 
 internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1_intVTable: __x_ABI_C__FIAsyncOperationCompletedHandler_1_intVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return failWith(err: E_NOINTERFACE)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper.addRef($0) },
     Release: { __x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper.release($0) },
     Invoke: {
@@ -57,7 +44,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1_intBridge : WinRTDe
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1_int
     internal typealias SwiftABI = test_component.AsyncOperationCompletedHandlerInt32
 
-    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -78,20 +65,7 @@ internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FIAsyncOperation
 }
 
 internal var __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleVTable: __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return failWith(err: E_NOINTERFACE)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleWrapper.addRef($0) },
     Release: { __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleWrapper.release($0) },
     Invoke: {
@@ -121,7 +95,7 @@ internal class __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleBridge : W
     internal typealias CABI = __x_ABI_C__FIAsyncOperationProgressHandler_2_int_double
     internal typealias SwiftABI = test_component.AsyncOperationProgressHandlerInt32_Double
 
-    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, progressInfo) in
@@ -142,20 +116,7 @@ internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FIAsyncOperation
 }
 
 internal var __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleVTable: __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return failWith(err: E_NOINTERFACE)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleWrapper.addRef($0) },
     Release: { __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleWrapper.release($0) },
     Invoke: {
@@ -185,7 +146,7 @@ internal class __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_dou
     internal typealias CABI = __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_double
     internal typealias SwiftABI = test_component.AsyncOperationWithProgressCompletedHandlerInt32_Double
 
-    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -199,20 +160,7 @@ private var IID___x_ABI_C__FIIterable_1_IInspectable: test_component.IID {
 }
 
 internal var __x_ABI_C__FIIterable_1_IInspectableVTable: __x_ABI_C__FIIterable_1_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterable_1_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterable_1_IInspectableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterable_1_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterable_1_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterable_1_IInspectableWrapper.release($0) },
     GetIids: {
@@ -298,20 +246,7 @@ private var IID___x_ABI_C__FIIterable_1_HSTRING: test_component.IID {
 }
 
 internal var __x_ABI_C__FIIterable_1_HSTRINGVTable: __x_ABI_C__FIIterable_1_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterable_1_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterable_1_HSTRINGWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterable_1_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterable_1_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterable_1_HSTRINGWrapper.release($0) },
     GetIids: {
@@ -397,20 +332,7 @@ private var IID___x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IIns
 }
 
 internal var __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableVTable: __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.release($0) },
     GetIids: {
@@ -496,20 +418,7 @@ private var IID___x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTR
 }
 
 internal var __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGVTable: __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.release($0) },
     GetIids: {
@@ -595,20 +504,7 @@ private var IID___x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_
 }
 
 internal var __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVTable: __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.release($0) },
     GetIids: {
@@ -694,20 +590,7 @@ private var IID___x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBase: test_c
 }
 
 internal var __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseWrapper.release($0) },
     GetIids: {
@@ -793,20 +676,7 @@ private var IID___x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasic: test
 }
 
 internal var __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicVTable: __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.release($0) },
     GetIids: {
@@ -892,20 +762,7 @@ private var IID___x_ABI_C__FIIterator_1_IInspectable: test_component.IID {
 }
 
 internal var __x_ABI_C__FIIterator_1_IInspectableVTable: __x_ABI_C__FIIterator_1_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterator_1_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterator_1_IInspectableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterator_1_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterator_1_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterator_1_IInspectableWrapper.release($0) },
     GetIids: {
@@ -1033,20 +890,7 @@ private var IID___x_ABI_C__FIIterator_1_HSTRING: test_component.IID {
 }
 
 internal var __x_ABI_C__FIIterator_1_HSTRINGVTable: __x_ABI_C__FIIterator_1_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterator_1_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterator_1_HSTRINGWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterator_1_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterator_1_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterator_1_HSTRINGWrapper.release($0) },
     GetIids: {
@@ -1173,20 +1017,7 @@ private var IID___x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IIns
 }
 
 internal var __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableVTable: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.release($0) },
     GetIids: {
@@ -1314,20 +1145,7 @@ private var IID___x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTR
 }
 
 internal var __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGVTable: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.release($0) },
     GetIids: {
@@ -1455,20 +1273,7 @@ private var IID___x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_
 }
 
 internal var __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVTable: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.release($0) },
     GetIids: {
@@ -1596,20 +1401,7 @@ private var IID___x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBase: test_c
 }
 
 internal var __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseWrapper.release($0) },
     GetIids: {
@@ -1736,20 +1528,7 @@ private var IID___x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasic: test
 }
 
 internal var __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicVTable: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.addRef($0) },
     Release: { __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.release($0) },
     GetIids: {
@@ -1877,20 +1656,7 @@ private var IID___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable: test_component
 }
 
 internal var __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableVTable: __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.release($0) },
     GetIids: {
@@ -1997,20 +1763,7 @@ private var IID___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING: test_component.IID 
 }
 
 internal var __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGVTable: __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.release($0) },
     GetIids: {
@@ -2116,20 +1869,7 @@ private var IID___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__C
 }
 
 internal var __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVTable: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.addRef($0) },
     Release: { __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.release($0) },
     GetIids: {
@@ -2235,20 +1975,7 @@ private var IID___x_ABI_C__FIMapChangedEventArgs_1_HSTRING: test_component.IID {
 }
 
 internal var __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGVTable: __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper.release($0) },
     GetIids: {
@@ -2353,20 +2080,7 @@ private var IID___x_ABI_C__FIMapView_2_HSTRING_IInspectable: test_component.IID 
 }
 
 internal var __x_ABI_C__FIMapView_2_HSTRING_IInspectableVTable: __x_ABI_C__FIMapView_2_HSTRING_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.release($0) },
     GetIids: {
@@ -2532,20 +2246,7 @@ private var IID___x_ABI_C__FIMapView_2_HSTRING_HSTRING: test_component.IID {
 }
 
 internal var __x_ABI_C__FIMapView_2_HSTRING_HSTRINGVTable: __x_ABI_C__FIMapView_2_HSTRING_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.release($0) },
     GetIids: {
@@ -2710,20 +2411,7 @@ private var IID___x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase:
 }
 
 internal var __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVTable: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.addRef($0) },
     Release: { __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.release($0) },
     GetIids: {
@@ -2888,20 +2576,7 @@ private var IID___x_ABI_C__FIMap_2_HSTRING_IInspectable: test_component.IID {
 }
 
 internal var __x_ABI_C__FIMap_2_HSTRING_IInspectableVTable: __x_ABI_C__FIMap_2_HSTRING_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper.release($0) },
     GetIids: {
@@ -3122,20 +2797,7 @@ private var IID___x_ABI_C__FIMap_2_HSTRING_HSTRING: test_component.IID {
 }
 
 internal var __x_ABI_C__FIMap_2_HSTRING_HSTRINGVTable: __x_ABI_C__FIMap_2_HSTRING_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper.release($0) },
     GetIids: {
@@ -3354,20 +3016,7 @@ private var IID___x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase: tes
 }
 
 internal var __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVTable: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.addRef($0) },
     Release: { __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.release($0) },
     GetIids: {
@@ -3585,20 +3234,7 @@ private var IID___x_ABI_C__FIObservableMap_2_HSTRING_IInspectable: test_componen
 }
 
 internal var __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableVTable: __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableWrapper.release($0) },
     GetIids: {
@@ -3753,20 +3389,7 @@ private var IID___x_ABI_C__FIObservableMap_2_HSTRING_HSTRING: test_component.IID
 }
 
 internal var __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGVTable: __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGWrapper.release($0) },
     GetIids: {
@@ -3921,20 +3544,7 @@ private var IID___x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase
 }
 
 internal var __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.addRef($0) },
     Release: { __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.release($0) },
     GetIids: {
@@ -4132,20 +3742,7 @@ private var IID___x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBas
 }
 
 internal var __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicVTable: __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.addRef($0) },
     Release: { __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.release($0) },
     GetIids: {
@@ -4343,20 +3940,7 @@ private var IID___x_ABI_C__FIVectorView_1_IInspectable: test_component.IID {
 }
 
 internal var __x_ABI_C__FIVectorView_1_IInspectableVTable: __x_ABI_C__FIVectorView_1_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIVectorView_1_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIVectorView_1_IInspectableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIVectorView_1_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIVectorView_1_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FIVectorView_1_IInspectableWrapper.release($0) },
     GetIids: {
@@ -4518,20 +4102,7 @@ private var IID___x_ABI_C__FIVectorView_1_HSTRING: test_component.IID {
 }
 
 internal var __x_ABI_C__FIVectorView_1_HSTRINGVTable: __x_ABI_C__FIVectorView_1_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIVectorView_1_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIVectorView_1_HSTRINGWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIVectorView_1_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIVectorView_1_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FIVectorView_1_HSTRINGWrapper.release($0) },
     GetIids: {
@@ -4691,20 +4262,7 @@ private var IID___x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBase: test
 }
 
 internal var __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseWrapper.addRef($0) },
     Release: { __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseWrapper.release($0) },
     GetIids: {
@@ -4863,20 +4421,7 @@ private var IID___x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasic: te
 }
 
 internal var __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicVTable: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.addRef($0) },
     Release: { __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.release($0) },
     GetIids: {
@@ -5038,20 +4583,7 @@ private var IID___x_ABI_C__FIVector_1_IInspectable: test_component.IID {
 }
 
 internal var __x_ABI_C__FIVector_1_IInspectableVTable: __x_ABI_C__FIVector_1_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIVector_1_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIVector_1_IInspectableWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIVector_1_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIVector_1_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FIVector_1_IInspectableWrapper.release($0) },
     GetIids: {
@@ -5359,20 +4891,7 @@ private var IID___x_ABI_C__FIVector_1_HSTRING: test_component.IID {
 }
 
 internal var __x_ABI_C__FIVector_1_HSTRINGVTable: __x_ABI_C__FIVector_1_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIVector_1_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIVector_1_HSTRINGWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIVector_1_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIVector_1_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FIVector_1_HSTRINGWrapper.release($0) },
     GetIids: {
@@ -5675,20 +5194,7 @@ private var IID___x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase: test_com
 }
 
 internal var __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.addRef($0) },
     Release: { __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.release($0) },
     GetIids: {
@@ -5987,20 +5493,7 @@ private var IID___x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic: test_c
 }
 
 internal var __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicVTable: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.addRef($0) },
     Release: { __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.release($0) },
     GetIids: {
@@ -6315,20 +5808,7 @@ internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FMapChangedEvent
 }
 
 internal var __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableVTable: __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return failWith(err: E_NOINTERFACE)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableWrapper.release($0) },
     Invoke: {
@@ -6360,7 +5840,7 @@ internal class __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableBridge :
     internal typealias CABI = __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectable
     internal typealias SwiftABI = test_component.MapChangedEventHandlerString_Any
 
-    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
@@ -6381,20 +5861,7 @@ internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FMapChangedEvent
 }
 
 internal var __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGVTable: __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return failWith(err: E_NOINTERFACE)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGWrapper.addRef($0) },
     Release: { __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGWrapper.release($0) },
     Invoke: {
@@ -6426,7 +5893,7 @@ internal class __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGBridge : WinR
     internal typealias CABI = __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRING
     internal typealias SwiftABI = test_component.MapChangedEventHandlerString_String
 
-    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
@@ -6447,20 +5914,7 @@ internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FVectorChangedEv
 }
 
 internal var __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return failWith(err: E_NOINTERFACE)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseWrapper.addRef($0) },
     Release: { __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseWrapper.release($0) },
     Invoke: {
@@ -6492,7 +5946,7 @@ internal class __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent
     internal typealias CABI = __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = test_component.VectorChangedEventHandlerBase
 
-    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
@@ -6513,20 +5967,7 @@ internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FVectorChangedEv
 }
 
 internal var __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicVTable: __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return failWith(err: E_NOINTERFACE)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.addRef($0) },
     Release: { __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.release($0) },
     Invoke: {
@@ -6558,7 +5999,7 @@ internal class __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent
     internal typealias CABI = __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = test_component.VectorChangedEventHandlerIBasic
 
-    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
@@ -6579,20 +6020,7 @@ internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FIEventHandler_1
 }
 
 internal var __x_ABI_C__FIEventHandler_1_IInspectableVTable: __x_ABI_C__FIEventHandler_1_IInspectableVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIEventHandler_1_IInspectableWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return failWith(err: E_NOINTERFACE)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIEventHandler_1_IInspectableWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIEventHandler_1_IInspectableWrapper.addRef($0) },
     Release: { __x_ABI_C__FIEventHandler_1_IInspectableWrapper.release($0) },
     Invoke: {
@@ -6624,7 +6052,7 @@ internal class __x_ABI_C__FIEventHandler_1_IInspectableBridge : WinRTDelegateBri
     internal typealias CABI = __x_ABI_C__FIEventHandler_1_IInspectable
     internal typealias SwiftABI = test_component.EventHandlerAny
 
-    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
@@ -6638,20 +6066,7 @@ private var IID___x_ABI_C__FIAsyncOperationWithProgress_2_int_double: test_compo
 }
 
 internal var __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleVTable: __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper.addRef($0) },
     Release: { __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper.release($0) },
     GetIids: {
@@ -6840,20 +6255,7 @@ private var IID___x_ABI_C__FIAsyncOperation_1_int: test_component.IID {
 }
 
 internal var __x_ABI_C__FIAsyncOperation_1_intVTable: __x_ABI_C__FIAsyncOperation_1_intVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIAsyncOperation_1_intWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIAsyncOperation_1_intWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIAsyncOperation_1_intWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIAsyncOperation_1_intWrapper.addRef($0) },
     Release: { __x_ABI_C__FIAsyncOperation_1_intWrapper.release($0) },
     GetIids: {
@@ -7003,29 +6405,25 @@ private var IID___x_ABI_C__FIReference_1_GUID: test_component.IID {
     .init(Data1: 0x7d50f649, Data2: 0x632c, Data3: 0x51f9, Data4: ( 0x84,0x9a,0xee,0x49,0x42,0x89,0x33,0xea ))// 7d50f649-632c-51f9-849a-ee49428933ea
 }
 
-internal extension GUID {
-    init?(ref: UnsafeMutablePointer<__x_ABI_C__FIReference_1_GUID>?) {
-        guard let val = ref else { return nil }
+internal struct __x_ABI_C__FIReference_1_GUIDBridge: ReferenceBridge {
+    typealias CABI = __x_ABI_C__FIReference_1_GUID
+    typealias SwiftProjection = GUID
+    static var IID: test_component.IID { IID___x_ABI_C__FIReference_1_GUID }
+
+    static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+        guard let val = abi else { return nil }
         var result: GUID = .init()
         try! CHECKED(val.pointee.lpVtbl.pointee.get_Value(val, &result))
-        self = result
+        return result
+    }
+
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &__x_ABI_C__FIReference_1_GUIDVTable) { $0 }
+        return .init(lpVtbl: vtblPtr)
     }
 }
 internal var __x_ABI_C__FIReference_1_GUIDVTable: __x_ABI_C__FIReference_1_GUIDVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIReference_1_GUIDWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIReference_1_GUIDWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIReference_1_GUIDWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIReference_1_GUIDWrapper.addRef($0) },
     Release: { __x_ABI_C__FIReference_1_GUIDWrapper.release($0) },
     GetIids: {
@@ -7055,48 +6453,35 @@ internal var __x_ABI_C__FIReference_1_GUIDVTable: __x_ABI_C__FIReference_1_GUIDV
 
     get_Value: {
         guard let __unwrapped__instance = __x_ABI_C__FIReference_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        let result = __unwrapped__instance.value as! GUID
+        let result = __unwrapped__instance
         $1?.initialize(to: result)
         return S_OK
     }
 )
-internal class __x_ABI_C__FIReference_1_GUIDWrapper: WinRTWrapperBase<__x_ABI_C__FIReference_1_GUID, IReference> {
-    override class var IID: test_component.IID { IID___x_ABI_C__FIReference_1_GUID }
-    init?(_ value: GUID?) {
-        guard let value = value else { return nil }
-        let abi = withUnsafeMutablePointer(to: &__x_ABI_C__FIReference_1_GUIDVTable) {
-            __x_ABI_C__FIReference_1_GUID(lpVtbl:$0)
-        }
-        super.init(abi, __IMPL_Windows_Foundation.IPropertyValueImpl(value: value))
-    }
-}
+typealias __x_ABI_C__FIReference_1_GUIDWrapper = ReferenceWrapperBase<test_component.__x_ABI_C__FIReference_1_GUIDBridge>
 private var IID___x_ABI_C__FIReference_1_int: test_component.IID {
     .init(Data1: 0x548cefbd, Data2: 0xbc8a, Data3: 0x5fa0, Data4: ( 0x8d,0xf2,0x95,0x74,0x40,0xfc,0x8b,0xf4 ))// 548cefbd-bc8a-5fa0-8df2-957440fc8bf4
 }
 
-internal extension Int32 {
-    init?(ref: UnsafeMutablePointer<__x_ABI_C__FIReference_1_int>?) {
-        guard let val = ref else { return nil }
+internal struct __x_ABI_C__FIReference_1_intBridge: ReferenceBridge {
+    typealias CABI = __x_ABI_C__FIReference_1_int
+    typealias SwiftProjection = Int32
+    static var IID: test_component.IID { IID___x_ABI_C__FIReference_1_int }
+
+    static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+        guard let val = abi else { return nil }
         var result: INT32 = 0
         try! CHECKED(val.pointee.lpVtbl.pointee.get_Value(val, &result))
-        self = result
+        return result
+    }
+
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &__x_ABI_C__FIReference_1_intVTable) { $0 }
+        return .init(lpVtbl: vtblPtr)
     }
 }
 internal var __x_ABI_C__FIReference_1_intVTable: __x_ABI_C__FIReference_1_intVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIReference_1_intWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIReference_1_intWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIReference_1_intWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIReference_1_intWrapper.addRef($0) },
     Release: { __x_ABI_C__FIReference_1_intWrapper.release($0) },
     GetIids: {
@@ -7126,48 +6511,35 @@ internal var __x_ABI_C__FIReference_1_intVTable: __x_ABI_C__FIReference_1_intVtb
 
     get_Value: {
         guard let __unwrapped__instance = __x_ABI_C__FIReference_1_intWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        let result = __unwrapped__instance.value as! Int32
+        let result = __unwrapped__instance
         $1?.initialize(to: result)
         return S_OK
     }
 )
-internal class __x_ABI_C__FIReference_1_intWrapper: WinRTWrapperBase<__x_ABI_C__FIReference_1_int, IReference> {
-    override class var IID: test_component.IID { IID___x_ABI_C__FIReference_1_int }
-    init?(_ value: Int32?) {
-        guard let value = value else { return nil }
-        let abi = withUnsafeMutablePointer(to: &__x_ABI_C__FIReference_1_intVTable) {
-            __x_ABI_C__FIReference_1_int(lpVtbl:$0)
-        }
-        super.init(abi, __IMPL_Windows_Foundation.IPropertyValueImpl(value: value))
-    }
-}
+typealias __x_ABI_C__FIReference_1_intWrapper = ReferenceWrapperBase<test_component.__x_ABI_C__FIReference_1_intBridge>
 private var IID___x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSigned: test_component.IID {
     .init(Data1: 0x5888a1ed, Data2: 0xabae, Data3: 0x584f, Data4: ( 0xbf,0x08,0x13,0x1b,0x25,0x42,0x80,0x6b ))// 5888a1ed-abae-584f-bf08-131b2542806b
 }
 
-internal extension test_component.Signed {
-    init?(ref: UnsafeMutablePointer<__x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSigned>?) {
-        guard let val = ref else { return nil }
+internal struct __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedBridge: ReferenceBridge {
+    typealias CABI = __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSigned
+    typealias SwiftProjection = test_component.Signed
+    static var IID: test_component.IID { IID___x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSigned }
+
+    static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+        guard let val = abi else { return nil }
         var result: Signed = .init(0)
         try! CHECKED(val.pointee.lpVtbl.pointee.get_Value(val, &result))
-        self = result
+        return result
+    }
+
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &__x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedVTable) { $0 }
+        return .init(lpVtbl: vtblPtr)
     }
 }
 internal var __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedVTable: __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedWrapper.queryInterface(pUnk, riid.pointee, ppvObject)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedWrapper.addRef($0) },
     Release: { __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedWrapper.release($0) },
     GetIids: {
@@ -7197,21 +6569,12 @@ internal var __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedVTable: 
 
     get_Value: {
         guard let __unwrapped__instance = __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        let result = __unwrapped__instance.value as! test_component.Signed
+        let result = __unwrapped__instance
         $1?.initialize(to: result)
         return S_OK
     }
 )
-internal class __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedWrapper: WinRTWrapperBase<__x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSigned, IReference> {
-    override class var IID: test_component.IID { IID___x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSigned }
-    init?(_ value: test_component.Signed?) {
-        guard let value = value else { return nil }
-        let abi = withUnsafeMutablePointer(to: &__x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedVTable) {
-            __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSigned(lpVtbl:$0)
-        }
-        super.init(abi, __IMPL_Windows_Foundation.IPropertyValueImpl(value: value))
-    }
-}
+typealias __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedWrapper = ReferenceWrapperBase<test_component.__x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedBridge>
 private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgs: test_component.IID {
     .init(Data1: 0x60e30bb2, Data2: 0x55fe, Data3: 0x5e7e, Data4: ( 0xb1,0xe6,0xf9,0xba,0x28,0x90,0x0a,0x82 ))// 60e30bb2-55fe-5e7e-b1e6-f9ba28900a82
 }
@@ -7224,20 +6587,7 @@ internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHand
 }
 
 internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return failWith(err: E_NOINTERFACE)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsWrapper.addRef($0) },
     Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsWrapper.release($0) },
     Invoke: {
@@ -7265,7 +6615,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClas
     internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgs
     internal typealias SwiftABI = test_component.TypedEventHandlerClass_DeferrableEventArgs
 
-    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
@@ -7286,20 +6636,7 @@ internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHand
 }
 
 internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsVTable: __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsVtbl = .init(
-    QueryInterface: {
-        guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-        ppvObject.pointee = nil
-
-        switch riid.pointee {
-            case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsWrapper.IID:
-                _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                return S_OK
-            default:
-                return failWith(err: E_NOINTERFACE)
-        }
-    },
-
+    QueryInterface: { __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsWrapper.queryInterface($0, $1, $2) },
     AddRef: { __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsWrapper.addRef($0) },
     Release: { __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsWrapper.release($0) },
     Invoke: {
@@ -7327,7 +6664,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimp
     internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgs
     internal typealias SwiftABI = test_component.TypedEventHandlerSimple_SimpleEventArgs
 
-    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -343,7 +343,7 @@ public enum __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIObjectHandler
         public typealias SwiftABI = __ABI_test_component.ObjectHandler
 
-        public static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+        public static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (item) in
@@ -357,7 +357,7 @@ public enum __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIVoidToVoidDelegate
         public typealias SwiftABI = __ABI_test_component.VoidToVoidDelegate
 
-        public static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+        public static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -3,7 +3,7 @@
 import Ctest_component
 
 public enum __IMPL_test_component {
-    public class IAsyncMethodsWithProgressBridge : AbiInterfaceBridge {
+    public enum IAsyncMethodsWithProgressBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_Ctest__component_CIAsyncMethodsWithProgress
         public typealias SwiftABI = __ABI_test_component.IAsyncMethodsWithProgress
         public typealias SwiftProjection = AnyIAsyncMethodsWithProgress
@@ -32,7 +32,7 @@ public enum __IMPL_test_component {
 
     }
 
-    public class IAsyncOperationIntBridge : AbiInterfaceBridge {
+    public enum IAsyncOperationIntBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_Ctest__component_CIAsyncOperationInt
         public typealias SwiftABI = __ABI_test_component.IAsyncOperationInt
         public typealias SwiftProjection = AnyIAsyncOperationInt
@@ -65,7 +65,7 @@ public enum __IMPL_test_component {
 
     }
 
-    public class IBasicBridge : AbiInterfaceBridge {
+    public enum IBasicBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_Ctest__component_CIBasic
         public typealias SwiftABI = __ABI_test_component.IBasic
         public typealias SwiftProjection = AnyIBasic
@@ -94,7 +94,7 @@ public enum __IMPL_test_component {
 
     }
 
-    public class IIAmImplementableBridge : AbiInterfaceBridge {
+    public enum IIAmImplementableBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_Ctest__component_CIIAmImplementable
         public typealias SwiftABI = __ABI_test_component.IIAmImplementable
         public typealias SwiftProjection = AnyIIAmImplementable
@@ -193,7 +193,7 @@ public enum __IMPL_test_component {
 
     }
 
-    public class IInterfaceWithObservableVectorBridge : AbiInterfaceBridge {
+    public enum IInterfaceWithObservableVectorBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_Ctest__component_CIInterfaceWithObservableVector
         public typealias SwiftABI = __ABI_test_component.IInterfaceWithObservableVector
         public typealias SwiftProjection = AnyIInterfaceWithObservableVector
@@ -222,7 +222,7 @@ public enum __IMPL_test_component {
 
     }
 
-    public class ISimpleDelegateBridge : AbiInterfaceBridge {
+    public enum ISimpleDelegateBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_Ctest__component_CISimpleDelegate
         public typealias SwiftABI = __ABI_test_component.ISimpleDelegate
         public typealias SwiftProjection = AnyISimpleDelegate
@@ -255,7 +255,7 @@ public enum __IMPL_test_component {
 
     }
 
-    public class InterfaceWithReturnDelegateBridge : AbiInterfaceBridge {
+    public enum InterfaceWithReturnDelegateBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_Ctest__component_CInterfaceWithReturnDelegate
         public typealias SwiftABI = __ABI_test_component.InterfaceWithReturnDelegate
         public typealias SwiftProjection = AnyInterfaceWithReturnDelegate
@@ -292,7 +292,7 @@ public enum __IMPL_test_component {
 
     }
 
-    public class WithKeywordBridge : AbiInterfaceBridge {
+    public enum WithKeywordBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_Ctest__component_CWithKeyword
         public typealias SwiftABI = __ABI_test_component.WithKeyword
         public typealias SwiftProjection = AnyWithKeyword

--- a/tests/test_component/Sources/test_component/test_component.Delegates+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+ABI.swift
@@ -33,20 +33,7 @@ extension __ABI_test_component_Delegates {
 
     typealias InDelegateWrapper = InterfaceWrapperBase<__IMPL_test_component_Delegates.InDelegateBridge>
     internal static var InDelegateVTable: __x_ABI_Ctest__component_CDelegates_CIInDelegateVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, InDelegateWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return failWith(err: E_NOINTERFACE)
-            }
-        },
-
+        QueryInterface: { InDelegateWrapper.queryInterface($0, $1, $2) },
         AddRef: { InDelegateWrapper.addRef($0) },
         Release: { InDelegateWrapper.release($0) },
         Invoke: {
@@ -82,20 +69,7 @@ extension __ABI_test_component_Delegates {
 
     typealias ReturnInt32DelegateWrapper = InterfaceWrapperBase<__IMPL_test_component_Delegates.ReturnInt32DelegateBridge>
     internal static var ReturnInt32DelegateVTable: __x_ABI_Ctest__component_CDelegates_CIReturnInt32DelegateVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, ReturnInt32DelegateWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return failWith(err: E_NOINTERFACE)
-            }
-        },
-
+        QueryInterface: { ReturnInt32DelegateWrapper.queryInterface($0, $1, $2) },
         AddRef: { ReturnInt32DelegateWrapper.addRef($0) },
         Release: { ReturnInt32DelegateWrapper.release($0) },
         Invoke: {
@@ -129,20 +103,7 @@ extension __ABI_test_component_Delegates {
 
     typealias SignalDelegateWrapper = InterfaceWrapperBase<__IMPL_test_component_Delegates.SignalDelegateBridge>
     internal static var SignalDelegateVTable: __x_ABI_Ctest__component_CDelegates_CISignalDelegateVtbl = .init(
-        QueryInterface: {
-            guard let pUnk = $0, let riid = $1, let ppvObject = $2 else { return E_INVALIDARG }
-            ppvObject.pointee = nil
-
-            switch riid.pointee {
-                case IUnknown.IID, IInspectable.IID, ISwiftImplemented.IID, IAgileObject.IID, SignalDelegateWrapper.IID:
-                    _ = pUnk.pointee.lpVtbl.pointee.AddRef(pUnk)
-                    ppvObject.pointee = UnsafeMutableRawPointer(pUnk)
-                    return S_OK
-                default:
-                    return failWith(err: E_NOINTERFACE)
-            }
-        },
-
+        QueryInterface: { SignalDelegateWrapper.queryInterface($0, $1, $2) },
         AddRef: { SignalDelegateWrapper.addRef($0) },
         Release: { SignalDelegateWrapper.release($0) },
         Invoke: {

--- a/tests/test_component/Sources/test_component/test_component.Delegates+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+Impl.swift
@@ -8,7 +8,7 @@ public enum __IMPL_test_component_Delegates {
         public typealias CABI = __x_ABI_Ctest__component_CDelegates_CIInDelegate
         public typealias SwiftABI = __ABI_test_component_Delegates.InDelegate
 
-        public static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+        public static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (value) in
@@ -22,7 +22,7 @@ public enum __IMPL_test_component_Delegates {
         public typealias CABI = __x_ABI_Ctest__component_CDelegates_CIReturnInt32Delegate
         public typealias SwiftABI = __ABI_test_component_Delegates.ReturnInt32Delegate
 
-        public static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+        public static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in
@@ -36,7 +36,7 @@ public enum __IMPL_test_component_Delegates {
         public typealias CABI = __x_ABI_Ctest__component_CDelegates_CISignalDelegate
         public typealias SwiftABI = __ABI_test_component_Delegates.SignalDelegate
 
-        public static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection? {
+        public static func from(abi: UnsafeMutablePointer<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -139,7 +139,7 @@ open class Base : WinRTClass {
         composing: Composable.Type,
         _ createCallback: (UnsealedWinRTClassWrapper<Composable>?, inout test_component.IInspectable?) -> Composable.Default.SwiftABI)
     {
-        self._inner = MakeComposed(composing: composing, (self as! Composable.Default.SwiftProjection), createCallback)
+        self._inner = MakeComposed(composing: composing, (self as! Composable.SwiftProjection), createCallback)
     }
     open func queryInterface(_ iid: test_component.IID) -> IUnknownRef? {
         switch iid {
@@ -166,11 +166,11 @@ open class Base : WinRTClass {
         try _IBaseOverrides.OnDoTheThingImpl()
     }
 
-    internal class IBaseOverrides : ComposableImpl {
+    internal struct IBaseOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
         internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        internal class Default : MakeComposedAbi {
-            internal typealias SwiftProjection = Base
+        internal typealias SwiftProjection = Base
+        internal struct Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIBase
             internal typealias SwiftABI = __ABI_test_component.IBase
         }
@@ -405,7 +405,7 @@ open class BaseNoOverrides : WinRTClass {
         composing: Composable.Type,
         _ createCallback: (UnsealedWinRTClassWrapper<Composable>?, inout test_component.IInspectable?) -> Composable.Default.SwiftABI)
     {
-        self._inner = MakeComposed(composing: composing, (self as! Composable.Default.SwiftProjection), createCallback)
+        self._inner = MakeComposed(composing: composing, (self as! Composable.SwiftProjection), createCallback)
     }
     open func queryInterface(_ iid: test_component.IID) -> IUnknownRef? {
         return test_component.queryInterface(self, iid)
@@ -418,11 +418,11 @@ open class BaseNoOverrides : WinRTClass {
         }
     }
 
-    internal class IBaseNoOverrides : ComposableImpl {
+    internal struct IBaseNoOverrides : ComposableImpl {
         internal typealias CABI = C_IInspectable
         internal typealias SwiftABI = test_component.IInspectable
-        internal class Default : MakeComposedAbi {
-            internal typealias SwiftProjection = BaseNoOverrides
+        internal typealias SwiftProjection = BaseNoOverrides
+        internal struct Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIBaseNoOverrides
             internal typealias SwiftABI = __ABI_test_component.IBaseNoOverrides
         }
@@ -947,11 +947,11 @@ public final class Derived : test_component.Base {
         set { try! _default.put_PropImpl(newValue) }
     }
 
-    internal class IBaseOverrides : ComposableImpl {
+    internal struct IBaseOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
         internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        internal class Default : MakeComposedAbi {
-            internal typealias SwiftProjection = Derived
+        internal typealias SwiftProjection = Derived
+        internal struct Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIDerived
             internal typealias SwiftABI = __ABI_test_component.IDerived
         }
@@ -994,11 +994,11 @@ public final class DerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
         try _default.MethodImpl()
     }
 
-    internal class IBaseOverrides : ComposableImpl {
+    internal struct IBaseOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
         internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        internal class Default : MakeComposedAbi {
-            internal typealias SwiftProjection = DerivedFromNoConstructor
+        internal typealias SwiftProjection = DerivedFromNoConstructor
+        internal struct Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIDerivedFromNoConstructor
             internal typealias SwiftABI = __ABI_test_component.IDerivedFromNoConstructor
         }
@@ -1395,11 +1395,11 @@ open class UnsealedDerived : test_component.Base {
         try _IUnsealedDerivedOverloads2.OnAfterDoTheThingImpl()
     }
 
-    internal class IUnsealedDerivedOverloads2 : ComposableImpl {
+    internal struct IUnsealedDerivedOverloads2 : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
         internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
-        internal class Default : MakeComposedAbi {
-            internal typealias SwiftProjection = UnsealedDerived
+        internal typealias SwiftProjection = UnsealedDerived
+        internal struct Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerived
         }
@@ -1410,11 +1410,11 @@ open class UnsealedDerived : test_component.Base {
         try _IUnsealedDerivedOverrides.OnBeforeDoTheThingImpl()
     }
 
-    internal class IUnsealedDerivedOverrides : ComposableImpl {
+    internal struct IUnsealedDerivedOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverrides
         internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverrides
-        internal class Default : MakeComposedAbi {
-            internal typealias SwiftProjection = UnsealedDerived
+        internal typealias SwiftProjection = UnsealedDerived
+        internal struct Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerived
         }
@@ -1482,11 +1482,11 @@ open class UnsealedDerived2 : test_component.UnsealedDerived {
         try _default.MethodImpl()
     }
 
-    internal class IUnsealedDerivedOverloads2 : ComposableImpl {
+    internal struct IUnsealedDerivedOverloads2 : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
         internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
-        internal class Default : MakeComposedAbi {
-            internal typealias SwiftProjection = UnsealedDerived2
+        internal typealias SwiftProjection = UnsealedDerived2
+        internal struct Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived2
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerived2
         }
@@ -1543,11 +1543,11 @@ open class UnsealedDerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
         }
     }
 
-    internal class IBaseOverrides : ComposableImpl {
+    internal struct IBaseOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
         internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        internal class Default : MakeComposedAbi {
-            internal typealias SwiftProjection = UnsealedDerivedFromNoConstructor
+        internal typealias SwiftProjection = UnsealedDerivedFromNoConstructor
+        internal struct Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedFromNoConstructor
         }
@@ -1598,11 +1598,11 @@ open class UnsealedDerivedNoConstructor : test_component.Base {
     }
     private static var _IUnsealedDerivedNoConstructorFactory : __ABI_test_component.IUnsealedDerivedNoConstructorFactory =  try! RoGetActivationFactory(HString("test_component.UnsealedDerivedNoConstructor"))
 
-    internal class IBaseOverrides : ComposableImpl {
+    internal struct IBaseOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
         internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        internal class Default : MakeComposedAbi {
-            internal typealias SwiftProjection = UnsealedDerivedNoConstructor
+        internal typealias SwiftProjection = UnsealedDerivedNoConstructor
+        internal struct Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoConstructor
         }
@@ -1659,11 +1659,11 @@ open class UnsealedDerivedNoOverrides : test_component.BaseNoOverrides {
         }
     }
 
-    internal class IUnsealedDerivedNoOverrides : ComposableImpl {
+    internal struct IUnsealedDerivedNoOverrides : ComposableImpl {
         internal typealias CABI = C_IInspectable
         internal typealias SwiftABI = test_component.IInspectable
-        internal class Default : MakeComposedAbi {
-            internal typealias SwiftProjection = UnsealedDerivedNoOverrides
+        internal typealias SwiftProjection = UnsealedDerivedNoOverrides
+        internal struct Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoOverrides
         }

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -166,11 +166,11 @@ open class Base : WinRTClass {
         try _IBaseOverrides.OnDoTheThingImpl()
     }
 
-    internal struct IBaseOverrides : ComposableImpl {
+    internal enum IBaseOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
         internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
         internal typealias SwiftProjection = Base
-        internal struct Default : AbiInterface {
+        internal enum Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIBase
             internal typealias SwiftABI = __ABI_test_component.IBase
         }
@@ -418,11 +418,11 @@ open class BaseNoOverrides : WinRTClass {
         }
     }
 
-    internal struct IBaseNoOverrides : ComposableImpl {
+    internal enum IBaseNoOverrides : ComposableImpl {
         internal typealias CABI = C_IInspectable
         internal typealias SwiftABI = test_component.IInspectable
         internal typealias SwiftProjection = BaseNoOverrides
-        internal struct Default : AbiInterface {
+        internal enum Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIBaseNoOverrides
             internal typealias SwiftABI = __ABI_test_component.IBaseNoOverrides
         }
@@ -947,11 +947,11 @@ public final class Derived : test_component.Base {
         set { try! _default.put_PropImpl(newValue) }
     }
 
-    internal struct IBaseOverrides : ComposableImpl {
+    internal enum IBaseOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
         internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
         internal typealias SwiftProjection = Derived
-        internal struct Default : AbiInterface {
+        internal enum Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIDerived
             internal typealias SwiftABI = __ABI_test_component.IDerived
         }
@@ -994,11 +994,11 @@ public final class DerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
         try _default.MethodImpl()
     }
 
-    internal struct IBaseOverrides : ComposableImpl {
+    internal enum IBaseOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
         internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
         internal typealias SwiftProjection = DerivedFromNoConstructor
-        internal struct Default : AbiInterface {
+        internal enum Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIDerivedFromNoConstructor
             internal typealias SwiftABI = __ABI_test_component.IDerivedFromNoConstructor
         }
@@ -1395,11 +1395,11 @@ open class UnsealedDerived : test_component.Base {
         try _IUnsealedDerivedOverloads2.OnAfterDoTheThingImpl()
     }
 
-    internal struct IUnsealedDerivedOverloads2 : ComposableImpl {
+    internal enum IUnsealedDerivedOverloads2 : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
         internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
         internal typealias SwiftProjection = UnsealedDerived
-        internal struct Default : AbiInterface {
+        internal enum Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerived
         }
@@ -1410,11 +1410,11 @@ open class UnsealedDerived : test_component.Base {
         try _IUnsealedDerivedOverrides.OnBeforeDoTheThingImpl()
     }
 
-    internal struct IUnsealedDerivedOverrides : ComposableImpl {
+    internal enum IUnsealedDerivedOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverrides
         internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverrides
         internal typealias SwiftProjection = UnsealedDerived
-        internal struct Default : AbiInterface {
+        internal enum Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerived
         }
@@ -1482,11 +1482,11 @@ open class UnsealedDerived2 : test_component.UnsealedDerived {
         try _default.MethodImpl()
     }
 
-    internal struct IUnsealedDerivedOverloads2 : ComposableImpl {
+    internal enum IUnsealedDerivedOverloads2 : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
         internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
         internal typealias SwiftProjection = UnsealedDerived2
-        internal struct Default : AbiInterface {
+        internal enum Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived2
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerived2
         }
@@ -1543,11 +1543,11 @@ open class UnsealedDerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
         }
     }
 
-    internal struct IBaseOverrides : ComposableImpl {
+    internal enum IBaseOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
         internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
         internal typealias SwiftProjection = UnsealedDerivedFromNoConstructor
-        internal struct Default : AbiInterface {
+        internal enum Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedFromNoConstructor
         }
@@ -1598,11 +1598,11 @@ open class UnsealedDerivedNoConstructor : test_component.Base {
     }
     private static var _IUnsealedDerivedNoConstructorFactory : __ABI_test_component.IUnsealedDerivedNoConstructorFactory =  try! RoGetActivationFactory(HString("test_component.UnsealedDerivedNoConstructor"))
 
-    internal struct IBaseOverrides : ComposableImpl {
+    internal enum IBaseOverrides : ComposableImpl {
         internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
         internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
         internal typealias SwiftProjection = UnsealedDerivedNoConstructor
-        internal struct Default : AbiInterface {
+        internal enum Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoConstructor
         }
@@ -1659,11 +1659,11 @@ open class UnsealedDerivedNoOverrides : test_component.BaseNoOverrides {
         }
     }
 
-    internal struct IUnsealedDerivedNoOverrides : ComposableImpl {
+    internal enum IUnsealedDerivedNoOverrides : ComposableImpl {
         internal typealias CABI = C_IInspectable
         internal typealias SwiftABI = test_component.IInspectable
         internal typealias SwiftProjection = UnsealedDerivedNoOverrides
-        internal struct Default : AbiInterface {
+        internal enum Default : AbiInterface {
             internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides
             internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoOverrides
         }


### PR DESCRIPTION
we have different wrappers/bridge types which are used for wrapping/unwrapping pointers from the ABI. These are more "complex" scenarios, like:

1. projecting `IReference<T>` as `T?` in Swift
2. projecting/unwrapping composable classes
3. unwrapping interfaces
4. projecting `delegate` as function in Swift

Simple value type or non-composable classes are straightforward to return from the ABI.

Prior to this change, scenarios 1 and 2 used the same base `WinRTWrapperBase` but did other things slightly differently. The purpose of this change was two fold:
1. make all the wrappers derive from the same base wrapper class which uses the `AbiBridge` protocol for defining how the types are bridged. The main reason here is for follow up changes to fix ref count issues. this will let those changes be smaller and better scoped. plus this is just a general code improvement to the way things were done and was my initial intention with the design
2. reduce the amount of code generated by having a common `QueryInterface` implementation.

## Changes
1. Update `AbiBridge` to have the `static func from(abi: UnsafeMutablePointer<CABI>?) -> SwiftProjection?` class that's currently only on the `InterfaceWrapperBase`
2. Rename `WinRTWrapperBase2` to `WinRTAbiBridgeWrapper`
3. Update `ComposableImpl` to be an `ABIBridge`. This was mostly just moving the `SwiftProjection` to the outer type. I then have to provide the default `from` implementation which does what unwrapping composable classes does today.
4. Created `ReferenceWrapperBase` which handles the `QueryInterface` for `IPropertyValue` for these apis.
5. Remove custom `IPropertyValueWrapper`. I opted to keep the existing handwritten `IPropertyValueImpl` for sake of simplifying this change.

### End Results
The export count for Debug builds is **down** by 1K...yay! Release build size and export size is the same (file size is minimally smaller, like 50KB). My assumption here is there was already aggressive COMDAT folding which resulted in all of the `QueryInterface` implementations being folded into a single one anyways

### Tests
Ran arc locally and it works