### PR TITLE
fix uuid name

### DIFF
--- a/swiftwinrt/code_writers/type_writers.cpp
+++ b/swiftwinrt/code_writers/type_writers.cpp
@@ -87,9 +87,10 @@ void write_swift_type_identifier_ex(writer& w, metadata_type const& type, bool e
     }
     else if (auto systype = dynamic_cast<const system_type*>(&type))
     {
-        if (systype->swift_type_name() == "GUID")
+        if (systype->category() == param_category::guid_type)
         {
-            w.write("%.GUID", w.support);
+            // GUID requires full type name due to collisions with WinSDK
+            w.write(systype->swift_full_name());
         }
         else
         {
@@ -101,7 +102,7 @@ void write_swift_type_identifier_ex(writer& w, metadata_type const& type, bool e
         // Make sure the module gets imported
         w.add_depends(type);
 
-        // Module 
+        // Module
         if (type_def->is_generic())
         {
             // Generic instances are always in the support module
@@ -123,7 +124,7 @@ void write_swift_type_identifier_ex(writer& w, metadata_type const& type, bool e
             // to avoid needing parens in (any IFoo)?
             w.write("Any");
         }
-        
+
         w.write(remove_backtick(type.swift_type_name()));
 
         if (omit_generic_args == false && !type_def->generic_params.empty())

--- a/swiftwinrt/helpers.h
+++ b/swiftwinrt/helpers.h
@@ -824,7 +824,7 @@ namespace swiftwinrt
         }
         if (auto sysType = dynamic_cast<const system_type*>(type))
         {
-            return param_category::guid_type;
+            return sysType->category();
         }
         if (auto mapped = dynamic_cast<const mapped_type*>(type))
         {

--- a/swiftwinrt/types.cpp
+++ b/swiftwinrt/types.cpp
@@ -690,7 +690,7 @@ namespace swiftwinrt
     {
         if (typeName == "Guid"sv)
         {
-            static system_type const guid_type{ "Foundation.UUID"sv, "GUID"sv, "g16"sv };
+            static system_type const guid_type{ "Foundation"sv, "UUID"sv, "Foundation.UUID"sv, "GUID"sv, "g16"sv, param_category::guid_type };
             return guid_type;
         }
 

--- a/swiftwinrt/types.h
+++ b/swiftwinrt/types.h
@@ -175,10 +175,19 @@ namespace swiftwinrt
 
     struct system_type final : metadata_type
     {
-        system_type(std::string_view swiftName, std::string_view cppName, std::string_view signature) :
-            m_swiftName(swiftName),
+        system_type(
+            std::string_view swiftModule,
+            std::string_view swiftTypeName,
+            std::string_view swiftFullName,
+            std::string_view cppName,
+            std::string_view signature,
+            param_category category) :
+            m_swiftModuleName(swiftModule),
+            m_swiftTypeName(swiftTypeName),
+            m_swiftFullName(swiftFullName),
             m_cppName(cppName),
-            m_signature(signature)
+            m_signature(signature),
+            m_category(category)
         {
         }
 
@@ -190,19 +199,20 @@ namespace swiftwinrt
             return {};
         }
 
+
         virtual std::string_view swift_logical_namespace() const override
         {
-            return "Foundation";
+            return m_swiftModuleName;
         }
 
         virtual std::string_view swift_full_name() const override
         {
-            return m_swiftName;
+            return m_swiftFullName;
         }
 
         virtual std::string_view swift_type_name() const override
         {
-            return m_swiftName;
+            return m_swiftTypeName;
         }
 
         virtual std::string_view cpp_abi_name() const override
@@ -249,9 +259,14 @@ namespace swiftwinrt
         {
             // no special declaration necessary
         }
+
+        param_category category() const { return m_category; }
     private:
 
-        std::string_view m_swiftName;
+        std::string_view m_swiftModuleName;
+        std::string_view m_swiftTypeName;
+        std::string_view m_swiftFullName;
+        param_category m_category;
         std::string_view m_cppName;
         std::string_view m_signature;
     };

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -287,6 +287,12 @@ typedef interface __x_ABI_Ctest__component_CIVoidToVoidDelegate __x_ABI_Ctest__c
 
 #endif // ____x_ABI_Ctest__component_CInterfaceWithReturnDelegate_FWD_DEFINED__
 
+#ifndef ____x_ABI_Ctest__component_CWithIterableGuids_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CWithIterableGuids_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CWithIterableGuids __x_ABI_Ctest__component_CWithIterableGuids;
+
+#endif // ____x_ABI_Ctest__component_CWithIterableGuids_FWD_DEFINED__
+
 #ifndef ____x_ABI_Ctest__component_CWithKeyword_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CWithKeyword_FWD_DEFINED__
     typedef interface __x_ABI_Ctest__component_CWithKeyword __x_ABI_Ctest__component_CWithKeyword;
@@ -570,6 +576,90 @@ typedef interface __x_ABI_C__FIAsyncOperationWithProgress_2_int_double __x_ABI_C
 
     
     #endif // ____x_ABI_C__FIIterable_1_IInspectable_INTERFACE_DEFINED__
+    
+#if !defined(____x_ABI_C__FIIterator_1_GUID_INTERFACE_DEFINED__)
+    #define ____x_ABI_C__FIIterator_1_GUID_INTERFACE_DEFINED__
+
+    typedef interface __x_ABI_C__FIIterator_1_GUID __x_ABI_C__FIIterator_1_GUID;
+
+    //  Declare the parameterized interface IID.
+    EXTERN_C const IID IID___x_ABI_C__FIIterator_1_GUID;
+
+    typedef struct __x_ABI_C__FIIterator_1_GUIDVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_C__FIIterator_1_GUID* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_C__FIIterator_1_GUID* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_C__FIIterator_1_GUID* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_C__FIIterator_1_GUID* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_C__FIIterator_1_GUID* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_C__FIIterator_1_GUID* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* get_Current)(__x_ABI_C__FIIterator_1_GUID* This,
+        GUID* result);
+    HRESULT (STDMETHODCALLTYPE* get_HasCurrent)(__x_ABI_C__FIIterator_1_GUID* This,
+        boolean* result);
+    HRESULT (STDMETHODCALLTYPE* MoveNext)(__x_ABI_C__FIIterator_1_GUID* This,
+        boolean* result);
+    HRESULT (STDMETHODCALLTYPE* GetMany)(__x_ABI_C__FIIterator_1_GUID* This,
+        UINT32 itemsLength,
+        GUID* items,
+        UINT32* result);
+
+        END_INTERFACE
+    } __x_ABI_C__FIIterator_1_GUIDVtbl;
+
+    interface __x_ABI_C__FIIterator_1_GUID
+    {
+        CONST_VTBL struct __x_ABI_C__FIIterator_1_GUIDVtbl* lpVtbl;
+    };
+
+    
+    #endif // ____x_ABI_C__FIIterator_1_GUID_INTERFACE_DEFINED__
+    
+#if !defined(____x_ABI_C__FIIterable_1_GUID_INTERFACE_DEFINED__)
+    #define ____x_ABI_C__FIIterable_1_GUID_INTERFACE_DEFINED__
+
+    typedef interface __x_ABI_C__FIIterable_1_GUID __x_ABI_C__FIIterable_1_GUID;
+
+    //  Declare the parameterized interface IID.
+    EXTERN_C const IID IID___x_ABI_C__FIIterable_1_GUID;
+
+    typedef struct __x_ABI_C__FIIterable_1_GUIDVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_C__FIIterable_1_GUID* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_C__FIIterable_1_GUID* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_C__FIIterable_1_GUID* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_C__FIIterable_1_GUID* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_C__FIIterable_1_GUID* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_C__FIIterable_1_GUID* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* First)(__x_ABI_C__FIIterable_1_GUID* This,
+        __x_ABI_C__FIIterator_1_GUID** result);
+
+        END_INTERFACE
+    } __x_ABI_C__FIIterable_1_GUIDVtbl;
+
+    interface __x_ABI_C__FIIterable_1_GUID
+    {
+        CONST_VTBL struct __x_ABI_C__FIIterable_1_GUIDVtbl* lpVtbl;
+    };
+
+    
+    #endif // ____x_ABI_C__FIIterable_1_GUID_INTERFACE_DEFINED__
     
 #if !defined(____x_ABI_C__FIIterator_1_HSTRING_INTERFACE_DEFINED__)
     #define ____x_ABI_C__FIIterator_1_HSTRING_INTERFACE_DEFINED__
