### PR TITLE
fix nuget upload to nuget.org

### DIFF
--- a/nuget/swiftwinrt.nuspec
+++ b/nuget/swiftwinrt.nuspec
@@ -12,9 +12,9 @@
     <tags>swift WinRT</tags>
     <copyright>© The Browser Company of New York. All rights reserved.</copyright>
     <projectUrl>https://github.com/thebrowsercompany/swiftwinrt</projectUrl>
-    <repository type="git" url="https://github.com/thebrowsercompany/swiftwinrt"/>
+    <repository type="git" url="https://github.com/thebrowsercompany/swift-winrt"/>
     <license type="expression">BSD-3-Clause</license>
-    <readme>readme.md</readme>
+    <readme>README.md</readme>
   </metadata>
   <files>
     <file src="$swiftwinrt_exe$" target="bin"/>

--- a/nuget/swiftwinrt.nuspec
+++ b/nuget/swiftwinrt.nuspec
@@ -11,7 +11,7 @@
     <releaseNotes></releaseNotes>
     <tags>swift WinRT</tags>
     <copyright>© The Browser Company of New York. All rights reserved.</copyright>
-    <projectUrl>https://github.com/thebrowsercompany/swiftwinrt</projectUrl>
+    <projectUrl>https://github.com/thebrowsercompany/swift-winrt</projectUrl>
     <repository type="git" url="https://github.com/thebrowsercompany/swift-winrt"/>
     <license type="expression">BSD-3-Clause</license>
     <readme>README.md</readme>


### PR DESCRIPTION
nuget upload is failing with the following error:

`Response status code does not indicate success: 400 (The readme file 'readme.md' does not exist in the package.).`

this must be due to the casing of the README.md file...very odd

also fixed up the project url while here