### PR TITLE
fix writing composable impl for generic default interfaces

### DIFF
--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -402,7 +402,7 @@ namespace swiftwinrt
                 auto full_names = w.push_full_type_names(true);
 
                 auto returnStatement = isInitializer ?
-                    w.write_temp(" -> %", bind_type_abi(classType)) :
+                    w.write_temp(" -> %", bind_type_abi(classType->default_interface)) :
                     w.write_temp("%", bind<write_return_type_declaration>(function, write_type_params::swift));
 
                 std::vector<function_param> params = composableFactory ? get_projected_params(factory_info.value(), function) : function.params;
@@ -455,6 +455,7 @@ bind<write_abi_args>(function));
                         w.write("}\n");
                     }
 
+                    
                     if (function.return_type && !isInitializer)
                     {
                         w.write("%\n", bind<write_consume_return_statement>(function));

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -2166,42 +2166,51 @@ public init<Composable: ComposableImpl>(
     internal typealias SwiftProjection = WinRTClassWeakReference<Class>
     internal enum Default : AbiInterface {
         internal typealias CABI = %
-        internal typealias SwiftABI = %.%
+        internal typealias SwiftABI = %
     }
 }
 )";
 
+        auto composableName = w.write_temp("%", bind_type_abi(overrides));
         // If we're composing a type without any overrides, then we'll just create an IInspectable vtable which wraps
         // this object and provides facilities for reference counting and getting the class name of the swift object.
         w.write(format,
-            overrides.swift_type_name(),
+            composableName,
             bind([&](writer& w) {
-                    if (use_iinspectable_vtable)
-                    {
-                        write_type_mangled(w, ElementType::Object);
-                    }
-                    else
-                    {
-                        write_type_mangled(w, overrides);
-                    }}),
+                if (use_iinspectable_vtable)
+                {
+                    write_type_mangled(w, ElementType::Object);
+                }
+                else
+                {
+                    write_type_mangled(w, overrides);
+                }}),
             bind([&](writer& w) {
-                    if (use_iinspectable_vtable)
-                    {
-                        w.write("%.IInspectable", w.support);
-                    }
-                    else
-                    {
-                        w.write("%.%", abi_namespace(overrides), overrides.swift_type_name());
-                    }}),
+                if (use_iinspectable_vtable)
+                {
+                    w.write("%.IInspectable", w.support);
+                }
+                else
+                {
+                    w.write("%.%", abi_namespace(overrides), composableName);
+                }}),
             parent,
             bind_type_mangled(default_interface),
-            abi_namespace(parent),
-            default_interface);
+            bind([&](writer& w) {
+                if (is_generic_inst(overrides))
+                {
+                    w.write("%.%", w.swift_module, composableName);
+                }
+                else
+                {
+                    w.write("%.%", abi_namespace(parent), default_interface);
+                }
+            }));
 
         if (compose)
         {
             auto modifier = parent.is_composable() ? "open" : "public";
-            w.write("internal typealias Composable = %\n", overrides.swift_type_name());
+            w.write("internal typealias Composable = %\n", composableName);
         }
     }
 
@@ -2317,7 +2326,7 @@ public init<Composable: ComposableImpl>(
             {
                 auto generic_type = dynamic_cast<const generic_inst*>(default_interface);
                 guard = w.push_generic_params(*generic_type);
-                swiftAbi = w.write_temp("%", bind_type_abi(generic_type));
+                swiftAbi = w.write_temp("%.%", w.swift_module, bind_type_abi(generic_type));
             }
 
             auto modifier = composable ? "open" : "public";

--- a/swiftwinrt/type_writers.h
+++ b/swiftwinrt/type_writers.h
@@ -497,10 +497,18 @@ namespace swiftwinrt
                     }
                 }
             }