@@ -1709,6 +1799,56 @@ typedef interface __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIB
     
     #endif // ____x_ABI_C__FIVectorView_1_IInspectable_INTERFACE_DEFINED__
     
+#if !defined(____x_ABI_C__FIVectorView_1_GUID_INTERFACE_DEFINED__)
+    #define ____x_ABI_C__FIVectorView_1_GUID_INTERFACE_DEFINED__
+
+    typedef interface __x_ABI_C__FIVectorView_1_GUID __x_ABI_C__FIVectorView_1_GUID;
+
+    //  Declare the parameterized interface IID.
+    EXTERN_C const IID IID___x_ABI_C__FIVectorView_1_GUID;
+
+    typedef struct __x_ABI_C__FIVectorView_1_GUIDVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_C__FIVectorView_1_GUID* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_C__FIVectorView_1_GUID* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_C__FIVectorView_1_GUID* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_C__FIVectorView_1_GUID* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_C__FIVectorView_1_GUID* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_C__FIVectorView_1_GUID* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* GetAt)(__x_ABI_C__FIVectorView_1_GUID* This,
+        UINT32 index,
+        GUID* result);
+    HRESULT (STDMETHODCALLTYPE* get_Size)(__x_ABI_C__FIVectorView_1_GUID* This,
+        UINT32* result);
+    HRESULT (STDMETHODCALLTYPE* IndexOf)(__x_ABI_C__FIVectorView_1_GUID* This,
+        GUID value,
+        UINT32* index,
+        boolean* result);
+    HRESULT (STDMETHODCALLTYPE* GetMany)(__x_ABI_C__FIVectorView_1_GUID* This,
+        UINT32 startIndex,
+        UINT32 itemsLength,
+        GUID* items,
+        UINT32* result);
+
+        END_INTERFACE
+    } __x_ABI_C__FIVectorView_1_GUIDVtbl;
+
+    interface __x_ABI_C__FIVectorView_1_GUID
+    {
+        CONST_VTBL struct __x_ABI_C__FIVectorView_1_GUIDVtbl* lpVtbl;
+    };
+
+    
+    #endif // ____x_ABI_C__FIVectorView_1_GUID_INTERFACE_DEFINED__
+    
 #if !defined(____x_ABI_C__FIVectorView_1_HSTRING_INTERFACE_DEFINED__)
     #define ____x_ABI_C__FIVectorView_1_HSTRING_INTERFACE_DEFINED__
 
@@ -1825,6 +1965,73 @@ typedef interface __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIB
 
     
     #endif // ____x_ABI_C__FIVector_1_IInspectable_INTERFACE_DEFINED__
