### PR TITLE
fix unwrapping winrtweakreference

### DIFF
--- a/swiftwinrt/Resources/Support/Aggregation.swift
+++ b/swiftwinrt/Resources/Support/Aggregation.swift
@@ -40,6 +40,10 @@ extension WinRTClassWeakReference: CustomAddRef {
     }
 }
 
+extension WinRTClassWeakReference: AnyObjectWrapper {
+    var obj: AnyObject? { instance }
+}
+
 @_spi(WinRTInternal)
 public protocol ComposableImpl<Class> : AbiInterfaceBridge where SwiftABI: IInspectable, SwiftProjection: WinRTClassWeakReference<Class>  {
     associatedtype Class: WinRTClass
@@ -95,7 +99,7 @@ public class UnsealedWinRTClassWrapper<Composable: ComposableImpl> : WinRTAbiBri
         let abi = Composable.makeAbi()
         super.init(abi, Composable.SwiftProjection(impl))
     }
-    
+
     public static func unwrapFrom(base: ComPtr<Composable.Default.CABI>) -> Composable.Class? {
         let overrides: Composable.SwiftABI = try! base.queryInterface()
         if let weakRef = tryUnwrapFrom(abi: RawPointer(overrides)) { return weakRef.instance }

--- a/swiftwinrt/Resources/Support/IInspectable.swift
+++ b/swiftwinrt/Resources/Support/IInspectable.swift
@@ -39,6 +39,10 @@ open class IInspectable: IUnknown {
 //      internal typealias swift_overrides = SUPPORT_MODULE.IInspectable
 // }
 // internal typealias Composable = IBaseNoOverrides
+protocol AnyObjectWrapper {
+    var obj: AnyObject? { get }
+}
+
 public enum __ABI_ {
     public class AnyWrapper : WinRTWrapperBase<C_IInspectable, AnyObject> {
       public init?(_ swift: Any?) {
@@ -65,6 +69,7 @@ public enum __ABI_ {
       public static func unwrapFrom(abi: ComPtr<C_IInspectable>?) -> Any? {
         guard let abi = abi else { return nil }
         if let instance = tryUnwrapFrom(abi: abi) {
+          if let weakRef = instance as? AnyObjectWrapper { return weakRef.obj }
           return instance
         }
 

--- a/tests/test_app/AggregationTests.swift
+++ b/tests/test_app/AggregationTests.swift
@@ -131,6 +131,15 @@ class AggregationTests : XCTestCase {
     // calling it directly on the AppDerived type won't
     XCTAssertEqual(runtimeClassName(appDerived), "test_component.Base")
   }
+
+  public func testAggregatedObjectUnwrappedAsAny() throws {
+    let derived = AppDerived()
+    Class.takeBaseAndGiveToCallbackAsObject(derived) { sender in
+      let base = sender as? AppDerived
+      XCTAssertNotNil(derived)
+      XCTAssertIdentical(base, derived)
+    }
+  }
 }
 
 var aggregationTests: [XCTestCaseEntry] = [
@@ -147,5 +156,6 @@ var aggregationTests: [XCTestCaseEntry] = [
     ("testUnwrappingAppImplementedComposedFromDerivedNoOverrides", AggregationTests.testUnwrappingAppImplementedComposedFromDerivedNoOverrides),
     ("testCustomConstructorOnUnsealedType", AggregationTests.testCustomConstructorOnUnsealedType),
     ("testGetRuntimeClassNameReturnsBase", AggregationTests.testGetRuntimeClassNameReturnsBase),
+    ("testAggregatedObjectUnwrappedAsAny", AggregationTests.testAggregatedObjectUnwrappedAsAny),
   ])
 ]

--- a/tests/test_component/Sources/CWinRT/include/test_component.Delegates.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.Delegates.h
@@ -14,6 +14,12 @@ typedef interface __x_ABI_Ctest__component_CDelegates_CIInDelegate __x_ABI_Ctest
 
 #endif // ____x_ABI_Ctest__component_CDelegates_CIInDelegate_FWD_DEFINED__
 
+    #ifndef ____x_ABI_Ctest__component_CDelegates_CIInObjectDelegate_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CDelegates_CIInObjectDelegate_FWD_DEFINED__
+typedef interface __x_ABI_Ctest__component_CDelegates_CIInObjectDelegate __x_ABI_Ctest__component_CDelegates_CIInObjectDelegate;
+
+#endif // ____x_ABI_Ctest__component_CDelegates_CIInObjectDelegate_FWD_DEFINED__
+
     #ifndef ____x_ABI_Ctest__component_CDelegates_CIOutInt32Delegate_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CDelegates_CIOutInt32Delegate_FWD_DEFINED__
 typedef interface __x_ABI_Ctest__component_CDelegates_CIOutInt32Delegate __x_ABI_Ctest__component_CDelegates_CIOutInt32Delegate;
@@ -73,6 +79,32 @@ typedef interface __x_ABI_Ctest__component_CDelegates_CISignalDelegate __x_ABI_C
     
     EXTERN_C const IID IID___x_ABI_Ctest__component_CDelegates_CIInDelegate;
     #endif /* !defined(____x_ABI_Ctest__component_CDelegates_CIInDelegate_INTERFACE_DEFINED__) */
+    
+#if !defined(____x_ABI_Ctest__component_CDelegates_CIInObjectDelegate_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CDelegates_CIInObjectDelegate_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CDelegates_CIInObjectDelegateVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CDelegates_CIInObjectDelegate* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CDelegates_CIInObjectDelegate* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CDelegates_CIInObjectDelegate* This);
+        HRESULT (STDMETHODCALLTYPE* Invoke)(__x_ABI_Ctest__component_CDelegates_CIInObjectDelegate* This,
+        IInspectable* value);
+
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CDelegates_CIInObjectDelegateVtbl;
+
+    interface __x_ABI_Ctest__component_CDelegates_CIInObjectDelegate
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CDelegates_CIInObjectDelegateVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CDelegates_CIInObjectDelegate;
+    #endif /* !defined(____x_ABI_Ctest__component_CDelegates_CIInObjectDelegate_INTERFACE_DEFINED__) */
     
 #if !defined(____x_ABI_Ctest__component_CDelegates_CIOutInt32Delegate_INTERFACE_DEFINED__)
     #define ____x_ABI_Ctest__component_CDelegates_CIOutInt32Delegate_INTERFACE_DEFINED__

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -2147,6 +2147,12 @@ typedef interface __x_ABI_Ctest__component_CDelegates_CIInDelegate __x_ABI_Ctest
 
 #endif // ____x_ABI_Ctest__component_CDelegates_CIInDelegate_FWD_DEFINED__
 
+    #ifndef ____x_ABI_Ctest__component_CDelegates_CIInObjectDelegate_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CDelegates_CIInObjectDelegate_FWD_DEFINED__
+typedef interface __x_ABI_Ctest__component_CDelegates_CIInObjectDelegate __x_ABI_Ctest__component_CDelegates_CIInObjectDelegate;
+
+#endif // ____x_ABI_Ctest__component_CDelegates_CIInObjectDelegate_FWD_DEFINED__
+
     #ifndef ____x_ABI_Ctest__component_CDelegates_CIReturnInt32Delegate_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CDelegates_CIReturnInt32Delegate_FWD_DEFINED__
 typedef interface __x_ABI_Ctest__component_CDelegates_CIReturnInt32Delegate __x_ABI_Ctest__component_CDelegates_CIReturnInt32Delegate;
@@ -2871,6 +2877,9 @@ struct __x_ABI_Ctest__component_CStructWithEnum
         INT32* result);
     HRESULT (STDMETHODCALLTYPE* get_StaticProperty)(__x_ABI_Ctest__component_CIClassStatics* This,
         INT32* value);
+    HRESULT (STDMETHODCALLTYPE* TakeBaseAndGiveToCallbackAsObject)(__x_ABI_Ctest__component_CIClassStatics* This,
+        __x_ABI_Ctest__component_CIBase* base,
+        __x_ABI_Ctest__component_CDelegates_CIInObjectDelegate* callback);
 
         END_INTERFACE
     } __x_ABI_Ctest__component_CIClassStaticsVtbl;

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -51,7 +51,7 @@ private var IID___x_ABI_Ctest__component_CIClassFactory2: test_component.IID {
 }
 
 private var IID___x_ABI_Ctest__component_CIClassStatics: test_component.IID {
-    .init(Data1: 0x2E573677, Data2: 0xD7B8, Data3: 0x5305, Data4: ( 0x8F,0x9D,0x1B,0x23,0x15,0xE3,0x77,0x8B ))// 2E573677-D7B8-5305-8F9D-1B2315E3778B
+    .init(Data1: 0x3E30803C, Data2: 0x35D4, Data3: 0x52A7, Data4: ( 0xB2,0x11,0xFD,0xC5,0xD6,0xAC,0x48,0x7B ))// 3E30803C-35D4-52A7-B211-FDC5D6AC487B
 }
 
 private var IID___x_ABI_Ctest__component_CIClassStatics2: test_component.IID {
@@ -871,6 +871,14 @@ public enum __ABI_test_component {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StaticProperty(pThis, &value))
             }
             return value
+        }
+
+        internal func TakeBaseAndGiveToCallbackAsObjectImpl(_ base: test_component.Base?, _ callback: test_component.InObjectDelegate?) throws {
+            let callbackWrapper = __ABI_test_component_Delegates.InObjectDelegateWrapper(callback)
+            let _callback = try! callbackWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.TakeBaseAndGiveToCallbackAsObject(pThis, RawPointer(base), _callback))
+            }
         }
 
     }