-            // In generics, don't use the ABI name or we get IVectorIBase instead of IVectorBase
-            else if (abi_types && !writing_generic)
+            else if (abi_types)
             {
-                write(type->cpp_abi_name());
+                // In generics, don't use the ABI name or we get IVectorIBase instead of IVectorBase
+                if (!writing_generic)
+                {
+                    write(type->cpp_abi_name());
+                }
+                else
+                {
+                    // Otherwise, write the swift type name when writing a swift abi generic type
+                    write(type->swift_type_name());
+                }
             }
             else if (type->swift_logical_namespace() != type_namespace || full_type_names)
             {

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -47,11 +47,11 @@ typedef interface __x_ABI_Ctest__component_CIVoidToVoidDelegate __x_ABI_Ctest__c
 
 #endif // ____x_ABI_Ctest__component_CIBase_FWD_DEFINED__
 
-#ifndef ____x_ABI_Ctest__component_CIBaseCollectionFactory_FWD_DEFINED__
-#define ____x_ABI_Ctest__component_CIBaseCollectionFactory_FWD_DEFINED__
-    typedef interface __x_ABI_Ctest__component_CIBaseCollectionFactory __x_ABI_Ctest__component_CIBaseCollectionFactory;
+#ifndef ____x_ABI_Ctest__component_CIBaseCollectionProtectedFactory_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CIBaseCollectionProtectedFactory_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CIBaseCollectionProtectedFactory __x_ABI_Ctest__component_CIBaseCollectionProtectedFactory;
 
-#endif // ____x_ABI_Ctest__component_CIBaseCollectionFactory_FWD_DEFINED__
+#endif // ____x_ABI_Ctest__component_CIBaseCollectionProtectedFactory_FWD_DEFINED__
 
 #ifndef ____x_ABI_Ctest__component_CIBaseNoOverrides_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CIBaseNoOverrides_FWD_DEFINED__
@@ -2479,36 +2479,40 @@ struct __x_ABI_Ctest__component_CStructWithEnum
     EXTERN_C const IID IID___x_ABI_Ctest__component_CIBase;
 #endif /* !defined(____x_ABI_Ctest__component_CIBase_INTERFACE_DEFINED__) */
     
-#if !defined(____x_ABI_Ctest__component_CIBaseCollectionFactory_INTERFACE_DEFINED__)
-    #define ____x_ABI_Ctest__component_CIBaseCollectionFactory_INTERFACE_DEFINED__
-    typedef struct __x_ABI_Ctest__component_CIBaseCollectionFactoryVtbl
+#if !defined(____x_ABI_Ctest__component_CIBaseCollectionProtectedFactory_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CIBaseCollectionProtectedFactory_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CIBaseCollectionProtectedFactoryVtbl
     {
         BEGIN_INTERFACE
 
-        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This,
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIBaseCollectionProtectedFactory* This,
             REFIID riid,
             void** ppvObject);
-        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This);
-        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This);
-        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This,
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIBaseCollectionProtectedFactory* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIBaseCollectionProtectedFactory* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIBaseCollectionProtectedFactory* This,
             ULONG* iidCount,
             IID** iids);
-        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This,
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIBaseCollectionProtectedFactory* This,
             HSTRING* className);
-        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This,
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIBaseCollectionProtectedFactory* This,
             TrustLevel* trustLevel);
-    
-        END_INTERFACE
-    } __x_ABI_Ctest__component_CIBaseCollectionFactoryVtbl;
+        HRESULT (STDMETHODCALLTYPE* CreateInstance)(__x_ABI_Ctest__component_CIBaseCollectionProtectedFactory* This,
+        IInspectable* baseInterface,
+        IInspectable** innerInterface,
+        __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase** value);
 
-    interface __x_ABI_Ctest__component_CIBaseCollectionFactory
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CIBaseCollectionProtectedFactoryVtbl;
+
+    interface __x_ABI_Ctest__component_CIBaseCollectionProtectedFactory
     {
-        CONST_VTBL struct __x_ABI_Ctest__component_CIBaseCollectionFactoryVtbl* lpVtbl;
+        CONST_VTBL struct __x_ABI_Ctest__component_CIBaseCollectionProtectedFactoryVtbl* lpVtbl;
     };
 
     
-    EXTERN_C const IID IID___x_ABI_Ctest__component_CIBaseCollectionFactory;
-#endif /* !defined(____x_ABI_Ctest__component_CIBaseCollectionFactory_INTERFACE_DEFINED__) */
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CIBaseCollectionProtectedFactory;
+#endif /* !defined(____x_ABI_Ctest__component_CIBaseCollectionProtectedFactory_INTERFACE_DEFINED__) */
     
 #if !defined(____x_ABI_Ctest__component_CIBaseNoOverrides_INTERFACE_DEFINED__)
     #define ____x_ABI_Ctest__component_CIBaseNoOverrides_INTERFACE_DEFINED__

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -47,6 +47,12 @@ typedef interface __x_ABI_Ctest__component_CIVoidToVoidDelegate __x_ABI_Ctest__c
 
 #endif // ____x_ABI_Ctest__component_CIBase_FWD_DEFINED__
 