+    
+#if !defined(____x_ABI_C__FIVector_1_GUID_INTERFACE_DEFINED__)
+    #define ____x_ABI_C__FIVector_1_GUID_INTERFACE_DEFINED__
+
+    typedef interface __x_ABI_C__FIVector_1_GUID __x_ABI_C__FIVector_1_GUID;
+
+    //  Declare the parameterized interface IID.
+    EXTERN_C const IID IID___x_ABI_C__FIVector_1_GUID;
+
+    typedef struct __x_ABI_C__FIVector_1_GUIDVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_C__FIVector_1_GUID* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_C__FIVector_1_GUID* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_C__FIVector_1_GUID* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_C__FIVector_1_GUID* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_C__FIVector_1_GUID* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_C__FIVector_1_GUID* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* GetAt)(__x_ABI_C__FIVector_1_GUID* This,
+        UINT32 index,
+        GUID* result);
+    HRESULT (STDMETHODCALLTYPE* get_Size)(__x_ABI_C__FIVector_1_GUID* This,
+        UINT32* result);
+    HRESULT (STDMETHODCALLTYPE* GetView)(__x_ABI_C__FIVector_1_GUID* This,
+        __x_ABI_C__FIVectorView_1_GUID** result);
+    HRESULT (STDMETHODCALLTYPE* IndexOf)(__x_ABI_C__FIVector_1_GUID* This,
+        GUID value,
+        UINT32* index,
+        boolean* result);
+    HRESULT (STDMETHODCALLTYPE* SetAt)(__x_ABI_C__FIVector_1_GUID* This,
+        UINT32 index,
+        GUID value);
+    HRESULT (STDMETHODCALLTYPE* InsertAt)(__x_ABI_C__FIVector_1_GUID* This,
+        UINT32 index,
+        GUID value);
+    HRESULT (STDMETHODCALLTYPE* RemoveAt)(__x_ABI_C__FIVector_1_GUID* This,
+        UINT32 index);
+    HRESULT (STDMETHODCALLTYPE* Append)(__x_ABI_C__FIVector_1_GUID* This,
+        GUID value);
+    HRESULT (STDMETHODCALLTYPE* RemoveAtEnd)(__x_ABI_C__FIVector_1_GUID* This);
+    HRESULT (STDMETHODCALLTYPE* Clear)(__x_ABI_C__FIVector_1_GUID* This);
+    HRESULT (STDMETHODCALLTYPE* GetMany)(__x_ABI_C__FIVector_1_GUID* This,
+        UINT32 startIndex,
+        UINT32 itemsLength,
+        GUID* items,
+        UINT32* result);
+    HRESULT (STDMETHODCALLTYPE* ReplaceAll)(__x_ABI_C__FIVector_1_GUID* This,
+        UINT32 itemsLength,
+        GUID* items);
+
+        END_INTERFACE
+    } __x_ABI_C__FIVector_1_GUIDVtbl;
+
+    interface __x_ABI_C__FIVector_1_GUID
+    {
+        CONST_VTBL struct __x_ABI_C__FIVector_1_GUIDVtbl* lpVtbl;
+    };
+
+    
+    #endif // ____x_ABI_C__FIVector_1_GUID_INTERFACE_DEFINED__
     
 #if !defined(____x_ABI_C__FIVector_1_HSTRING_INTERFACE_DEFINED__)
     #define ____x_ABI_C__FIVector_1_HSTRING_INTERFACE_DEFINED__
@@ -4104,6 +4311,39 @@ struct __x_ABI_Ctest__component_CStructWithIReference
     
     EXTERN_C const IID IID___x_ABI_Ctest__component_CInterfaceWithReturnDelegate;
 #endif /* !defined(____x_ABI_Ctest__component_CInterfaceWithReturnDelegate_INTERFACE_DEFINED__) */
+    
+#if !defined(____x_ABI_Ctest__component_CWithIterableGuids_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CWithIterableGuids_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CWithIterableGuidsVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CWithIterableGuids* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CWithIterableGuids* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CWithIterableGuids* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CWithIterableGuids* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CWithIterableGuids* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CWithIterableGuids* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* IDs)(__x_ABI_Ctest__component_CWithIterableGuids* This,
+        __x_ABI_C__FIVector_1_GUID** result);
+
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CWithIterableGuidsVtbl;
+
+    interface __x_ABI_Ctest__component_CWithIterableGuids
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CWithIterableGuidsVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CWithIterableGuids;
+#endif /* !defined(____x_ABI_Ctest__component_CWithIterableGuids_INTERFACE_DEFINED__) */
     
 #if !defined(____x_ABI_Ctest__component_CWithKeyword_INTERFACE_DEFINED__)
     #define ____x_ABI_Ctest__component_CWithKeyword_INTERFACE_DEFINED__

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -179,6 +179,10 @@ private var IID___x_ABI_Ctest__component_CInterfaceWithReturnDelegate: test_comp
     .init(Data1: 0xB0EBC406, Data2: 0x17C0, Data3: 0x5703, Data4: ( 0xB9,0xC7,0x50,0xBE,0x67,0x5B,0xBC,0x95 ))// B0EBC406-17C0-5703-B9C7-50BE675BBC95
 }
 
+private var IID___x_ABI_Ctest__component_CWithIterableGuids: test_component.IID {
+    .init(Data1: 0xF8BD03F6, Data2: 0xBD7E, Data3: 0x586D, Data4: ( 0x96,0xB8,0x63,0xB6,0x39,0xA8,0xD0,0x42 ))// F8BD03F6-BD7E-586D-96B8-63B639A8D042
+}
+
 private var IID___x_ABI_Ctest__component_CWithKeyword: test_component.IID {
     .init(Data1: 0x77E9FBAD, Data2: 0x3DCE, Data3: 0x5E50, Data4: ( 0xB4,0x39,0x91,0x91,0xF5,0x23,0x2A,0x84 ))// 77E9FBAD-3DCE-5E50-B439-9191F5232A84
 }
@@ -2215,6 +2219,60 @@ public enum __ABI_test_component {
     )
 
     public typealias InterfaceWithReturnDelegateWrapper = InterfaceWrapperBase<__IMPL_test_component.InterfaceWithReturnDelegateBridge>
