### PR TITLE
fixes for Win2D to build

### DIFF
--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -2318,6 +2318,7 @@ public init<Composable: ComposableImpl>(
             {
                 name_to_write = interface_name.substr(0, interface_name.find_first_of('<'));
             }
+            w.add_depends(*info.type);
             w.write(name_to_write);
         }
 

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -1000,6 +1000,7 @@ bind_bridge_fullname(type));
     static std::string modifier_for(typedef_base const& type_definition, interface_info const& iface, member_type member_type = member_type::property_or_method);
     static void write_interface_impl_members(writer& w, interface_info const& info, typedef_base const& type_definition)
     {
+        w.add_depends(type_definition);
         bool is_class = swiftwinrt::is_class(&type_definition);
 
         if (!info.is_default || (!is_class && info.base))
@@ -2056,7 +2057,8 @@ public init<Composable: ComposableImpl>(
     static std::string modifier_for(typedef_base const& type_definition, interface_info const& iface, member_type member)
     {
         std::string modifier;
-        const bool isClass = is_class(&type_definition);
+        auto classType = dynamic_cast<const class_type*>(&type_definition);
+        const bool isClass = classType != nullptr;
         if (isClass)
         {
             if (iface.overridable)
@@ -2073,7 +2075,7 @@ public init<Composable: ComposableImpl>(
             modifier = "fileprivate ";
         }
 
-        if (iface.attributed && isClass && member == member_type::property_or_method)
+        if (iface.attributed && isClass && classType->is_composable() && member == member_type::property_or_method)
         {
             modifier.append("class ");
         }

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -1000,7 +1000,7 @@ bind_bridge_fullname(type));
     static std::string modifier_for(typedef_base const& type_definition, interface_info const& iface, member_type member_type = member_type::property_or_method);
     static void write_interface_impl_members(writer& w, interface_info const& info, typedef_base const& type_definition)
     {
-        w.add_depends(type_definition);
+        w.add_depends(*info.type);
         bool is_class = swiftwinrt::is_class(&type_definition);
 
         if (!info.is_default || (!is_class && info.base))

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -991,6 +991,13 @@ bind_bridge_fullname(type));
         w.write("// MARK: WinRT\n");
     }
 
+    enum class member_type
+    {
+        property_or_method,
+        event
+    };
+
+    static std::string modifier_for(typedef_base const& type_definition, interface_info const& iface, member_type member_type = member_type::property_or_method);
     static void write_interface_impl_members(writer& w, interface_info const& info, typedef_base const& type_definition)
     {
         bool is_class = swiftwinrt::is_class(&type_definition);
@@ -1742,6 +1749,90 @@ vtable);
         }
     }
 