+#ifndef ____x_ABI_Ctest__component_CIBaseCollectionFactory_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CIBaseCollectionFactory_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CIBaseCollectionFactory __x_ABI_Ctest__component_CIBaseCollectionFactory;
+
+#endif // ____x_ABI_Ctest__component_CIBaseCollectionFactory_FWD_DEFINED__
+
 #ifndef ____x_ABI_Ctest__component_CIBaseNoOverrides_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CIBaseNoOverrides_FWD_DEFINED__
     typedef interface __x_ABI_Ctest__component_CIBaseNoOverrides __x_ABI_Ctest__component_CIBaseNoOverrides;
@@ -2472,6 +2478,37 @@ struct __x_ABI_Ctest__component_CStructWithEnum
     
     EXTERN_C const IID IID___x_ABI_Ctest__component_CIBase;
 #endif /* !defined(____x_ABI_Ctest__component_CIBase_INTERFACE_DEFINED__) */
+    
+#if !defined(____x_ABI_Ctest__component_CIBaseCollectionFactory_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CIBaseCollectionFactory_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CIBaseCollectionFactoryVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIBaseCollectionFactory* This,
+            TrustLevel* trustLevel);
+    
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CIBaseCollectionFactoryVtbl;
+
+    interface __x_ABI_Ctest__component_CIBaseCollectionFactory
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CIBaseCollectionFactoryVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CIBaseCollectionFactory;
+#endif /* !defined(____x_ABI_Ctest__component_CIBaseCollectionFactory_INTERFACE_DEFINED__) */
     
 #if !defined(____x_ABI_Ctest__component_CIBaseNoOverrides_INTERFACE_DEFINED__)
     #define ____x_ABI_Ctest__component_CIBaseNoOverrides_INTERFACE_DEFINED__

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
@@ -107,7 +107,7 @@ public final class StringMap : WinRTClass, IMap, IIterable, IObservableMap {
     public typealias K = String
     public typealias V = String
     public typealias T = AnyIKeyValuePair<String, String>?
-    private typealias SwiftABI = IMapString_String
+    private typealias SwiftABI = test_component.IMapString_String
     private typealias CABI = __x_ABI_C__FIMap_2_HSTRING_HSTRING
     private lazy var _default: SwiftABI! = getInterfaceForCaching()
     @_spi(WinRTInternal)

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -18,6 +18,10 @@ private var IID___x_ABI_Ctest__component_CIBase: test_component.IID {
     .init(Data1: 0xE9FE0BB2, Data2: 0xE1F6, Data3: 0x5E39, Data4: ( 0x92,0xBB,0x2F,0x19,0xFF,0xDE,0x3F,0xDC ))// E9FE0BB2-E1F6-5E39-92BB-2F19FFDE3FDC
 }
 
+private var IID___x_ABI_Ctest__component_CIBaseCollectionFactory: test_component.IID {
+    .init(Data1: 0xD6996627, Data2: 0x615A, Data3: 0x565D, Data4: ( 0x85,0xF2,0x04,0x69,0x6E,0xD2,0x88,0xD0 ))// D6996627-615A-565D-85F2-04696ED288D0
+}
+
 private var IID___x_ABI_Ctest__component_CIBaseNoOverrides: test_component.IID {
     .init(Data1: 0xCAC21C05, Data2: 0xB599, Data3: 0x5D37, Data4: ( 0xA9,0x3A,0xD6,0x0C,0xBD,0xD1,0xD0,0xE8 ))// CAC21C05-B599-5D37-A93A-D60CBDD1D0E8
 }
@@ -347,6 +351,11 @@ public enum __ABI_test_component {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.DoTheThing(pThis))
             }
         }