+    public class WithIterableGuids: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CWithIterableGuids }
+
+        open func IDsImpl() throws -> test_component.AnyIVector<Foundation.UUID>? {
+            let (result) = try ComPtrs.initialize { resultAbi in
+                _ = try perform(as: __x_ABI_Ctest__component_CWithIterableGuids.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.IDs(pThis, &resultAbi))
+                }
+            }
+            return test_component.__x_ABI_C__FIVector_1_GUIDWrapper.unwrapFrom(abi: result)
+        }
+
+    }
+
+    internal static var WithIterableGuidsVTable: __x_ABI_Ctest__component_CWithIterableGuidsVtbl = .init(
+        QueryInterface: { WithIterableGuidsWrapper.queryInterface($0, $1, $2) },
+        AddRef: { WithIterableGuidsWrapper.addRef($0) },
+        Release: { WithIterableGuidsWrapper.release($0) },
+        GetIids: {
+            let size = MemoryLayout<test_component.IID>.size
+            let iids = CoTaskMemAlloc(UInt64(size) * 3).assumingMemoryBound(to: test_component.IID.self)
+            iids[0] = IUnknown.IID
+            iids[1] = IInspectable.IID
+            iids[2] = __ABI_test_component.WithIterableGuidsWrapper.IID
+            $1!.pointee = 3
+            $2!.pointee = iids
+            return S_OK
+        },
+
+        GetRuntimeClassName: {
+            _ = $0
+            let hstring = try! HString("test_component.WithIterableGuids").detach()
+            $1!.pointee = hstring
+            return S_OK
+        },
+
+        GetTrustLevel: {
+            _ = $0
+            $1!.pointee = TrustLevel(rawValue: 0)
+            return S_OK
+        },
+
+        IDs: {
+            do {
+                guard let __unwrapped__instance = WithIterableGuidsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+                let result = try __unwrapped__instance.ids()
+                let resultWrapper = test_component.__x_ABI_C__FIVector_1_GUIDWrapper(result)
+                resultWrapper?.copyTo($1)
+                return S_OK
+            } catch { return failWith(err: E_FAIL) } 
+        }
+    )
+
+    public typealias WithIterableGuidsWrapper = InterfaceWrapperBase<__IMPL_test_component.WithIterableGuidsBridge>
     public class WithKeyword: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CWithKeyword }
 

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -243,6 +243,93 @@ fileprivate class __x_ABI_C__FIIterable_1_IInspectableImpl : IIterable, AbiInter
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
 }
 
+private var IID___x_ABI_C__FIIterable_1_GUID: test_component.IID {
+    .init(Data1: 0xf4ca3045, Data2: 0x5dd7, Data3: 0x54be, Data4: ( 0x98,0x2e,0xd8,0x8d,0x8c,0xa0,0x87,0x6e ))// f4ca3045-5dd7-54be-982e-d88d8ca0876e
+}
+
+internal var __x_ABI_C__FIIterable_1_GUIDVTable: __x_ABI_C__FIIterable_1_GUIDVtbl = .init(
+    QueryInterface: { __x_ABI_C__FIIterable_1_GUIDWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FIIterable_1_GUIDWrapper.addRef($0) },
+    Release: { __x_ABI_C__FIIterable_1_GUIDWrapper.release($0) },
+    GetIids: {
+        let size = MemoryLayout<test_component.IID>.size
+        let iids = CoTaskMemAlloc(UInt64(size) * 3).assumingMemoryBound(to: test_component.IID.self)
+        iids[0] = IUnknown.IID
+        iids[1] = IInspectable.IID
+        iids[2] = test_component.__x_ABI_C__FIIterable_1_GUIDWrapper.IID
+        $1!.pointee = 3
+        $2!.pointee = iids
+        return S_OK
+    },
+
+    GetRuntimeClassName: {
+        _ = $0
+        let hstring = try! HString("Windows.Foundation.Collections.IIterable`1<Foundation.UUID>").detach()
+        $1!.pointee = hstring
+        return S_OK
+    },
+
+    GetTrustLevel: {
+        _ = $0
+        $1!.pointee = TrustLevel(rawValue: 0)
+        return S_OK
+    },
+
+    First: {
+        guard let __unwrapped__instance = __x_ABI_C__FIIterable_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let result = __unwrapped__instance.first()
+        let resultWrapper = test_component.__x_ABI_C__FIIterator_1_GUIDWrapper(result)
+        resultWrapper?.copyTo($1)
+        return S_OK
+    }
+)
+typealias __x_ABI_C__FIIterable_1_GUIDWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1_GUIDBridge>
+internal class IIterableUUID: test_component.IInspectable {
+    override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1_GUID }
+
+    internal func FirstImpl() throws -> test_component.AnyIIterator<Foundation.UUID>? {
+        let (result) = try ComPtrs.initialize { resultAbi in
+            _ = try perform(as: __x_ABI_C__FIIterable_1_GUID.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
+            }
+        }
+        return test_component.__x_ABI_C__FIIterator_1_GUIDWrapper.unwrapFrom(abi: result)
+    }
+
+}
+
+internal enum __x_ABI_C__FIIterable_1_GUIDBridge : AbiInterfaceBridge {
+    internal typealias CABI = __x_ABI_C__FIIterable_1_GUID
+    internal typealias SwiftABI = IIterableUUID
+    internal typealias SwiftProjection = AnyIIterable<Foundation.UUID>
+    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        guard let abi = abi else { return nil }
+        return __x_ABI_C__FIIterable_1_GUIDImpl(abi)
+    }
+
+    internal static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &__x_ABI_C__FIIterable_1_GUIDVTable) { $0 }
+        return .init(lpVtbl: vtblPtr)
+    }
+}
+
+fileprivate class __x_ABI_C__FIIterable_1_GUIDImpl : IIterable, AbiInterfaceImpl {
+    typealias T = Foundation.UUID
+    typealias Bridge = __x_ABI_C__FIIterable_1_GUIDBridge
+    let _default: Bridge.SwiftABI
+    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        _default = Bridge.SwiftABI(fromAbi)
+    }
+
+    // MARK: WinRT
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
+    fileprivate func first() -> AnyIIterator<Foundation.UUID>? {
+        try! _default.FirstImpl()
+    }
+
+    public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
+}
+
 private var IID___x_ABI_C__FIIterable_1_HSTRING: test_component.IID {
     .init(Data1: 0xe2fcc7c1, Data2: 0x3bfc, Data3: 0x5a0b, Data4: ( 0xb2,0xb0,0x72,0xe7,0x69,0xd1,0xcb,0x7e ))// e2fcc7c1-3bfc-5a0b-b2b0-72e769d1cb7e
 }