--- a/tests/test_component/Sources/test_component/test_component.Delegates+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+ABI.swift
@@ -6,6 +6,10 @@ private var IID___x_ABI_Ctest__component_CDelegates_CIInDelegate: test_component
     .init(Data1: 0x419EF389, Data2: 0xAF4B, Data3: 0x5676, Data4: ( 0xBC,0xEE,0xE0,0xD7,0x9A,0x5C,0xCA,0xDE ))// 419EF389-AF4B-5676-BCEE-E0D79A5CCADE
 }
 
+private var IID___x_ABI_Ctest__component_CDelegates_CIInObjectDelegate: test_component.IID {
+    .init(Data1: 0x68F889F8, Data2: 0x1A16, Data3: 0x5F6D, Data4: ( 0x8A,0x04,0x24,0x58,0x38,0xEA,0xF3,0xD4 ))// 68F889F8-1A16-5F6D-8A04-245838EAF3D4
+}
+
 private var IID___x_ABI_Ctest__component_CDelegates_CIReturnInt32Delegate: test_component.IID {
     .init(Data1: 0xBCB57CF7, Data2: 0x97F9, Data3: 0x5B38, Data4: ( 0x99,0x47,0x39,0xC5,0x14,0x92,0x20,0xF0 ))// BCB57CF7-97F9-5B38-9947-39C5149220F0
 }