+
+    }
+
+    public class IBaseCollectionFactory: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseCollectionFactory }
 
     }
 

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -18,8 +18,8 @@ private var IID___x_ABI_Ctest__component_CIBase: test_component.IID {
     .init(Data1: 0xE9FE0BB2, Data2: 0xE1F6, Data3: 0x5E39, Data4: ( 0x92,0xBB,0x2F,0x19,0xFF,0xDE,0x3F,0xDC ))// E9FE0BB2-E1F6-5E39-92BB-2F19FFDE3FDC
 }
 
-private var IID___x_ABI_Ctest__component_CIBaseCollectionFactory: test_component.IID {
-    .init(Data1: 0xD6996627, Data2: 0x615A, Data3: 0x565D, Data4: ( 0x85,0xF2,0x04,0x69,0x6E,0xD2,0x88,0xD0 ))// D6996627-615A-565D-85F2-04696ED288D0
+private var IID___x_ABI_Ctest__component_CIBaseCollectionProtectedFactory: test_component.IID {
+    .init(Data1: 0xB5581456, Data2: 0xA980, Data3: 0x5851, Data4: ( 0xAD,0xA4,0x0A,0x7B,0x27,0x0F,0x6C,0xD9 ))// B5581456-A980-5851-ADA4-0A7B270F6CD9
 }
 
 private var IID___x_ABI_Ctest__component_CIBaseNoOverrides: test_component.IID {
@@ -354,8 +354,21 @@ public enum __ABI_test_component {
 
     }
 
-    public class IBaseCollectionFactory: test_component.IInspectable {
-        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseCollectionFactory }
+    public class IBaseCollectionProtectedFactory: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseCollectionProtectedFactory }
+
+        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.BaseCollection.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IVectorBase {
+            let (value) = try ComPtrs.initialize { valueAbi in
+                let _baseInterface = baseInterface?.toIInspectableABI { $0 }
+                let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
+                    _ = try perform(as: __x_ABI_Ctest__component_CIBaseCollectionProtectedFactory.self) { pThis in
+                        try CHECKED(pThis.pointee.lpVtbl.pointee.CreateInstance(pThis, _baseInterface, &_innerInterfaceAbi, &valueAbi))
+                    }
+                }
+                innerInterface = test_component.IInspectable(_innerInterface!)
+            }
+            return IVectorBase(value!)
+        }
 
     }
 

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -170,13 +170,13 @@ open class Base : WinRTClass {
     }
 }
 