@@ -883,6 +970,133 @@ fileprivate class __x_ABI_C__FIIterator_1_IInspectableImpl : IIterator, AbiInter
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : Any? {
+        get { try! _default.get_CurrentImpl() }
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
+    fileprivate var hasCurrent : Bool {
+        get { try! _default.get_HasCurrentImpl() }
+    }
+
+    public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
+}
+
+private var IID___x_ABI_C__FIIterator_1_GUID: test_component.IID {
+    .init(Data1: 0xd3d64048, Data2: 0x82b3, Data3: 0x53c7, Data4: ( 0x92,0x85,0xb0,0xbe,0x18,0x36,0x84,0x82 ))// d3d64048-82b3-53c7-9285-b0be18368482
+}
+
+internal var __x_ABI_C__FIIterator_1_GUIDVTable: __x_ABI_C__FIIterator_1_GUIDVtbl = .init(
+    QueryInterface: { __x_ABI_C__FIIterator_1_GUIDWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FIIterator_1_GUIDWrapper.addRef($0) },
+    Release: { __x_ABI_C__FIIterator_1_GUIDWrapper.release($0) },
+    GetIids: {
+        let size = MemoryLayout<test_component.IID>.size
+        let iids = CoTaskMemAlloc(UInt64(size) * 3).assumingMemoryBound(to: test_component.IID.self)
+        iids[0] = IUnknown.IID
+        iids[1] = IInspectable.IID
+        iids[2] = test_component.__x_ABI_C__FIIterator_1_GUIDWrapper.IID
+        $1!.pointee = 3
+        $2!.pointee = iids
+        return S_OK
+    },
+
+    GetRuntimeClassName: {
+        _ = $0
+        let hstring = try! HString("Windows.Foundation.Collections.IIterator`1<Foundation.UUID>").detach()
+        $1!.pointee = hstring
+        return S_OK
+    },
+
+    GetTrustLevel: {
+        _ = $0
+        $1!.pointee = TrustLevel(rawValue: 0)
+        return S_OK
+    },
+
+    get_Current: {
+        guard let __unwrapped__instance = __x_ABI_C__FIIterator_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let result = __unwrapped__instance.current
+        $1?.initialize(to: .init(from: result))
+        return S_OK
+    },
+
+    get_HasCurrent: {
+        guard let __unwrapped__instance = __x_ABI_C__FIIterator_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let result = __unwrapped__instance.hasCurrent
+        $1?.initialize(to: .init(from: result))
+        return S_OK
+    },
+
+    MoveNext: {
+        guard let __unwrapped__instance = __x_ABI_C__FIIterator_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let result = __unwrapped__instance.moveNext()
+        $1?.initialize(to: .init(from: result))
+        return S_OK
+    },
+
+    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+)
+typealias __x_ABI_C__FIIterator_1_GUIDWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1_GUIDBridge>
+internal class IIteratorUUID: test_component.IInspectable {
+    override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1_GUID }
+
+    internal func get_CurrentImpl() throws -> Foundation.UUID {
+        var result: test_component.GUID = .init()
+        _ = try perform(as: __x_ABI_C__FIIterator_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
+        }
+        return .init(from: result)
+    }
+
+    internal func get_HasCurrentImpl() throws -> Bool {
+        var result: boolean = 0
+        _ = try perform(as: __x_ABI_C__FIIterator_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
+        }
+        return .init(from: result)
+    }
+
+    internal func MoveNextImpl() throws -> Bool {
+        var result: boolean = 0
+        _ = try perform(as: __x_ABI_C__FIIterator_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
+        }
+        return .init(from: result)
+    }
+
+}
+
+internal enum __x_ABI_C__FIIterator_1_GUIDBridge : AbiInterfaceBridge {
+    internal typealias CABI = __x_ABI_C__FIIterator_1_GUID
+    internal typealias SwiftABI = IIteratorUUID
+    internal typealias SwiftProjection = AnyIIterator<Foundation.UUID>
+    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        guard let abi = abi else { return nil }
+        return __x_ABI_C__FIIterator_1_GUIDImpl(abi)
+    }
+
+    internal static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &__x_ABI_C__FIIterator_1_GUIDVTable) { $0 }
+        return .init(lpVtbl: vtblPtr)
+    }
+}
+
+fileprivate class __x_ABI_C__FIIterator_1_GUIDImpl : IIterator, AbiInterfaceImpl {
+    typealias T = Foundation.UUID
+    typealias Bridge = __x_ABI_C__FIIterator_1_GUIDBridge
+    let _default: Bridge.SwiftABI
+    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        _default = Bridge.SwiftABI(fromAbi)
+    }
+
+    // MARK: WinRT
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
+    fileprivate func moveNext() -> Bool {
+        try! _default.MoveNextImpl()
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
+    fileprivate var current : Foundation.UUID {
         get { try! _default.get_CurrentImpl() }
     }
 
@@ -4121,6 +4335,165 @@ fileprivate class __x_ABI_C__FIVectorView_1_IInspectableImpl : IVectorView, AbiI
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
 }
 