@@ -47,6 +51,42 @@ extension __ABI_test_component_Delegates {
 public extension WinRTDelegateBridge where CABI == __x_ABI_Ctest__component_CDelegates_CIInDelegate {
     static func makeAbi() -> CABI {
         let vtblPtr = withUnsafeMutablePointer(to: &__ABI_test_component_Delegates.InDelegateVTable) { $0 }
+        return .init(lpVtbl:vtblPtr)
+    }
+}
+
+// MARK - InObjectDelegate
+extension __ABI_test_component_Delegates {
+    public class InObjectDelegate: test_component.IUnknown {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CDelegates_CIInObjectDelegate }
+
+        open func InvokeImpl(_ value: Any?) throws {
+            let valueWrapper = __ABI_.AnyWrapper(value)
+            let _value = try! valueWrapper?.toABI { $0 }
+            _ = try perform(as: __x_ABI_Ctest__component_CDelegates_CIInObjectDelegate.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, _value))
+            }
+        }
+
+    }
+
+
+    typealias InObjectDelegateWrapper = InterfaceWrapperBase<__IMPL_test_component_Delegates.InObjectDelegateBridge>
+    internal static var InObjectDelegateVTable: __x_ABI_Ctest__component_CDelegates_CIInObjectDelegateVtbl = .init(
+        QueryInterface: { InObjectDelegateWrapper.queryInterface($0, $1, $2) },
+        AddRef: { InObjectDelegateWrapper.addRef($0) },
+        Release: { InObjectDelegateWrapper.release($0) },
+        Invoke: {
+            guard let __unwrapped__instance = InObjectDelegateWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+            let value: Any? = __ABI_.AnyWrapper.unwrapFrom(abi: ComPtr($1))
+            __unwrapped__instance(value)
+            return S_OK
+        }
+    )
+}
+public extension WinRTDelegateBridge where CABI == __x_ABI_Ctest__component_CDelegates_CIInObjectDelegate {
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &__ABI_test_component_Delegates.InObjectDelegateVTable) { $0 }
         return .init(lpVtbl:vtblPtr)
     }
 }

--- a/tests/test_component/Sources/test_component/test_component.Delegates+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+Impl.swift
@@ -17,6 +17,20 @@ public enum __IMPL_test_component_Delegates {
             return handler
         }
     }