+    static bool derives_from(class_type const& base, class_type const& derived)
+    {
+        class_type const* checking = &derived;
+        while (checking != nullptr)
+        {
+            if (checking->base_class == &base)
+            {
+                return true;
+            }
+            checking = checking->base_class;
+        }
+        return false;
+    }
+
+    static bool base_matches(function_def const& base, function_def const& derived)
+    {
+        // Simple cases of name/param count/has return not matching
+        if (base.def.Name() != derived.def.Name()) return false;
+        if (base.return_type.has_value() != derived.return_type.has_value()) return false;
+        if (base.params.size() != derived.params.size()) return false;
+
+        // If they both have a return value, we need to check if the return values
+        // are derived from each other. If you have two functions like this:
+        //   (A.swift) class func make() -> A
+        //   (B.swift) class func make() -> B
+        // Then these would "match" according to the swift compiler
+        if (base.return_type.has_value())
+        {
+            auto base_return = base.return_type.value().type;
+            auto derived_return = derived.return_type.value().type;
+            if (base_return != derived_return)
+            {
+                // Check if the types are derived
+                auto base_return_class = dynamic_cast<const class_type*>(base_return);
+                auto derived_return_class = dynamic_cast<const class_type*>(derived_return);
+                if (base_return_class != nullptr && derived_return_class != nullptr)
+                {
+                    if (!derives_from(*base_return_class, *derived_return_class))
+                    {
+                        // Return types aren't a possible match, return false
+                        return false;
+                    }
+                }
+            }
+        }
+
+        size_t i = 0;
+        while (i < base.params.size())
+        {
+            if (base.params[i].type != derived.params[i].type)
+            {
+                // param doesn't match
+                return false;
+            }
+            ++i;
+        }
+        return true;
+    }
+
+    static bool base_has_matching_static_function(class_type const& type, attributed_type const& factory, function_def const& func)
+    {
+        if (type.base_class == nullptr)
+        {
+            return false;
+        }
+
+        for (const auto& [_, baseFactory] : type.base_class->factories)
+        {
+            // only look at statics
+            if (!baseFactory.statics) continue;
+            if (auto factoryIface = dynamic_cast<const interface_type*>(baseFactory.type))
+            {
+                for (const auto& baseMethod : factoryIface->functions)
+                {
+                    if (base_matches(baseMethod, func))
+                    {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
     static bool base_has_matching_constructor(class_type const& type, attributed_type const& factory, function_def const& func)
     {
         auto projectedParams = get_projected_params(factory, func);
@@ -1962,10 +2053,11 @@ public init<Composable: ComposableImpl>(
             bind<write_implementation_args>(function));
     }
 
-    static std::string modifier_for(typedef_base const& type_definition, interface_info const& iface)
+    static std::string modifier_for(typedef_base const& type_definition, interface_info const& iface, member_type member)
     {
         std::string modifier;
-        if (is_class(&type_definition))
+        const bool isClass = is_class(&type_definition);
+        if (isClass)
         {
             if (iface.overridable)
             {
@@ -1981,13 +2073,33 @@ public init<Composable: ComposableImpl>(
             modifier = "fileprivate ";
         }
 
-        if (iface.attributed)
+        if (iface.attributed && isClass && member == member_type::property_or_method)
+        {
+            modifier.append("class ");
+        }
+        else if (iface.attributed)
         {
             modifier.append("static ");
         }
 
         return modifier;
     }
+
+    static std::string modifier_for(typedef_base const& type_definition, attributed_type const& attributedType, function_def const& func)
+    {
+        interface_info info { attributedType.type };
+        info.attributed = true;
+        auto modifier = modifier_for(type_definition, info);
+        if (auto classType = dynamic_cast<const class_type*>(&type_definition))
+        {
+            if (base_has_matching_static_function(*classType, attributedType, func))
+            {
+                modifier.insert(0, "override ");
+            }
+        }
+        return modifier;
+    }
+
 
     static void write_class_impl_property(writer& w, property_def const& prop, interface_info const& iface, typedef_base const& type_definition)
     {
@@ -2084,7 +2196,7 @@ public init<Composable: ComposableImpl>(
             guard = w.push_generic_params(*genericInst);
         }
 
-        auto modifier = modifier_for(type_definition, iface);
+        auto modifier = modifier_for(type_definition, iface, member_type::event);
         if (!iface.attributed)
         {
             modifier.append("lazy ");
@@ -2138,7 +2250,7 @@ public init<Composable: ComposableImpl>(
 
                 write_documentation_comment(w, type, method.def.Name());
                 w.write("%func %(%)% {\n",
-                    modifier_for(type, static_info),
+                    modifier_for(type, statics, method),
                     get_swift_name(method),
                     bind<write_function_params>(method, write_type_params::swift_allow_implicit_unwrap),
                     bind<write_return_type_declaration>(method, write_type_params::swift_allow_implicit_unwrap));

--- a/swiftwinrt/code_writers/common_writers.h
+++ b/swiftwinrt/code_writers/common_writers.h
@@ -40,6 +40,7 @@ namespace swiftwinrt
     template<typename T>
     inline void write_generic_impl_name_base(writer& w, T const& type)
     {
+        w.add_depends(type);
         std::string implName = w.write_temp("%", bind_type_mangled(type));
         if (w.impl_names)
         {
@@ -79,6 +80,7 @@ namespace swiftwinrt
     template<typename T>
     inline void write_impl_name_base(writer& w, T const& type)
     {
+        w.add_depends(type);
         type_name type_name{ type };
         std::string implName = w.write_temp("%", type_name.name);
 

--- a/swiftwinrt/helpers.h
+++ b/swiftwinrt/helpers.h
@@ -565,6 +565,7 @@ namespace swiftwinrt
             "self",
             "static",
             "struct",
+            "subscript",
             "super",
             "switch",
             "throw",

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -2448,15 +2448,16 @@ enum __x_ABI_Ctest__component_CKeywords
     __x_ABI_Ctest__component_CKeywords_Self = 29,
     __x_ABI_Ctest__component_CKeywords_Static = 30,
     __x_ABI_Ctest__component_CKeywords_Struct = 31,
-    __x_ABI_Ctest__component_CKeywords_Super = 32,
-    __x_ABI_Ctest__component_CKeywords_Switch = 33,
-    __x_ABI_Ctest__component_CKeywords_Throw = 34,
-    __x_ABI_Ctest__component_CKeywords_Throws = 35,
-    __x_ABI_Ctest__component_CKeywords_True = 36,
-    __x_ABI_Ctest__component_CKeywords_Try = 37,
-    __x_ABI_Ctest__component_CKeywords_Var = 38,
-    __x_ABI_Ctest__component_CKeywords_Where = 39,
-    __x_ABI_Ctest__component_CKeywords_While = 40,
+    __x_ABI_Ctest__component_CKeywords_Subscript = 32,
+    __x_ABI_Ctest__component_CKeywords_Super = 33,
+    __x_ABI_Ctest__component_CKeywords_Switch = 34,
+    __x_ABI_Ctest__component_CKeywords_Throw = 35,
+    __x_ABI_Ctest__component_CKeywords_Throws = 36,
+    __x_ABI_Ctest__component_CKeywords_True = 37,
+    __x_ABI_Ctest__component_CKeywords_Try = 38,
+    __x_ABI_Ctest__component_CKeywords_Var = 39,
+    __x_ABI_Ctest__component_CKeywords_Where = 40,
+    __x_ABI_Ctest__component_CKeywords_While = 41,
 };
 
 enum __x_ABI_Ctest__component_CSigned
@@ -4494,6 +4495,7 @@ struct __x_ABI_Ctest__component_CStructWithIReference
         EventRegistrationToken* token);
     HRESULT (STDMETHODCALLTYPE* remove_Repeat)(__x_ABI_Ctest__component_CWithKeyword* This,
         EventRegistrationToken token);
+    HRESULT (STDMETHODCALLTYPE* Subscript)(__x_ABI_Ctest__component_CWithKeyword* This);
 
         END_INTERFACE
     } __x_ABI_Ctest__component_CWithKeywordVtbl;

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -65,6 +65,12 @@ typedef interface __x_ABI_Ctest__component_CIVoidToVoidDelegate __x_ABI_Ctest__c
 
 #endif // ____x_ABI_Ctest__component_CIBaseNoOverridesProtectedFactory_FWD_DEFINED__
 
+#ifndef ____x_ABI_Ctest__component_CIBaseNoOverridesStatics_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CIBaseNoOverridesStatics_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CIBaseNoOverridesStatics __x_ABI_Ctest__component_CIBaseNoOverridesStatics;
+
+#endif // ____x_ABI_Ctest__component_CIBaseNoOverridesStatics_FWD_DEFINED__
+
 #ifndef ____x_ABI_Ctest__component_CIBaseOverrides_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CIBaseOverrides_FWD_DEFINED__
     typedef interface __x_ABI_Ctest__component_CIBaseOverrides __x_ABI_Ctest__component_CIBaseOverrides;
@@ -76,6 +82,12 @@ typedef interface __x_ABI_Ctest__component_CIVoidToVoidDelegate __x_ABI_Ctest__c
     typedef interface __x_ABI_Ctest__component_CIBaseProtectedFactory __x_ABI_Ctest__component_CIBaseProtectedFactory;
 
 #endif // ____x_ABI_Ctest__component_CIBaseProtectedFactory_FWD_DEFINED__
+
+#ifndef ____x_ABI_Ctest__component_CIBaseStatics_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CIBaseStatics_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CIBaseStatics __x_ABI_Ctest__component_CIBaseStatics;
+
+#endif // ____x_ABI_Ctest__component_CIBaseStatics_FWD_DEFINED__
 
 #ifndef ____x_ABI_Ctest__component_CIBasic_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CIBasic_FWD_DEFINED__
@@ -142,6 +154,12 @@ typedef interface __x_ABI_Ctest__component_CIVoidToVoidDelegate __x_ABI_Ctest__c
     typedef interface __x_ABI_Ctest__component_CIDerivedFromNoConstructor __x_ABI_Ctest__component_CIDerivedFromNoConstructor;
 
 #endif // ____x_ABI_Ctest__component_CIDerivedFromNoConstructor_FWD_DEFINED__
+
+#ifndef ____x_ABI_Ctest__component_CIDerivedStatics_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CIDerivedStatics_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CIDerivedStatics __x_ABI_Ctest__component_CIDerivedStatics;
+
+#endif // ____x_ABI_Ctest__component_CIDerivedStatics_FWD_DEFINED__
 
 #ifndef ____x_ABI_Ctest__component_CIEventTester_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CIEventTester_FWD_DEFINED__
@@ -2795,6 +2813,40 @@ struct __x_ABI_Ctest__component_CStructWithIReference
     EXTERN_C const IID IID___x_ABI_Ctest__component_CIBaseNoOverridesProtectedFactory;
 #endif /* !defined(____x_ABI_Ctest__component_CIBaseNoOverridesProtectedFactory_INTERFACE_DEFINED__) */
     
+#if !defined(____x_ABI_Ctest__component_CIBaseNoOverridesStatics_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CIBaseNoOverridesStatics_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CIBaseNoOverridesStaticsVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIBaseNoOverridesStatics* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIBaseNoOverridesStatics* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIBaseNoOverridesStatics* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIBaseNoOverridesStatics* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIBaseNoOverridesStatics* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIBaseNoOverridesStatics* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* CreateFromString)(__x_ABI_Ctest__component_CIBaseNoOverridesStatics* This,
+        HSTRING value,
+        __x_ABI_Ctest__component_CIBaseNoOverrides** result);
+
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CIBaseNoOverridesStaticsVtbl;
+
+    interface __x_ABI_Ctest__component_CIBaseNoOverridesStatics
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CIBaseNoOverridesStaticsVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CIBaseNoOverridesStatics;
+#endif /* !defined(____x_ABI_Ctest__component_CIBaseNoOverridesStatics_INTERFACE_DEFINED__) */
+    
 #if !defined(____x_ABI_Ctest__component_CIBaseOverrides_INTERFACE_DEFINED__)
     #define ____x_ABI_Ctest__component_CIBaseOverrides_INTERFACE_DEFINED__
     typedef struct __x_ABI_Ctest__component_CIBaseOverridesVtbl
@@ -2861,6 +2913,40 @@ struct __x_ABI_Ctest__component_CStructWithIReference
     
     EXTERN_C const IID IID___x_ABI_Ctest__component_CIBaseProtectedFactory;
 #endif /* !defined(____x_ABI_Ctest__component_CIBaseProtectedFactory_INTERFACE_DEFINED__) */
+    
+#if !defined(____x_ABI_Ctest__component_CIBaseStatics_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CIBaseStatics_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CIBaseStaticsVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIBaseStatics* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIBaseStatics* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIBaseStatics* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIBaseStatics* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIBaseStatics* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIBaseStatics* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* CreateFromString)(__x_ABI_Ctest__component_CIBaseStatics* This,
+        HSTRING value,
+        __x_ABI_Ctest__component_CIBase** result);
+
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CIBaseStaticsVtbl;
+
+    interface __x_ABI_Ctest__component_CIBaseStatics
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CIBaseStaticsVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CIBaseStatics;
+#endif /* !defined(____x_ABI_Ctest__component_CIBaseStatics_INTERFACE_DEFINED__) */
     
 #if !defined(____x_ABI_Ctest__component_CIBasic_INTERFACE_DEFINED__)
     #define ____x_ABI_Ctest__component_CIBasic_INTERFACE_DEFINED__
@@ -3368,6 +3454,40 @@ struct __x_ABI_Ctest__component_CStructWithIReference
     
     EXTERN_C const IID IID___x_ABI_Ctest__component_CIDerivedFromNoConstructor;
 #endif /* !defined(____x_ABI_Ctest__component_CIDerivedFromNoConstructor_INTERFACE_DEFINED__) */
+    
+#if !defined(____x_ABI_Ctest__component_CIDerivedStatics_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CIDerivedStatics_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CIDerivedStaticsVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIDerivedStatics* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIDerivedStatics* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIDerivedStatics* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIDerivedStatics* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIDerivedStatics* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIDerivedStatics* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* CreateFromString)(__x_ABI_Ctest__component_CIDerivedStatics* This,
+        HSTRING value,
+        __x_ABI_Ctest__component_CIDerived** result);
+
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CIDerivedStaticsVtbl;
+
+    interface __x_ABI_Ctest__component_CIDerivedStatics
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CIDerivedStaticsVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CIDerivedStatics;
+#endif /* !defined(____x_ABI_Ctest__component_CIDerivedStatics_INTERFACE_DEFINED__) */
     
 #if !defined(____x_ABI_Ctest__component_CIEventTester_INTERFACE_DEFINED__)
     #define ____x_ABI_Ctest__component_CIEventTester_INTERFACE_DEFINED__

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -31,12 +31,20 @@ private var IID___x_ABI_Ctest__component_CIBaseNoOverridesProtectedFactory: test
     .init(Data1: 0x92FC0572, Data2: 0x825F, Data3: 0x5B3F, Data4: ( 0x9B,0x0B,0xF0,0x80,0xA1,0x66,0xEF,0x06 ))// 92FC0572-825F-5B3F-9B0B-F080A166EF06
 }
 
+private var IID___x_ABI_Ctest__component_CIBaseNoOverridesStatics: test_component.IID {
+    .init(Data1: 0xCC810B5D, Data2: 0x97FC, Data3: 0x5B35, Data4: ( 0xAE,0xEA,0xA4,0x7F,0x5F,0x58,0x06,0xF7 ))// CC810B5D-97FC-5B35-AEEA-A47F5F5806F7
+}
+
 private var IID___x_ABI_Ctest__component_CIBaseOverrides: test_component.IID {
     .init(Data1: 0xEE3CBD78, Data2: 0x04B7, Data3: 0x534F, Data4: ( 0xA7,0x15,0x53,0xDA,0xF5,0x35,0x01,0x3C ))// EE3CBD78-04B7-534F-A715-53DAF535013C
 }
 
 private var IID___x_ABI_Ctest__component_CIBaseProtectedFactory: test_component.IID {
     .init(Data1: 0x05CAD233, Data2: 0x20A7, Data3: 0x581F, Data4: ( 0xBD,0x44,0x0D,0x13,0x6C,0x31,0x0E,0x0F ))// 05CAD233-20A7-581F-BD44-0D136C310E0F
+}
+
+private var IID___x_ABI_Ctest__component_CIBaseStatics: test_component.IID {
+    .init(Data1: 0x9E36C560, Data2: 0xE3AE, Data3: 0x55DF, Data4: ( 0xBA,0x41,0x6B,0xB5,0x47,0xA2,0x81,0x65 ))// 9E36C560-E3AE-55DF-BA41-6BB547A28165
 }
 
 private var IID___x_ABI_Ctest__component_CIBasic: test_component.IID {
@@ -81,6 +89,10 @@ private var IID___x_ABI_Ctest__component_CIDerived: test_component.IID {
 
 private var IID___x_ABI_Ctest__component_CIDerivedFromNoConstructor: test_component.IID {
     .init(Data1: 0x2A9D928D, Data2: 0xAD55, Data3: 0x59EC, Data4: ( 0x9B,0x73,0xE2,0xED,0x06,0x57,0xE6,0xC4 ))// 2A9D928D-AD55-59EC-9B73-E2ED0657E6C4
+}
+
+private var IID___x_ABI_Ctest__component_CIDerivedStatics: test_component.IID {
+    .init(Data1: 0x5DE6D589, Data2: 0x61EC, Data3: 0x5020, Data4: ( 0x80,0x3A,0x3E,0x62,0x6C,0x8B,0xBC,0x8E ))// 5DE6D589-61EC-5020-803A-3E626C8BBC8E
 }
 
 private var IID___x_ABI_Ctest__component_CIEventTester: test_component.IID {
@@ -400,6 +412,21 @@ public enum __ABI_test_component {
 
     }
 
+    public class IBaseNoOverridesStatics: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseNoOverridesStatics }
+
+        internal func CreateFromStringImpl(_ value: String) throws -> test_component.BaseNoOverrides? {
+            let (result) = try ComPtrs.initialize { resultAbi in
+                let _value = try! HString(value)
+                _ = try perform(as: __x_ABI_Ctest__component_CIBaseNoOverridesStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFromString(pThis, _value.get(), &resultAbi))
+                }
+            }
+            return .from(abi: result)
+        }
+
+    }
+
     public class IBaseOverrides: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseOverrides }
 
@@ -425,6 +452,21 @@ public enum __ABI_test_component {
                 innerInterface = test_component.IInspectable(_innerInterface!)
             }
             return IBase(value!)
+        }
+
+    }
+
+    public class IBaseStatics: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseStatics }
+
+        internal func CreateFromStringImpl(_ value: String) throws -> test_component.Base? {
+            let (result) = try ComPtrs.initialize { resultAbi in
+                let _value = try! HString(value)
+                _ = try perform(as: __x_ABI_Ctest__component_CIBaseStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFromString(pThis, _value.get(), &resultAbi))
+                }
+            }
+            return .from(abi: result)
         }
 
     }