+private var IID___x_ABI_C__FIVectorView_1_GUID: test_component.IID {
+    .init(Data1: 0x9520e64b, Data2: 0x15b2, Data3: 0x52a6, Data4: ( 0x98,0xed,0x31,0x91,0xfa,0x6c,0xf6,0x8a ))// 9520e64b-15b2-52a6-98ed-3191fa6cf68a
+}
+
+internal var __x_ABI_C__FIVectorView_1_GUIDVTable: __x_ABI_C__FIVectorView_1_GUIDVtbl = .init(
+    QueryInterface: { __x_ABI_C__FIVectorView_1_GUIDWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FIVectorView_1_GUIDWrapper.addRef($0) },
+    Release: { __x_ABI_C__FIVectorView_1_GUIDWrapper.release($0) },
+    GetIids: {
+        let size = MemoryLayout<test_component.IID>.size
+        let iids = CoTaskMemAlloc(UInt64(size) * 4).assumingMemoryBound(to: test_component.IID.self)
+        iids[0] = IUnknown.IID
+        iids[1] = IInspectable.IID
+        iids[2] = test_component.__x_ABI_C__FIVectorView_1_GUIDWrapper.IID
+        iids[3] = test_component.__x_ABI_C__FIIterable_1_GUIDWrapper.IID
+        $1!.pointee = 4
+        $2!.pointee = iids
+        return S_OK
+    },
+
+    GetRuntimeClassName: {
+        _ = $0
+        let hstring = try! HString("Windows.Foundation.Collections.IVectorView`1<Foundation.UUID>").detach()
+        $1!.pointee = hstring
+        return S_OK
+    },
+
+    GetTrustLevel: {
+        _ = $0
+        $1!.pointee = TrustLevel(rawValue: 0)
+        return S_OK
+    },
+
+    GetAt: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVectorView_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let index: UInt32 = $1
+        let result = __unwrapped__instance.getAt(index)
+        $2?.initialize(to: .init(from: result))
+        return S_OK
+    },
+
+    get_Size: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVectorView_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let result = __unwrapped__instance.size
+        $1?.initialize(to: result)
+        return S_OK
+    },
+
+    IndexOf: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVectorView_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let value: Foundation.UUID = .init(from: $1)
+        var index: UInt32 = 0
+        let result = __unwrapped__instance.indexOf(value, &index)
+        $2?.initialize(to: index)
+        $3?.initialize(to: .init(from: result))
+        return S_OK
+    },
+
+    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+)
+typealias __x_ABI_C__FIVectorView_1_GUIDWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1_GUIDBridge>
+internal class IVectorViewUUID: test_component.IInspectable {
+    override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1_GUID }
+
+    internal func GetAtImpl(_ index: UInt32) throws -> Foundation.UUID {
+        var result: test_component.GUID = .init()
+        _ = try perform(as: __x_ABI_C__FIVectorView_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
+        }
+        return .init(from: result)
+    }
+
+    internal func get_SizeImpl() throws -> UInt32 {
+        var result: UINT32 = 0
+        _ = try perform(as: __x_ABI_C__FIVectorView_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
+        }
+        return result
+    }
+
+    internal func IndexOfImpl(_ value: Foundation.UUID, _ index: inout UInt32) throws -> Bool {
+        var result: boolean = 0
+        _ = try perform(as: __x_ABI_C__FIVectorView_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, .init(from: value), &index, &result))
+        }
+        return .init(from: result)
+    }
+
+}
+
+internal enum __x_ABI_C__FIVectorView_1_GUIDBridge : AbiInterfaceBridge {
+    internal typealias CABI = __x_ABI_C__FIVectorView_1_GUID
+    internal typealias SwiftABI = IVectorViewUUID
+    internal typealias SwiftProjection = AnyIVectorView<Foundation.UUID>
+    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        guard let abi = abi else { return nil }
+        return __x_ABI_C__FIVectorView_1_GUIDImpl(abi)
+    }
+
+    internal static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &__x_ABI_C__FIVectorView_1_GUIDVTable) { $0 }
+        return .init(lpVtbl: vtblPtr)
+    }
+}
+
+fileprivate class __x_ABI_C__FIVectorView_1_GUIDImpl : IVectorView, AbiInterfaceImpl {
+    typealias T = Foundation.UUID
+    typealias Bridge = __x_ABI_C__FIVectorView_1_GUIDBridge
+    let _default: Bridge.SwiftABI
+    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        _default = Bridge.SwiftABI(fromAbi)
+    }
+
+    // MARK: Collection
+    typealias Element = T
+    var startIndex: Int { 0 }
+    var endIndex: Int { Int(size) }
+    func index(after i: Int) -> Int {
+        i+1
+    }
+
+    func index(of: Element) -> Int? {
+        var index: UInt32 = 0
+        let result = indexOf(of, &index)
+        guard result else { return nil }
+        return Int(index)
+    }
+    var count: Int { Int(size) }
+
+    subscript(position: Int) -> Element {
+        get {
+            getAt(UInt32(position))
+        }
+    }
+    // MARK: WinRT
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
+    fileprivate func getAt(_ index: UInt32) -> Foundation.UUID {
+        try! _default.GetAtImpl(index)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
+    fileprivate func indexOf(_ value: Foundation.UUID, _ index: inout UInt32) -> Bool {
+        try! _default.IndexOfImpl(value, &index)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
+    fileprivate var size : UInt32 {
+        get { try! _default.get_SizeImpl() }
+    }
+
+    private lazy var _IIterable: IIterableUUID! = getInterfaceForCaching()
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
+    fileprivate func first() -> AnyIIterator<Foundation.UUID>? {
+        try! _IIterable.FirstImpl()
+    }
+
+    public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
+}
+
 private var IID___x_ABI_C__FIVectorView_1_HSTRING: test_component.IID {
     .init(Data1: 0x2f13c006, Data2: 0xa03a, Data3: 0x5f69, Data4: ( 0xb0,0x90,0x75,0xa4,0x3e,0x33,0x42,0x3e ))// 2f13c006-a03a-5f69-b090-75a43e33423e
 }
@@ -4908,6 +5281,306 @@ fileprivate class __x_ABI_C__FIVector_1_IInspectableImpl : IVector, AbiInterface
     private lazy var _IIterable: IIterableAny! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.first)
     fileprivate func first() -> AnyIIterator<Any?>? {
+        try! _IIterable.FirstImpl()
+    }
+
+    public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
+}
+
+private var IID___x_ABI_C__FIVector_1_GUID: test_component.IID {
+    .init(Data1: 0x482e676d, Data2: 0xb913, Data3: 0x5ec1, Data4: ( 0xaf,0xa8,0x5f,0x96,0x92,0x2e,0x94,0xae ))// 482e676d-b913-5ec1-afa8-5f96922e94ae
+}
+
+internal var __x_ABI_C__FIVector_1_GUIDVTable: __x_ABI_C__FIVector_1_GUIDVtbl = .init(
+    QueryInterface: { __x_ABI_C__FIVector_1_GUIDWrapper.queryInterface($0, $1, $2) },
+    AddRef: { __x_ABI_C__FIVector_1_GUIDWrapper.addRef($0) },
+    Release: { __x_ABI_C__FIVector_1_GUIDWrapper.release($0) },
+    GetIids: {
+        let size = MemoryLayout<test_component.IID>.size
+        let iids = CoTaskMemAlloc(UInt64(size) * 4).assumingMemoryBound(to: test_component.IID.self)
+        iids[0] = IUnknown.IID
+        iids[1] = IInspectable.IID
+        iids[2] = test_component.__x_ABI_C__FIVector_1_GUIDWrapper.IID
+        iids[3] = test_component.__x_ABI_C__FIIterable_1_GUIDWrapper.IID
+        $1!.pointee = 4
+        $2!.pointee = iids
+        return S_OK
+    },
+
+    GetRuntimeClassName: {
+        _ = $0
+        let hstring = try! HString("Windows.Foundation.Collections.IVector`1<Foundation.UUID>").detach()
+        $1!.pointee = hstring
+        return S_OK
+    },
+
+    GetTrustLevel: {
+        _ = $0
+        $1!.pointee = TrustLevel(rawValue: 0)
+        return S_OK
+    },
+
+    GetAt: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVector_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let index: UInt32 = $1
+        let result = __unwrapped__instance.getAt(index)
+        $2?.initialize(to: .init(from: result))
+        return S_OK
+    },
+
+    get_Size: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVector_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let result = __unwrapped__instance.size
+        $1?.initialize(to: result)
+        return S_OK
+    },
+
+    GetView: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVector_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let result = __unwrapped__instance.getView()
+        let resultWrapper = test_component.__x_ABI_C__FIVectorView_1_GUIDWrapper(result)
+        resultWrapper?.copyTo($1)
+        return S_OK
+    },
+
+    IndexOf: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVector_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let value: Foundation.UUID = .init(from: $1)
+        var index: UInt32 = 0
+        let result = __unwrapped__instance.indexOf(value, &index)
+        $2?.initialize(to: index)
+        $3?.initialize(to: .init(from: result))
+        return S_OK
+    },
+
+    SetAt: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVector_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let index: UInt32 = $1
+        let value: Foundation.UUID = .init(from: $2)
+        __unwrapped__instance.setAt(index, value)
+        return S_OK
+    },
+
+    InsertAt: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVector_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let index: UInt32 = $1
+        let value: Foundation.UUID = .init(from: $2)
+        __unwrapped__instance.insertAt(index, value)
+        return S_OK
+    },
+
+    RemoveAt: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVector_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let index: UInt32 = $1
+        __unwrapped__instance.removeAt(index)
+        return S_OK
+    },
+
+    Append: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVector_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        let value: Foundation.UUID = .init(from: $1)
+        __unwrapped__instance.append(value)
+        return S_OK
+    },
+
+    RemoveAtEnd: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVector_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        __unwrapped__instance.removeAtEnd()
+        return S_OK
+    },
+
+    Clear: {
+        guard let __unwrapped__instance = __x_ABI_C__FIVector_1_GUIDWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+        __unwrapped__instance.clear()
+        return S_OK
+    },
+
+    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) },
+
+    ReplaceAll: { _, _, _ in return failWith(err: E_NOTIMPL) }
+)
+typealias __x_ABI_C__FIVector_1_GUIDWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1_GUIDBridge>
+internal class IVectorUUID: test_component.IInspectable {
+    override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1_GUID }
+
+    internal func GetAtImpl(_ index: UInt32) throws -> Foundation.UUID {
+        var result: test_component.GUID = .init()
+        _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
+        }
+        return .init(from: result)
+    }
+
+    internal func get_SizeImpl() throws -> UInt32 {
+        var result: UINT32 = 0
+        _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
+        }
+        return result
+    }
+
+    internal func GetViewImpl() throws -> test_component.AnyIVectorView<Foundation.UUID>? {
+        let (result) = try ComPtrs.initialize { resultAbi in
+            _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
+            }
+        }
+        return test_component.__x_ABI_C__FIVectorView_1_GUIDWrapper.unwrapFrom(abi: result)
+    }
+
+    internal func IndexOfImpl(_ value: Foundation.UUID, _ index: inout UInt32) throws -> Bool {
+        var result: boolean = 0
+        _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, .init(from: value), &index, &result))
+        }
+        return .init(from: result)
+    }
+
+    internal func SetAtImpl(_ index: UInt32, _ value: Foundation.UUID) throws {
+        _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.SetAt(pThis, index, .init(from: value)))
+        }
+    }
+
+    internal func InsertAtImpl(_ index: UInt32, _ value: Foundation.UUID) throws {
+        _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.InsertAt(pThis, index, .init(from: value)))
+        }
+    }
+
+    internal func RemoveAtImpl(_ index: UInt32) throws {
+        _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
+        }
+    }
+
+    internal func AppendImpl(_ value: Foundation.UUID) throws {
+        _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Append(pThis, .init(from: value)))
+        }
+    }
+
+    internal func RemoveAtEndImpl() throws {
+        _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
+        }
+    }
+
+    internal func ClearImpl() throws {
+        _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
+        }
+    }
+
+}
+
+internal enum __x_ABI_C__FIVector_1_GUIDBridge : AbiInterfaceBridge {
+    internal typealias CABI = __x_ABI_C__FIVector_1_GUID
+    internal typealias SwiftABI = IVectorUUID
+    internal typealias SwiftProjection = AnyIVector<Foundation.UUID>
+    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        guard let abi = abi else { return nil }
+        return __x_ABI_C__FIVector_1_GUIDImpl(abi)
+    }
+
+    internal static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &__x_ABI_C__FIVector_1_GUIDVTable) { $0 }
+        return .init(lpVtbl: vtblPtr)
+    }
+}
+
+fileprivate class __x_ABI_C__FIVector_1_GUIDImpl : IVector, AbiInterfaceImpl {
+    typealias T = Foundation.UUID
+    typealias Bridge = __x_ABI_C__FIVector_1_GUIDBridge
+    let _default: Bridge.SwiftABI
+    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        _default = Bridge.SwiftABI(fromAbi)
+    }
+
+    // MARK: Collection
+    typealias Element = T
+    var startIndex: Int { 0 }
+    var endIndex: Int { Int(size) }
+    func index(after i: Int) -> Int {
+        i+1
+    }
+
+    func index(of: Element) -> Int? {
+        var index: UInt32 = 0
+        let result = indexOf(of, &index)
+        guard result else { return nil }
+        return Int(index)
+    }
+    var count: Int { Int(size) }
+
+
+    subscript(position: Int) -> Element {
+        get {
+            getAt(UInt32(position))
+        }
+        set(newValue) {
+            setAt(UInt32(position), newValue)
+        }
+    }
+
+    func removeLast() {
+        removeAtEnd()
+    }
+
+    // MARK: WinRT
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getat)
+    fileprivate func getAt(_ index: UInt32) -> Foundation.UUID {
+        try! _default.GetAtImpl(index)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getview)
+    fileprivate func getView() -> AnyIVectorView<Foundation.UUID>? {
+        try! _default.GetViewImpl()
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.indexof)
+    fileprivate func indexOf(_ value: Foundation.UUID, _ index: inout UInt32) -> Bool {
+        try! _default.IndexOfImpl(value, &index)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.setat)
+    fileprivate func setAt(_ index: UInt32, _ value: Foundation.UUID) {
+        try! _default.SetAtImpl(index, value)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.insertat)
+    fileprivate func insertAt(_ index: UInt32, _ value: Foundation.UUID) {
+        try! _default.InsertAtImpl(index, value)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeat)
+    fileprivate func removeAt(_ index: UInt32) {
+        try! _default.RemoveAtImpl(index)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.append)
+    fileprivate func append(_ value: Foundation.UUID) {
+        try! _default.AppendImpl(value)
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeatend)
+    fileprivate func removeAtEnd() {
+        try! _default.RemoveAtEndImpl()
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.clear)
+    fileprivate func clear() {
+        try! _default.ClearImpl()
+    }
+
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
+    fileprivate var size : UInt32 {
+        get { try! _default.get_SizeImpl() }
+    }
+
+    private lazy var _IIterable: IIterableUUID! = getInterfaceForCaching()
+    /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.first)
+    fileprivate func first() -> AnyIIterator<Foundation.UUID>? {
         try! _IIterable.FirstImpl()
     }
 

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -293,6 +293,35 @@ public enum __IMPL_test_component {
 
     }
 