+    public class InObjectDelegateBridge : WinRTDelegateBridge {
+        public typealias Handler = InObjectDelegate
+        public typealias CABI = __x_ABI_Ctest__component_CDelegates_CIInObjectDelegate
+        public typealias SwiftABI = __ABI_test_component_Delegates.InObjectDelegate
+
+        public static func from(abi: ComPtr<CABI>?) -> Handler? {
+            guard let abi = abi else { return nil }
+            let _default = SwiftABI(abi)
+            let handler: Handler = { (value) in
+                try! _default.InvokeImpl(value)
+            }
+            return handler
+        }
+    }
     public class ReturnInt32DelegateBridge : WinRTDelegateBridge {
         public typealias Handler = ReturnInt32Delegate
         public typealias CABI = __x_ABI_Ctest__component_CDelegates_CIReturnInt32Delegate

--- a/tests/test_component/Sources/test_component/test_component.Delegates.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates.swift
@@ -3,5 +3,6 @@
 import Ctest_component
 
 public typealias InDelegate = (String) -> ()
+public typealias InObjectDelegate = (Any?) -> ()
 public typealias ReturnInt32Delegate = () -> Int32
 public typealias SignalDelegate = () -> ()

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -598,6 +598,10 @@ public final class Class : WinRTClass, IBasic {
         return try! _IClassStatics.StaticTestReturnImpl()
     }
 
+    public static func takeBaseAndGiveToCallbackAsObject(_ base: Base!, _ callback: test_component.InObjectDelegate!) {
+        try! _IClassStatics.TakeBaseAndGiveToCallbackAsObjectImpl(base, callback)
+    }
+
     public static var staticProperty : Int32 {
         get { try! _IClassStatics.get_StaticPropertyImpl() }
     }

--- a/tests/test_component/cpp/Class.h
+++ b/tests/test_component/cpp/Class.h
@@ -129,7 +129,7 @@ namespace winrt::test_component::implementation
 
         Fruit EnumProperty() const;
         void EnumProperty(Fruit const& value);
-        
+
         void NoexceptVoid() noexcept;
         int32_t NoexceptInt32() noexcept;
         hstring NoexceptString() noexcept;
@@ -175,7 +175,7 @@ namespace winrt::test_component::implementation
 
         test_component::IBasic Implementation()
         {
-            return m_basicImpl != nullptr ? m_basicImpl : make<BasicDelegate>(); 
+            return m_basicImpl != nullptr ? m_basicImpl : make<BasicDelegate>();
         }
         void Implementation(test_component::IBasic const& value)
         {
@@ -190,7 +190,7 @@ namespace winrt::test_component::implementation
         }
 
         Windows::Foundation::IReference<int32_t> StartValue() { return m_startValue; }
-        void StartValue(Windows::Foundation::IReference<int32_t> const& value) { 
+        void StartValue(Windows::Foundation::IReference<int32_t> const& value) {
             m_startValue = value;
             if (m_startValue)
             {
@@ -210,6 +210,7 @@ namespace winrt::test_component::implementation
         test_component::BaseNoOverrides BaseNoOverridesProperty() { return m_baseNoOverrides; }
         void BaseNoOverridesProperty(test_component::BaseNoOverrides const& value) { m_baseNoOverrides = value; }
 
+        static void TakeBaseAndGiveToCallbackAsObject(test_component::Base const& base, test_component::Delegates::InObjectDelegate const& callback) { callback(base);}
     private:
         static float s_float;
         bool m_fail{};
@@ -236,7 +237,7 @@ namespace winrt::test_component::implementation
         test_component::BaseNoOverrides m_baseNoOverrides { nullptr };
     };
 
-    
+
     struct DeferrableEventArgs : DeferrableEventArgsT<DeferrableEventArgs>, deferrable_event_args<DeferrableEventArgs>
     {
         DeferrableEventArgs() = default;

--- a/tests/test_component/cpp/test_component.idl
+++ b/tests/test_component/cpp/test_component.idl
@@ -65,6 +65,7 @@ namespace test_component
             delegate Int32 ReturnInt32Delegate();
             delegate void OutStringDelegate(out String value);
             delegate void OutInt32Delegate(out Int32 value);
+            delegate void InObjectDelegate(Object value);
             //  delegate String[] ReturnStringArrayDelegate();
             //  delegate void OutStringArrayDelegate(out String[] value);
             //  delegate void RefStringArrayDelegate(ref String[] value);
@@ -298,6 +299,7 @@ namespace test_component
 
             Base BaseProperty;
             BaseNoOverrides BaseNoOverridesProperty;
+            static void TakeBaseAndGiveToCallbackAsObject(Base base, test_component.Delegates.InObjectDelegate callback);
         }
 
         static runtimeclass StaticClass
@@ -307,7 +309,6 @@ namespace test_component
             static String InNonBlittableStruct(NonBlittableStruct value);
 
             static void TakeBase(Base base);
-
         }
         //namespace Structs
         //


### PR DESCRIPTION
with fixing memory leaks and adding the `WinRTClassWeakReference` class, this caused a regression in unwrapping them as `Any` where we'd simply return the `WinRTClassWeakReference` type. This manifested in Arc for event handlers, where the sender parameter is `Any`. When unwrapping `Any` objects, we should check for the type being one of these and return the object its holding instead

## Changes
1. Add `AnyObjectWrapper` protocol and check for this in the `__ABI.AnyWrapper` when unwrapping objects
2. Add conformance of `AnyObjectWrapper` to `WinRTClassWeakReference`. 
3. Added tests case

Fixes WPP-795