-public final class BaseCollection : WinRTClass, IVector, IIterable {
+open class BaseCollection : WinRTClass, IVector, IIterable {
     public typealias T = Base?
-    private typealias SwiftABI = IVectorBase
+    private typealias SwiftABI = test_component.IVectorBase
     private typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase
     private lazy var _default: SwiftABI! = getInterfaceForCaching()
     @_spi(WinRTInternal)
-    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+    override open func _getABI<T>() -> UnsafeMutablePointer<T>? {
         if T.self == CABI.self {
             return RawPointer(_default)
         }
@@ -186,7 +186,7 @@ public final class BaseCollection : WinRTClass, IVector, IIterable {
     @_spi(WinRTInternal)
     public static func from(abi: ComPtr<__x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase>?) -> BaseCollection? {
         guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
+        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
     }
 
     @_spi(WinRTInternal)
@@ -194,9 +194,19 @@ public final class BaseCollection : WinRTClass, IVector, IIterable {
         super.init(fromAbi)
     }
 
-    override public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? {
+    @_spi(WinRTInternal)
+    public init<Composable: ComposableImpl>(
+        composing: Composable.Type,
+        _ createCallback: (UnsealedWinRTClassWrapper<Composable>?, inout test_component.IInspectable?) -> Composable.Default.SwiftABI)
+    {
+        super.init()
+        MakeComposed(composing: composing, (self as! Composable.Class), createCallback)
+    }
+    override open func queryInterface(_ iid: test_component.IID) -> IUnknownRef? {
         return super.queryInterface(iid)
     }
+    private static var _IBaseCollectionFactory : __ABI_test_component.IBaseCollectionFactory =  try! RoGetActivationFactory(HString("test_component.BaseCollection"))
+
     // MARK: Collection
     public typealias Element = T
     public var startIndex: Int { 0 }
@@ -273,6 +283,17 @@ public final class BaseCollection : WinRTClass, IVector, IIterable {
         try! _IIterable.FirstImpl()
     }
 
+    internal enum IVectorBase : ComposableImpl {
+        internal typealias CABI = C_IInspectable
+        internal typealias SwiftABI = test_component.IInspectable
+        internal typealias Class = BaseCollection
+        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
+        internal enum Default : AbiInterface {
+            internal typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase
+            internal typealias SwiftABI = test_component.IVectorBase
+        }
+    }
+    internal typealias Composable = IVectorBase
     deinit {
         _default = nil
         _IIterable = nil
@@ -283,7 +304,7 @@ public final class BaseMapCollection : WinRTClass, IMap, IIterable {
     public typealias K = String
     public typealias V = Base?
     public typealias T = AnyIKeyValuePair<String, Base?>?
-    private typealias SwiftABI = IMapString_Base
+    private typealias SwiftABI = test_component.IMapString_Base
     private typealias CABI = __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
     private lazy var _default: SwiftABI! = getInterfaceForCaching()
     @_spi(WinRTInternal)
@@ -408,7 +429,7 @@ open class BaseNoOverrides : WinRTClass {
 
 public final class BaseObservableCollection : WinRTClass, IObservableVector, IVector, IIterable {
     public typealias T = Base?
-    private typealias SwiftABI = IObservableVectorBase
+    private typealias SwiftABI = test_component.IObservableVectorBase
     private typealias CABI = __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase
     private lazy var _default: SwiftABI! = getInterfaceForCaching()
     @_spi(WinRTInternal)

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -205,7 +205,14 @@ open class BaseCollection : WinRTClass, IVector, IIterable {
     override open func queryInterface(_ iid: test_component.IID) -> IUnknownRef? {
         return super.queryInterface(iid)
     }
-    private static var _IBaseCollectionFactory : __ABI_test_component.IBaseCollectionFactory =  try! RoGetActivationFactory(HString("test_component.BaseCollection"))
+    private static var _IBaseCollectionProtectedFactory : __ABI_test_component.IBaseCollectionProtectedFactory =  try! RoGetActivationFactory(HString("test_component.BaseCollection"))
+
+    override public init() {
+        super.init()
+        MakeComposed(composing: Self.Composable.self, self) { baseInterface, innerInterface in 
+            try! Self._IBaseCollectionProtectedFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+        }
+    }
 
     // MARK: Collection
     public typealias Element = T

--- a/tests/test_component/cpp/BaseCollection.h
+++ b/tests/test_component/cpp/BaseCollection.h
@@ -22,3 +22,11 @@ namespace winrt::test_component::implementation
         void ReplaceAll(array_view<test_component::Base const> items);
     };
 }
+
+
+namespace winrt::test_component::factory_implementation
+{
+    struct BaseCollection : BaseCollectionT<BaseCollection, implementation::BaseCollection>
+    {
+    };
+}

--- a/tests/test_component/cpp/test_component.idl
+++ b/tests/test_component/cpp/test_component.idl
@@ -443,8 +443,10 @@ namespace test_component
         }
 
 
+        // unsealed to verify composable type names for generic default interfaces
         unsealed runtimeclass BaseCollection : [default] IVector<Base>
         {
+            protected BaseCollection();
         }
 
         runtimeclass BaseMapCollection : [default] IMap<String, Base>

--- a/tests/test_component/cpp/test_component.idl
+++ b/tests/test_component/cpp/test_component.idl
@@ -443,7 +443,7 @@ namespace test_component
         }
 
 
-        runtimeclass BaseCollection : [default] IVector<Base>
+        unsealed runtimeclass BaseCollection : [default] IVector<Base>
         {
         }
 


### PR DESCRIPTION
for composable classes with generic default interfaces, we were incorrectly writing type names like `IVector<Foo>`, which aren't valid swift type names. This uses the same `bind_type_abi` method we use for removing the brackets and writing a name like `IVectorFoo` instead.

This error didn't manifest itself until trying to use the `ThemeShadow` class which resulted in `UIWeakElementCollection` being generated, which is unsealed.

## Changes
1. description above
2. Had to change `typealias SwiftABI = IVectorFoo` to the full name since there is a naming collision now
3. updated one of the class definitions to be unsealed to verify the fix works

Fixes WIN-1015