+    public enum WithIterableGuidsBridge : AbiInterfaceBridge {
+        public typealias CABI = __x_ABI_Ctest__component_CWithIterableGuids
+        public typealias SwiftABI = __ABI_test_component.WithIterableGuids
+        public typealias SwiftProjection = AnyWithIterableGuids
+        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+            guard let abi = abi else { return nil }
+            return WithIterableGuidsImpl(abi)
+        }
+
+        public static func makeAbi() -> CABI {
+            let vtblPtr = withUnsafeMutablePointer(to: &__ABI_test_component.WithIterableGuidsVTable) { $0 }
+            return .init(lpVtbl: vtblPtr)
+        }
+    }
+
+    fileprivate class WithIterableGuidsImpl: WithIterableGuids, WinRTAbiImpl {
+        fileprivate typealias Bridge = WithIterableGuidsBridge
+        fileprivate let _default: Bridge.SwiftABI
+        fileprivate var thisPtr: test_component.IInspectable { _default }
+        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+            _default = Bridge.SwiftABI(fromAbi)
+        }
+
+        fileprivate func ids() throws -> AnyIVector<Foundation.UUID>! {
+            try _default.IDsImpl()
+        }
+
+    }
+
     public enum WithKeywordBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_Ctest__component_CWithKeyword
         public typealias SwiftABI = __ABI_test_component.WithKeyword

