### PR TITLE
fix ireference usage in structs

### DIFF
--- a/swiftwinrt/code_writers/struct_writers.cpp
+++ b/swiftwinrt/code_writers/struct_writers.cpp
@@ -5,7 +5,7 @@
 #include "common.h"
 #include "can_write.h"
 #include "struct_writers.h"
-namespace swiftwinrt 
+namespace swiftwinrt
 {
     void write_struct_initializer_params(writer & w, struct_type const& type)
     {
@@ -19,7 +19,7 @@ namespace swiftwinrt
             {
                 s();
 
-                w.write("%: %", get_swift_name(field), field.type);
+                w.write("%: %", get_swift_name(field), bind<write_type>(*field.type, write_type_params::swift));
             }
 
         }

--- a/tests/test_app/main.swift
+++ b/tests/test_app/main.swift
@@ -71,6 +71,31 @@ class SwiftWinRTTests : XCTestCase {
     XCTAssertEqual(nonBlittableStruct.fourth, "Yay!", "not copied correctly")
   }
 
+  public func testStructWithIReference() throws {
+    let simple = Simple()
+    var structWithIReference = try simple.returnStructWithReference()
+
+    XCTAssertEqual(structWithIReference.value1, 4, "not copied correctly")
+    XCTAssertEqual(structWithIReference.value2, 2, "not copied correctly")
+    // takeStructWithReference requires the struct to have these values
+    try simple.takeStructWithReference(structWithIReference)
+
+    structWithIReference = simple.structWithReferenceProperty
+
+    XCTAssertNil(structWithIReference.value1, "not copied correctly")
+    XCTAssertNil(structWithIReference.value2, "not copied correctly")
+
+    simple.structWithReferenceProperty = StructWithIReference(value1: 4, value2: nil)
+    structWithIReference = simple.structWithReferenceProperty
+    XCTAssertEqual(structWithIReference.value1, 4, "not copied correctly")
+    XCTAssertEqual(structWithIReference.value2, nil, "not copied correctly")
+
+    simple.structWithReferenceProperty = StructWithIReference(value1: 4, value2: 2)
+    structWithIReference = simple.structWithReferenceProperty
+    XCTAssertEqual(structWithIReference.value1, 4, "not copied correctly")
+    XCTAssertEqual(structWithIReference.value2, 2, "not copied correctly")
+  }
+
   public func testEnums() throws {
     let classy = Class()
 
@@ -430,6 +455,7 @@ var tests: [XCTestCaseEntry] = [
     ("testNullValues", SwiftWinRTTests.testNullValues),
     ("testOutParams", SwiftWinRTTests.testOutParams),
     ("testStaticMethods", SwiftWinRTTests.testStaticMethods),
+    ("testStructWithIReference", SwiftWinRTTests.testStructWithIReference),
     ("testUnicode", SwiftWinRTTests.testUnicode),
     ("testErrorInfo", SwiftWinRTTests.testErrorInfo),
   ])

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -2179,6 +2179,8 @@ typedef struct __x_ABI_Ctest__component_CBlittableStruct __x_ABI_Ctest__componen
 
 typedef struct __x_ABI_Ctest__component_CNonBlittableStruct __x_ABI_Ctest__component_CNonBlittableStruct;
 
+typedef struct __x_ABI_Ctest__component_CStructWithIReference __x_ABI_Ctest__component_CStructWithIReference;
+
 enum __x_ABI_Ctest__component_CFruit
     {
         __x_ABI_Ctest__component_CFruit_Banana = 0,
@@ -2286,6 +2288,12 @@ struct __x_ABI_Ctest__component_CSimpleEventArgs
 struct __x_ABI_Ctest__component_CStructWithEnum
     {
         enum __x_ABI_Ctest__component_CSwiftifiableNames Names;
+};
+
+struct __x_ABI_Ctest__component_CStructWithIReference
+    {
+        __x_ABI_C__FIReference_1_int* Value1;
+    __x_ABI_C__FIReference_1_int* Value2;
 };
 
 #if !defined(____x_ABI_Ctest__component_CIObjectHandler_INTERFACE_DEFINED__)
@@ -3424,6 +3432,14 @@ struct __x_ABI_Ctest__component_CStructWithEnum
         struct __x_ABI_Ctest__component_CBlittableStruct* value);
     HRESULT (STDMETHODCALLTYPE* put_BlittableStructProperty)(__x_ABI_Ctest__component_CISimple* This,
         struct __x_ABI_Ctest__component_CBlittableStruct value);
+    HRESULT (STDMETHODCALLTYPE* ReturnStructWithReference)(__x_ABI_Ctest__component_CISimple* This,
+        struct __x_ABI_Ctest__component_CStructWithIReference* result);
+    HRESULT (STDMETHODCALLTYPE* TakeStructWithReference)(__x_ABI_Ctest__component_CISimple* This,
+        struct __x_ABI_Ctest__component_CStructWithIReference value);
+    HRESULT (STDMETHODCALLTYPE* get_StructWithReferenceProperty)(__x_ABI_Ctest__component_CISimple* This,
+        struct __x_ABI_Ctest__component_CStructWithIReference* value);
+    HRESULT (STDMETHODCALLTYPE* put_StructWithReferenceProperty)(__x_ABI_Ctest__component_CISimple* This,
+        struct __x_ABI_Ctest__component_CStructWithIReference value);
     HRESULT (STDMETHODCALLTYPE* ReturnNonBlittableStruct)(__x_ABI_Ctest__component_CISimple* This,
         struct __x_ABI_Ctest__component_CNonBlittableStruct* result);
     HRESULT (STDMETHODCALLTYPE* TakeNonBlittableStruct)(__x_ABI_Ctest__component_CISimple* This,

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -103,7 +103,7 @@ private var IID___x_ABI_Ctest__component_CINullValuesStatics: test_component.IID
 }
 
 private var IID___x_ABI_Ctest__component_CISimple: test_component.IID {
-    .init(Data1: 0xBAC2883F, Data2: 0x0E80, Data3: 0x5319, Data4: ( 0x88,0xE6,0x9B,0xFE,0x73,0x3B,0x7A,0x66 ))// BAC2883F-0E80-5319-88E6-9BFE733B7A66
+    .init(Data1: 0xAE7B4545, Data2: 0xD9D0, Data3: 0x5655, Data4: ( 0xB1,0xDE,0xA0,0x7D,0xA1,0x3B,0xD8,0x9B ))// AE7B4545-D9D0-5655-B1DE-A07DA13BD89B
 }
 
 private var IID___x_ABI_Ctest__component_CISimpleDelegate: test_component.IID {
@@ -1684,6 +1684,36 @@ public enum __ABI_test_component {
             }
         }
 
+        internal func ReturnStructWithReferenceImpl() throws -> test_component.StructWithIReference {
+            var result: __x_ABI_Ctest__component_CStructWithIReference = .init()
+            _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnStructWithReference(pThis, &result))
+            }
+            return .from(abi: result)
+        }
+
+        internal func TakeStructWithReferenceImpl(_ value: test_component.StructWithIReference) throws {
+            let _value = __ABI_test_component._ABI_StructWithIReference(from: value)
+            _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.TakeStructWithReference(pThis, _value.val))
+            }
+        }
+
+        internal func get_StructWithReferencePropertyImpl() throws -> test_component.StructWithIReference {
+            var value: __x_ABI_Ctest__component_CStructWithIReference = .init()
+            _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_StructWithReferenceProperty(pThis, &value))
+            }
+            return .from(abi: value)
+        }
+
+        internal func put_StructWithReferencePropertyImpl(_ value: test_component.StructWithIReference) throws {
+            let _value = __ABI_test_component._ABI_StructWithIReference(from: value)
+            _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_StructWithReferenceProperty(pThis, _value.val))
+            }
+        }
+
         internal func ReturnNonBlittableStructImpl() throws -> test_component.NonBlittableStruct {
             var result: __x_ABI_Ctest__component_CNonBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
@@ -2335,6 +2365,28 @@ public enum __ABI_test_component {
             WindowsDeleteString(val.First)
             WindowsDeleteString(val.Second)
             WindowsDeleteString(val.Fourth)
+        }
+    }
+    public class _ABI_StructWithIReference {
+        public var val: __x_ABI_Ctest__component_CStructWithIReference = .init()
+        public init() { }
+        public init(from swift: test_component.StructWithIReference) {
+            let Value1Wrapper = test_component.__x_ABI_C__FIReference_1_intWrapper(swift.value1)
+            Value1Wrapper?.copyTo(&val.Value1)
+            let Value2Wrapper = test_component.__x_ABI_C__FIReference_1_intWrapper(swift.value2)
+            Value2Wrapper?.copyTo(&val.Value2)
+        }
+
+        public func detach() -> __x_ABI_Ctest__component_CStructWithIReference {
+            let result = val
+            val.Value1 = nil
+            val.Value2 = nil
+            return result
+        }
+
+        deinit {
+            _ = val.Value1?.pointee.lpVtbl.pointee.Release(val.Value1)
+            _ = val.Value2?.pointee.lpVtbl.pointee.Release(val.Value2)
         }
     }
     internal typealias IBaseOverridesWrapper = UnsealedWinRTClassWrapper<test_component.Base.IBaseOverrides>

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -6660,7 +6660,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClas
     }
 }
 private var IID___x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgs: test_component.IID {
-    .init(Data1: 0xa0dda56b, Data2: 0x12f6, Data3: 0x52f4, Data4: ( 0x90,0x3d,0x55,0xce,0x8f,0xa7,0x7e,0xac ))// a0dda56b-12f6-52f4-903d-55ce8fa77eac
+    .init(Data1: 0x17d0b9f7, Data2: 0xa3c3, Data3: 0x5961, Data4: ( 0x9a,0x78,0xfb,0x92,0xed,0xa1,0x58,0xc6 ))// 17d0b9f7-a3c3-5961-9a78-fb92eda158c6
 }
 
 internal extension WinRTDelegateBridge where CABI == __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgs {

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -1176,6 +1176,14 @@ public final class Simple : WinRTClass {
         try _default.TakeBlittableStructImpl(value)
     }
 
+    public func returnStructWithReference() throws -> StructWithIReference {
+        try _default.ReturnStructWithReferenceImpl()
+    }
+
+    public func takeStructWithReference(_ value: StructWithIReference) throws {
+        try _default.TakeStructWithReferenceImpl(value)
+    }
+
     public func returnNonBlittableStruct() throws -> NonBlittableStruct {
         try _default.ReturnNonBlittableStructImpl()
     }
@@ -1201,6 +1209,11 @@ public final class Simple : WinRTClass {
     public var stringProperty : String {
         get { try! _default.get_StringPropertyImpl() }
         set { try! _default.put_StringPropertyImpl(newValue) }
+    }
+
+    public var structWithReferenceProperty : StructWithIReference {
+        get { try! _default.get_StructWithReferencePropertyImpl() }
+        set { try! _default.put_StructWithReferencePropertyImpl(newValue) }
     }
 
     public lazy var inEvent : Event<test_component.InDelegate> = {
@@ -1671,6 +1684,19 @@ public struct StructWithEnum: Hashable, Codable {
     }
     public static func from(abi: __x_ABI_Ctest__component_CStructWithEnum) -> StructWithEnum {
         .init(names: abi.Names)
+    }
+}
+
+public struct StructWithIReference: Hashable, Codable {
+    public var value1: Int32?
+    public var value2: Int32?
+    public init() {}
+    public init(value1: Int32?, value2: Int32?) {
+        self.value1 = value1
+        self.value2 = value2
+    }
+    public static func from(abi: __x_ABI_Ctest__component_CStructWithIReference) -> StructWithIReference {
+        .init(value1: test_component.__x_ABI_C__FIReference_1_intWrapper.unwrapFrom(abi: ComPtr(abi.Value1)), value2: test_component.__x_ABI_C__FIReference_1_intWrapper.unwrapFrom(abi: ComPtr(abi.Value2)))
     }
 }
 

--- a/tests/test_component/cpp/Simple.h
+++ b/tests/test_component/cpp/Simple.h
@@ -71,6 +71,31 @@ namespace winrt::test_component::implementation
             m_nonBlittableStruct = value;
         }
 
+        test_component::StructWithIReference ReturnStructWithReference()
+        {
+            winrt::Windows::Foundation::IReference<int32_t> value1 = 4;
+            winrt::Windows::Foundation::IReference<int32_t> value2 = 2;
+
+            return { value1, value2};
+        }
+
+        void TakeStructWithReference(test_component::StructWithIReference const& value)
+        {
+            if (winrt::unbox_value<int32_t>(value.Value1) != 4 && winrt::unbox_value<int32_t>(value.Value2) != 2)
+            {
+                throw hresult_not_implemented();
+            }
+        }
+
+        test_component::StructWithIReference StructWithReferenceProperty()
+        {
+            return m_structWithIReferenceStruct;
+        }
+        void StructWithReferenceProperty(test_component::StructWithIReference const& value)
+        {
+            m_structWithIReferenceStruct = value;
+        }
+
         hstring StringProperty()
         {
             return m_stringProp;
@@ -94,6 +119,7 @@ namespace winrt::test_component::implementation
         hstring m_stringProp{};
         test_component::BlittableStruct m_blittableStruct{};
         test_component::NonBlittableStruct m_nonBlittableStruct{};
+        test_component::StructWithIReference m_structWithIReferenceStruct{};
         winrt::event<test_component::Delegates::SignalDelegate> m_signalEvent;
         winrt::event<test_component::Delegates::InDelegate> m_inEvent;
         winrt::event<Windows::Foundation::TypedEventHandler<test_component::Simple, test_component::SimpleEventArgs>> m_simpleEvent;

--- a/tests/test_component/cpp/test_component.idl
+++ b/tests/test_component/cpp/test_component.idl
@@ -57,6 +57,12 @@ namespace test_component
             SwiftifiableNames Names;
         };
 
+        struct StructWithIReference
+        {
+            Windows.Foundation.IReference<Int32> Value1;
+            Windows.Foundation.IReference<Int32> Value2;
+        };
+
         namespace Delegates
         {
             delegate void SignalDelegate();
@@ -122,6 +128,10 @@ namespace test_component
             BlittableStruct ReturnBlittableStruct();
             void TakeBlittableStruct(BlittableStruct value);
             BlittableStruct BlittableStructProperty;
+
+            StructWithIReference ReturnStructWithReference();
+            void TakeStructWithReference(StructWithIReference value);
+            StructWithIReference StructWithReferenceProperty;
 
             NonBlittableStruct ReturnNonBlittableStruct();
             void TakeNonBlittableStruct(NonBlittableStruct value);


### PR DESCRIPTION
when someone tries to include a struct with reference types, the code gen breaks for a few reasons:

1. in the constructor of the projected struct, we were using `IReference<T>` instead of `T?`
2. in the abi conversion code, we weren't converting between the ABI and swift types appropriately

## Changes

- for (1) above, use the `write_type` api
- for (2) above, check if the member type is an ireference and appropriately set the value

## Tests

added test cases

Fixes WIN-450