@@ -1061,6 +1103,21 @@ public enum __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIDerivedFromNoConstructor.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Method(pThis))
             }
+        }
+
+    }
+
+    public class IDerivedStatics: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIDerivedStatics }
+
+        internal func CreateFromStringImpl(_ value: String) throws -> test_component.Derived? {
+            let (result) = try ComPtrs.initialize { resultAbi in
+                let _value = try! HString(value)
+                _ = try perform(as: __x_ABI_Ctest__component_CIDerivedStatics.self) { pThis in
+                    try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFromString(pThis, _value.get(), &resultAbi))
+                }
+            }
+            return .from(abi: result)
         }
 
     }

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -196,7 +196,7 @@ private var IID___x_ABI_Ctest__component_CWithIterableGuids: test_component.IID 
 }
 
 private var IID___x_ABI_Ctest__component_CWithKeyword: test_component.IID {
-    .init(Data1: 0x77E9FBAD, Data2: 0x3DCE, Data3: 0x5E50, Data4: ( 0xB4,0x39,0x91,0x91,0xF5,0x23,0x2A,0x84 ))// 77E9FBAD-3DCE-5E50-B439-9191F5232A84
+    .init(Data1: 0x18D4C535, Data2: 0x1785, Data3: 0x52CA, Data4: ( 0x88,0x51,0x8C,0xF3,0xD5,0x15,0x70,0x8A ))// 18D4C535-1785-52CA-8851-8CF3D515708A
 }
 
 private var IID___x_ABI_Ctest__component_CIObjectHandler: test_component.IID {
@@ -2371,6 +2371,12 @@ public enum __ABI_test_component {
             }
         }
 