--- a/tests/test_component/Sources/test_component/test_component+MakeFromAbi.swift
+++ b/tests/test_component/Sources/test_component/test_component+MakeFromAbi.swift
@@ -68,6 +68,11 @@ fileprivate func makeInterfaceWithReturnDelegateFrom(abi: test_component.IInspec
     return __IMPL_test_component.InterfaceWithReturnDelegateBridge.from(abi: RawPointer(swiftAbi))!
 }
 
+fileprivate func makeWithIterableGuidsFrom(abi: test_component.IInspectable) -> Any {
+    let swiftAbi: __ABI_test_component.WithIterableGuids = try! abi.QueryInterface()
+    return __IMPL_test_component.WithIterableGuidsBridge.from(abi: RawPointer(swiftAbi))!
+}
+
 fileprivate func makeWithKeywordFrom(abi: test_component.IInspectable) -> Any {
     let swiftAbi: __ABI_test_component.WithKeyword = try! abi.QueryInterface()
     return __IMPL_test_component.WithKeywordBridge.from(abi: RawPointer(swiftAbi))!
@@ -182,6 +187,7 @@ public class __MakeFromAbi: MakeFromAbi {
             case "IInterfaceWithObservableVector": return makeIInterfaceWithObservableVectorFrom(abi: abi)
             case "ISimpleDelegate": return makeISimpleDelegateFrom(abi: abi)
             case "InterfaceWithReturnDelegate": return makeInterfaceWithReturnDelegateFrom(abi: abi)
+            case "WithIterableGuids": return makeWithIterableGuidsFrom(abi: abi)
             case "WithKeyword": return makeWithKeywordFrom(abi: abi)
             case "Deferral": return makeDeferralFrom(abi: abi)
             case "PropertySet": return makePropertySetFrom(abi: abi)

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -1848,6 +1848,22 @@ extension InterfaceWithReturnDelegate {
 }
 public typealias AnyInterfaceWithReturnDelegate = any InterfaceWithReturnDelegate
 
+public protocol WithIterableGuids : WinRTInterface {
+    func ids() throws -> test_component.AnyIVector<Foundation.UUID>!
+}
+
+extension WithIterableGuids {
+    public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? {
+        switch iid {
+            case __ABI_test_component.WithIterableGuidsWrapper.IID:
+                let wrapper = __ABI_test_component.WithIterableGuidsWrapper(self)
+                return wrapper!.queryInterface(iid)
+            default: return nil
+        }
+    }
+}
+public typealias AnyWithIterableGuids = any WithIterableGuids
+
 public protocol WithKeyword : WinRTInterface {
     func `enum`(_ `extension`: String) throws
     var `struct`: String { get set }

--- a/tests/test_component/cpp/CollectionTester.idl
+++ b/tests/test_component/cpp/CollectionTester.idl
@@ -18,4 +18,9 @@ namespace test_component
         Windows.Foundation.Collections.IVector<String> ReturnStoredStringVector();
         Windows.Foundation.Collections.IMap<String, String> ReturnMapFromStringToString();
     }
+
+    interface WithIterableGuids
+    {
+        Windows.Foundation.Collections.IVector<Guid> IDs();
+    }
 }


### PR DESCRIPTION
in #134 I missed a case in `type_writers.cpp` where we were no longer writing the full GUID name.

also added some cleaning up around checking for the GUID type so things aren't done by string checking which was broken inadvertently