### PR TITLE
Print exceptions even when logging to a file

### DIFF
--- a/swiftwinrt/main.cpp
+++ b/swiftwinrt/main.cpp
@@ -447,6 +447,12 @@ Where <spec> is one or more of:
         catch (std::exception const& e)
         {
             w.write("swiftwinrt : error %\n", e.what());
+            if (settings.log && !log_file.empty())
+            {
+                // We're logging the error to a log file,
+                // but also print it to simplify diagnosing build errors.
+                fprintf(stderr, "error: %s", e.what());
+            }
             result = 1;
         }
 


### PR DESCRIPTION
Currently failures look like the below and are hard to diagnose:

```
[cmake] -- changes to swiftwinrt.exe parameters detected
[cmake] -- running swiftwinrt.exe @SwiftWinRT.rsp
[cmake] CMake Error at SwiftWinRT.cmake:84 (execute_process):
[cmake]   execute_process failed command indexes:
[cmake] 
[cmake]     1: "Child return code: 1"
[cmake] 
[cmake] -- Configuring incomplete, errors occurred!