+        open func SubscriptImpl() throws {
+            _ = try perform(as: __x_ABI_Ctest__component_CWithKeyword.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.Subscript(pThis))
+            }
+        }
+
     }
 
     internal static var WithKeywordVTable: __x_ABI_Ctest__component_CWithKeywordVtbl = .init(
@@ -2437,6 +2443,14 @@ public enum __ABI_test_component {
             let token: EventRegistrationToken = $1
             __unwrapped__instance.`repeat`.removeHandler(token)
             return S_OK
+        },
+
+        Subscript: {
+            do {
+                guard let __unwrapped__instance = WithKeywordWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+                try __unwrapped__instance.`subscript`()
+                return S_OK
+            } catch { return failWith(err: E_FAIL) } 
         }
     )
 

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -349,6 +349,10 @@ public enum __IMPL_test_component {
             try _default.EnumImpl(`extension`)
         }
 
+        fileprivate func `subscript`() throws {
+            try _default.SubscriptImpl()
+        }
+
         fileprivate var `struct` : String {
             get { try! _default.get_StructImpl() }
             set { try! _default.put_StructImpl(newValue) }

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -10,15 +10,15 @@ public typealias SwiftifiableNames = __x_ABI_Ctest__component_CSwiftifiableNames
 public typealias Unsigned = __x_ABI_Ctest__component_CUnsigned
 public final class AsyncMethods {
     private static let _IAsyncMethodsStatics: __ABI_test_component.IAsyncMethodsStatics = try! RoGetActivationFactory(HString("test_component.AsyncMethods"))
-    public static func getCompletedAsync(_ result: Int32) -> AnyIAsyncOperation<Int32>! {
+    public class func getCompletedAsync(_ result: Int32) -> AnyIAsyncOperation<Int32>! {
         return try! _IAsyncMethodsStatics.GetCompletedAsyncImpl(result)
     }
 
-    public static func getCompletedWithErrorAsync(_ errorCode: HRESULT) -> AnyIAsyncOperation<Int32>! {
+    public class func getCompletedWithErrorAsync(_ errorCode: HRESULT) -> AnyIAsyncOperation<Int32>! {
         return try! _IAsyncMethodsStatics.GetCompletedWithErrorAsyncImpl(errorCode)
     }
 
-    public static func getPendingAsync() -> AsyncOperationInt! {
+    public class func getPendingAsync() -> AsyncOperationInt! {
         return try! _IAsyncMethodsStatics.GetPendingAsyncImpl()
     }
 
@@ -143,6 +143,11 @@ open class Base : WinRTClass {
         MakeComposed(composing: Self.Composable.self, self) { baseInterface, innerInterface in 
             try! Self._IBaseProtectedFactory.CreateInstanceImpl(baseInterface, &innerInterface)
         }
+    }
+
+    private static let _IBaseStatics: __ABI_test_component.IBaseStatics = try! RoGetActivationFactory(HString("test_component.Base"))
+    public class func createFromString(_ value: String) -> Base! {
+        return try! _IBaseStatics.CreateFromStringImpl(value)
     }
 
     public func doTheThing() throws {
@@ -419,6 +424,11 @@ open class BaseNoOverrides : WinRTClass {
         }
     }
 
+    private static let _IBaseNoOverridesStatics: __ABI_test_component.IBaseNoOverridesStatics = try! RoGetActivationFactory(HString("test_component.BaseNoOverrides"))
+    public class func createFromString(_ value: String) -> BaseNoOverrides! {
+        return try! _IBaseNoOverridesStatics.CreateFromStringImpl(value)
+    }
+
     internal enum IBaseNoOverrides : ComposableImpl {
         internal typealias CABI = C_IInspectable
         internal typealias SwiftABI = test_component.IInspectable
@@ -619,28 +629,28 @@ public final class Class : WinRTClass, IBasic {
     }
 
     private static let _IClassStatics: __ABI_test_component.IClassStatics = try! RoGetActivationFactory(HString("test_component.Class"))
-    public static func staticTest() {
+    public class func staticTest() {
         try! _IClassStatics.StaticTestImpl()
     }
 
-    public static func staticTestReturn() -> Int32 {
+    public class func staticTestReturn() -> Int32 {
         return try! _IClassStatics.StaticTestReturnImpl()
     }
 
-    public static func takeBaseAndGiveToCallbackAsObject(_ base: Base!, _ callback: test_component.InObjectDelegate!) {
+    public class func takeBaseAndGiveToCallbackAsObject(_ base: Base!, _ callback: test_component.InObjectDelegate!) {
         try! _IClassStatics.TakeBaseAndGiveToCallbackAsObjectImpl(base, callback)
     }
 
-    public static var staticProperty : Int32 {
+    public class var staticProperty : Int32 {
         get { try! _IClassStatics.get_StaticPropertyImpl() }
     }
 
     private static let _IClassStatics2: __ABI_test_component.IClassStatics2 = try! RoGetActivationFactory(HString("test_component.Class"))
-    public static func staticTestReturnFloat() -> Float {
+    public class func staticTestReturnFloat() -> Float {
         return try! _IClassStatics2.StaticTestReturnFloatImpl()
     }
 
-    public static var staticPropertyFloat : Float {
+    public class var staticPropertyFloat : Float {
         get { try! _IClassStatics2.get_StaticPropertyFloatImpl() }
         set { try! _IClassStatics2.put_StaticPropertyFloatImpl(newValue) }
     }
@@ -822,23 +832,23 @@ public final class CollectionTester : WinRTClass {
     }
 
     private static let _ICollectionTesterStatics: __ABI_test_component.ICollectionTesterStatics = try! RoGetActivationFactory(HString("test_component.CollectionTester"))
-    public static func inMap(_ value: AnyIMap<String, String>!) -> String {
+    public class func inMap(_ value: AnyIMap<String, String>!) -> String {
         return try! _ICollectionTesterStatics.InMapImpl(value)
     }
 
-    public static func inMapView(_ value: AnyIMapView<String, String>!) -> String {
+    public class func inMapView(_ value: AnyIMapView<String, String>!) -> String {
         return try! _ICollectionTesterStatics.InMapViewImpl(value)
     }
 
-    public static func inVector(_ value: AnyIVector<String>!) -> String {
+    public class func inVector(_ value: AnyIVector<String>!) -> String {
         return try! _ICollectionTesterStatics.InVectorImpl(value)
     }
 
-    public static func inVectorView(_ value: AnyIVectorView<String>!) -> String {
+    public class func inVectorView(_ value: AnyIVectorView<String>!) -> String {
         return try! _ICollectionTesterStatics.InVectorViewImpl(value)
     }
 
-    public static func getObjectAt(_ value: AnyIVector<Any?>!, _ index: UInt32, _ callback: ObjectHandler!) {
+    public class func getObjectAt(_ value: AnyIVector<Any?>!, _ index: UInt32, _ callback: ObjectHandler!) {
         try! _ICollectionTesterStatics.GetObjectAtImpl(value, index, callback)
     }
 
@@ -916,6 +926,11 @@ public final class Derived : test_component.Base {
 
     override public init() {
         super.init(fromAbi: try! RoActivateInstance(HString("test_component.Derived")))
+    }
+
+    private static let _IDerivedStatics: __ABI_test_component.IDerivedStatics = try! RoGetActivationFactory(HString("test_component.Derived"))
+    override public class func createFromString(_ value: String) -> Derived! {
+        return try! _IDerivedStatics.CreateFromStringImpl(value)
     }
 
     public var prop : Int32 {
@@ -1072,43 +1087,43 @@ public final class NoopClosable : WinRTClass, test_component.IClosable {
 
 public final class NullValues {
     private static let _INullValuesStatics: __ABI_test_component.INullValuesStatics = try! RoGetActivationFactory(HString("test_component.NullValues"))
-    public static func isObjectNull(_ value: Any!) -> Bool {
+    public class func isObjectNull(_ value: Any!) -> Bool {
         return try! _INullValuesStatics.IsObjectNullImpl(value)
     }
 
-    public static func isInterfaceNull(_ value: test_component.AnyIClosable!) -> Bool {
+    public class func isInterfaceNull(_ value: test_component.AnyIClosable!) -> Bool {
         return try! _INullValuesStatics.IsInterfaceNullImpl(value)
     }
 
-    public static func isGenericInterfaceNull(_ value: AnyIVector<String>!) -> Bool {
+    public class func isGenericInterfaceNull(_ value: AnyIVector<String>!) -> Bool {
         return try! _INullValuesStatics.IsGenericInterfaceNullImpl(value)
     }
 
-    public static func isClassNull(_ value: NoopClosable!) -> Bool {
+    public class func isClassNull(_ value: NoopClosable!) -> Bool {
         return try! _INullValuesStatics.IsClassNullImpl(value)
     }
 
-    public static func isDelegateNull(_ value: VoidToVoidDelegate!) -> Bool {
+    public class func isDelegateNull(_ value: VoidToVoidDelegate!) -> Bool {
         return try! _INullValuesStatics.IsDelegateNullImpl(value)
     }
 
-    public static func getNullObject() -> Any! {
+    public class func getNullObject() -> Any! {
         return try! _INullValuesStatics.GetNullObjectImpl()
     }
 
-    public static func getNullInterface() -> test_component.AnyIClosable! {
+    public class func getNullInterface() -> test_component.AnyIClosable! {
         return try! _INullValuesStatics.GetNullInterfaceImpl()
     }
 
-    public static func getNullGenericInterface() -> AnyIVector<String>! {
+    public class func getNullGenericInterface() -> AnyIVector<String>! {
         return try! _INullValuesStatics.GetNullGenericInterfaceImpl()
     }
 
-    public static func getNullClass() -> NoopClosable! {
+    public class func getNullClass() -> NoopClosable! {
         return try! _INullValuesStatics.GetNullClassImpl()
     }
 
-    public static func getNullDelegate() -> VoidToVoidDelegate! {
+    public class func getNullDelegate() -> VoidToVoidDelegate! {
         return try! _INullValuesStatics.GetNullDelegateImpl()
     }
 
@@ -1142,7 +1157,7 @@ public final class Simple : WinRTClass {
     }
 
     private static let _ISimpleStatics: __ABI_test_component.ISimpleStatics = try! RoGetActivationFactory(HString("test_component.Simple"))
-    public static func fireStaticEvent() {
+    public class func fireStaticEvent() {
         try! _ISimpleStatics.FireStaticEventImpl()
     }
 
@@ -1260,19 +1275,19 @@ public final class Simple : WinRTClass {
 
 public final class StaticClass {
     private static let _IStaticClassStatics: __ABI_test_component.IStaticClassStatics = try! RoGetActivationFactory(HString("test_component.StaticClass"))
-    public static func inEnum(_ value: Signed) -> String {
+    public class func inEnum(_ value: Signed) -> String {
         return try! _IStaticClassStatics.InEnumImpl(value)
     }
 
-    public static func inNonBlittableStruct(_ value: NonBlittableStruct) -> String {
+    public class func inNonBlittableStruct(_ value: NonBlittableStruct) -> String {
         return try! _IStaticClassStatics.InNonBlittableStructImpl(value)
     }
 
-    public static func takeBase(_ base: Base!) {
+    public class func takeBase(_ base: Base!) {
         try! _IStaticClassStatics.TakeBaseImpl(base)
     }
 
-    public static var enumProperty : Fruit {
+    public class var enumProperty : Fruit {
         get { try! _IStaticClassStatics.get_EnumPropertyImpl() }
         set { try! _IStaticClassStatics.put_EnumPropertyImpl(newValue) }
     }

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -10,15 +10,15 @@ public typealias SwiftifiableNames = __x_ABI_Ctest__component_CSwiftifiableNames
 public typealias Unsigned = __x_ABI_Ctest__component_CUnsigned
 public final class AsyncMethods {
     private static let _IAsyncMethodsStatics: __ABI_test_component.IAsyncMethodsStatics = try! RoGetActivationFactory(HString("test_component.AsyncMethods"))
-    public class func getCompletedAsync(_ result: Int32) -> AnyIAsyncOperation<Int32>! {
+    public static func getCompletedAsync(_ result: Int32) -> AnyIAsyncOperation<Int32>! {
         return try! _IAsyncMethodsStatics.GetCompletedAsyncImpl(result)
     }
 
-    public class func getCompletedWithErrorAsync(_ errorCode: HRESULT) -> AnyIAsyncOperation<Int32>! {
+    public static func getCompletedWithErrorAsync(_ errorCode: HRESULT) -> AnyIAsyncOperation<Int32>! {
         return try! _IAsyncMethodsStatics.GetCompletedWithErrorAsyncImpl(errorCode)
     }
 
-    public class func getPendingAsync() -> AsyncOperationInt! {
+    public static func getPendingAsync() -> AsyncOperationInt! {
         return try! _IAsyncMethodsStatics.GetPendingAsyncImpl()
     }
 
@@ -629,28 +629,28 @@ public final class Class : WinRTClass, IBasic {
     }
 
     private static let _IClassStatics: __ABI_test_component.IClassStatics = try! RoGetActivationFactory(HString("test_component.Class"))
-    public class func staticTest() {
+    public static func staticTest() {
         try! _IClassStatics.StaticTestImpl()
     }
 
-    public class func staticTestReturn() -> Int32 {
+    public static func staticTestReturn() -> Int32 {
         return try! _IClassStatics.StaticTestReturnImpl()
     }
 
-    public class func takeBaseAndGiveToCallbackAsObject(_ base: Base!, _ callback: test_component.InObjectDelegate!) {
+    public static func takeBaseAndGiveToCallbackAsObject(_ base: Base!, _ callback: test_component.InObjectDelegate!) {
         try! _IClassStatics.TakeBaseAndGiveToCallbackAsObjectImpl(base, callback)
     }
 
-    public class var staticProperty : Int32 {
+    public static var staticProperty : Int32 {
         get { try! _IClassStatics.get_StaticPropertyImpl() }
     }
 
     private static let _IClassStatics2: __ABI_test_component.IClassStatics2 = try! RoGetActivationFactory(HString("test_component.Class"))
-    public class func staticTestReturnFloat() -> Float {
+    public static func staticTestReturnFloat() -> Float {
         return try! _IClassStatics2.StaticTestReturnFloatImpl()
     }
 
-    public class var staticPropertyFloat : Float {
+    public static var staticPropertyFloat : Float {
         get { try! _IClassStatics2.get_StaticPropertyFloatImpl() }
         set { try! _IClassStatics2.put_StaticPropertyFloatImpl(newValue) }
     }
@@ -832,23 +832,23 @@ public final class CollectionTester : WinRTClass {
     }
 
     private static let _ICollectionTesterStatics: __ABI_test_component.ICollectionTesterStatics = try! RoGetActivationFactory(HString("test_component.CollectionTester"))
-    public class func inMap(_ value: AnyIMap<String, String>!) -> String {
+    public static func inMap(_ value: AnyIMap<String, String>!) -> String {
         return try! _ICollectionTesterStatics.InMapImpl(value)
     }
 
-    public class func inMapView(_ value: AnyIMapView<String, String>!) -> String {
+    public static func inMapView(_ value: AnyIMapView<String, String>!) -> String {
         return try! _ICollectionTesterStatics.InMapViewImpl(value)
     }
 
-    public class func inVector(_ value: AnyIVector<String>!) -> String {
+    public static func inVector(_ value: AnyIVector<String>!) -> String {
         return try! _ICollectionTesterStatics.InVectorImpl(value)
     }
 
-    public class func inVectorView(_ value: AnyIVectorView<String>!) -> String {
+    public static func inVectorView(_ value: AnyIVectorView<String>!) -> String {
         return try! _ICollectionTesterStatics.InVectorViewImpl(value)
     }
 
-    public class func getObjectAt(_ value: AnyIVector<Any?>!, _ index: UInt32, _ callback: ObjectHandler!) {
+    public static func getObjectAt(_ value: AnyIVector<Any?>!, _ index: UInt32, _ callback: ObjectHandler!) {
         try! _ICollectionTesterStatics.GetObjectAtImpl(value, index, callback)
     }
 
@@ -929,7 +929,7 @@ public final class Derived : test_component.Base {
     }
 
     private static let _IDerivedStatics: __ABI_test_component.IDerivedStatics = try! RoGetActivationFactory(HString("test_component.Derived"))
-    override public class func createFromString(_ value: String) -> Derived! {
+    override public static func createFromString(_ value: String) -> Derived! {
         return try! _IDerivedStatics.CreateFromStringImpl(value)
     }
 
@@ -1087,43 +1087,43 @@ public final class NoopClosable : WinRTClass, test_component.IClosable {
 
 public final class NullValues {
     private static let _INullValuesStatics: __ABI_test_component.INullValuesStatics = try! RoGetActivationFactory(HString("test_component.NullValues"))
-    public class func isObjectNull(_ value: Any!) -> Bool {
+    public static func isObjectNull(_ value: Any!) -> Bool {
         return try! _INullValuesStatics.IsObjectNullImpl(value)
     }
 
-    public class func isInterfaceNull(_ value: test_component.AnyIClosable!) -> Bool {
+    public static func isInterfaceNull(_ value: test_component.AnyIClosable!) -> Bool {
         return try! _INullValuesStatics.IsInterfaceNullImpl(value)
     }
 
-    public class func isGenericInterfaceNull(_ value: AnyIVector<String>!) -> Bool {
+    public static func isGenericInterfaceNull(_ value: AnyIVector<String>!) -> Bool {
         return try! _INullValuesStatics.IsGenericInterfaceNullImpl(value)
     }
 
-    public class func isClassNull(_ value: NoopClosable!) -> Bool {
+    public static func isClassNull(_ value: NoopClosable!) -> Bool {
         return try! _INullValuesStatics.IsClassNullImpl(value)
     }
 
-    public class func isDelegateNull(_ value: VoidToVoidDelegate!) -> Bool {
+    public static func isDelegateNull(_ value: VoidToVoidDelegate!) -> Bool {
         return try! _INullValuesStatics.IsDelegateNullImpl(value)
     }
 
-    public class func getNullObject() -> Any! {
+    public static func getNullObject() -> Any! {
         return try! _INullValuesStatics.GetNullObjectImpl()
     }
 
-    public class func getNullInterface() -> test_component.AnyIClosable! {
+    public static func getNullInterface() -> test_component.AnyIClosable! {
         return try! _INullValuesStatics.GetNullInterfaceImpl()
     }
 
-    public class func getNullGenericInterface() -> AnyIVector<String>! {
+    public static func getNullGenericInterface() -> AnyIVector<String>! {
         return try! _INullValuesStatics.GetNullGenericInterfaceImpl()
     }
 
-    public class func getNullClass() -> NoopClosable! {
+    public static func getNullClass() -> NoopClosable! {
         return try! _INullValuesStatics.GetNullClassImpl()
     }
 
-    public class func getNullDelegate() -> VoidToVoidDelegate! {
+    public static func getNullDelegate() -> VoidToVoidDelegate! {
         return try! _INullValuesStatics.GetNullDelegateImpl()
     }
 
@@ -1157,7 +1157,7 @@ public final class Simple : WinRTClass {
     }
 
     private static let _ISimpleStatics: __ABI_test_component.ISimpleStatics = try! RoGetActivationFactory(HString("test_component.Simple"))
-    public class func fireStaticEvent() {
+    public static func fireStaticEvent() {
         try! _ISimpleStatics.FireStaticEventImpl()
     }
 
@@ -1275,19 +1275,19 @@ public final class Simple : WinRTClass {
 
 public final class StaticClass {
     private static let _IStaticClassStatics: __ABI_test_component.IStaticClassStatics = try! RoGetActivationFactory(HString("test_component.StaticClass"))
-    public class func inEnum(_ value: Signed) -> String {
+    public static func inEnum(_ value: Signed) -> String {
         return try! _IStaticClassStatics.InEnumImpl(value)
     }
 
-    public class func inNonBlittableStruct(_ value: NonBlittableStruct) -> String {
+    public static func inNonBlittableStruct(_ value: NonBlittableStruct) -> String {
         return try! _IStaticClassStatics.InNonBlittableStructImpl(value)
     }
 
-    public class func takeBase(_ base: Base!) {
+    public static func takeBase(_ base: Base!) {
         try! _IStaticClassStatics.TakeBaseImpl(base)
     }
 
-    public class var enumProperty : Fruit {
+    public static var enumProperty : Fruit {
         get { try! _IStaticClassStatics.get_EnumPropertyImpl() }
         set { try! _IStaticClassStatics.put_EnumPropertyImpl(newValue) }
     }

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -1881,6 +1881,7 @@ public typealias AnyWithIterableGuids = any WithIterableGuids
 
 public protocol WithKeyword : WinRTInterface {
     func `enum`(_ `extension`: String) throws
+    func `subscript`() throws
     var `struct`: String { get set }
     var `repeat`: Event<EventHandler<Any?>> { get }
 }
@@ -2009,6 +2010,9 @@ extension test_component.Keywords {
     }
     public static var `struct` : test_component.Keywords {
         __x_ABI_Ctest__component_CKeywords_Struct
+    }
+    public static var `subscript` : test_component.Keywords {
+        __x_ABI_Ctest__component_CKeywords_Subscript
     }
     public static var `super` : test_component.Keywords {
         __x_ABI_Ctest__component_CKeywords_Super

--- a/tests/test_component/cpp/Base.h
+++ b/tests/test_component/cpp/Base.h
@@ -9,6 +9,7 @@ namespace winrt::test_component::implementation
         ~Base();
         virtual void DoTheThing();
         virtual void OnDoTheThing();
+        static winrt::test_component::Base CreateFromString(hstring const& value) { return winrt::make<Base>(); }
     };
 }
 namespace winrt::test_component::factory_implementation

--- a/tests/test_component/cpp/BaseNoOverrides.h
+++ b/tests/test_component/cpp/BaseNoOverrides.h
@@ -6,7 +6,7 @@ namespace winrt::test_component::implementation
     struct BaseNoOverrides : BaseNoOverridesT<BaseNoOverrides>
     {
         BaseNoOverrides() = default;
-
+        static winrt::test_component::BaseNoOverrides CreateFromString(hstring const& value) { return winrt::make<BaseNoOverrides>(); }
     };
 }
 namespace winrt::test_component::factory_implementation

--- a/tests/test_component/cpp/Derived.h
+++ b/tests/test_component/cpp/Derived.h
@@ -10,8 +10,9 @@ namespace winrt::test_component::implementation
 
         int32_t Prop();
         void Prop(int32_t value);
-       
+
         void OnDoTheThing() override;
+        static winrt::test_component::Derived CreateFromString(hstring const& value) { return winrt::make<Derived>(); }
         private:
         int32_t m_prop{};
     };

--- a/tests/test_component/cpp/Keywords.idl
+++ b/tests/test_component/cpp/Keywords.idl
@@ -39,6 +39,7 @@ namespace test_component
         Self,
         Static,
         Struct,
+        Subscript,
         Super,
         Switch,
         Throw,
@@ -54,5 +55,6 @@ namespace test_component
         void Enum(String extension);
         String Struct;
         event Windows.Foundation.EventHandler<Object> Repeat;
+        void Subscript();
     }
 }

--- a/tests/test_component/cpp/test_component.idl
+++ b/tests/test_component/cpp/test_component.idl
@@ -400,10 +400,14 @@ namespace test_component
             overridable void OnDoTheThing();
 
             void DoTheThing();
+
+            static Base CreateFromString(String value);
         };
 
         unsealed runtimeclass BaseNoOverrides {
             protected BaseNoOverrides();
+
+            static BaseNoOverrides CreateFromString(String value);
         }
 
 
@@ -415,6 +419,8 @@ namespace test_component
             Derived();
 
             Int32 Prop;
+
+            static Derived CreateFromString(String value);
         };
 
         unsealed runtimeclass UnsealedDerivedNoConstructor: Base {


### PR DESCRIPTION
These fixes were required to get the `Microsoft.Graphics.Canvas` WinMD to build, the few things that this winmd uncovered:

1. Simply deriving from an interface resulted in not properly tracking dependencies. 
2. `subscript` is a method and needs to be escaped with backticks
3. There are static methods which technically "override" others (they have the same name, num of params and return types are related). These need to be marked as `class` methods and the derived types have to say `override`  

## Changes
1. add `w.add_depends` in some places where we don't use any of the `write(type)` methods. We don't use those methods because swift name requirements for deriving from a generic interface don't follow "normal" (as in what most other languages do - where you need `IFoo` instead of `IFoo<Bar>`) naming patterns. Plus those write methods are fragile so just adding the `add_depends` instead of modifying the write methods to do the right thing
2. add `subscript` to the list of names that need backticks
3. this one is a bit more involved, we have to walk the class hierarchy and see if a function matches. This is similar to what we do for `base_has_matching_constructor` and a match is considered if the following are true:
   a. function name matches
   b. parameters match
   c. return type of derived static method is the same or derived from the return of the base class
   
 ## Testing

Added test cases