### PR TITLE
add support for identity

### DIFF
--- a/swiftwinrt/Resources/Support/Aggregation.swift
+++ b/swiftwinrt/Resources/Support/Aggregation.swift
@@ -11,7 +11,7 @@ import Foundation
 // to the swift object, to ensure it doesn't get cleaned up. The Swift object in turn holds a strong
 // reference to this object so that it stays alive.
 @_spi(WinRTInternal)
-public final class WinRTClassWeakReference<Class: WinRTClass> {
+public final class WinRTClassWeakReference<Class: WinRTObject> {
     fileprivate weak var instance: Class?
     public init(_ instance: Class){
         self.instance = instance
@@ -41,7 +41,7 @@ extension WinRTClassWeakReference: CustomAddRef {
 }
 
 extension WinRTClassWeakReference: AnyObjectWrapper {
-    var obj: AnyObject? { instance }
+    var obj: WinRTObject? { instance }
 }
 
 @_spi(WinRTInternal)

--- a/swiftwinrt/Resources/Support/IInspectable.swift
+++ b/swiftwinrt/Resources/Support/IInspectable.swift
@@ -62,6 +62,14 @@ public enum __ABI_ {
         if let swiftAbi = swiftObj as? IInspectable {
            let abi: UnsafeMutablePointer<C_IInspectable> = RawPointer(swiftAbi)
            return try body(abi)
+        } else if let winrtObj = swiftObj as? WinRTObject {
+          if let identity = winrtObj.identity {
+            return try body(identity)
+          }
+          return try super.toABI{
+            winrtObj.identity = $0
+            return try body($0)
+          }
         } else {
             return try super.toABI(body)
         }

--- a/swiftwinrt/Resources/Support/WinRTProtocols.swift
+++ b/swiftwinrt/Resources/Support/WinRTProtocols.swift
@@ -13,6 +13,18 @@ public protocol IWinRTObject: AnyObject {
 public protocol WinRTInterface: AnyObject, CustomQueryInterface {
 }
 
+open class WinRTObject: Equatable {
+  public init() {}
+
+  public static func == (lhs: WinRTObject, rhs: WinRTObject) -> Bool {
+    return lhs.identity == rhs.identity
+  }
+
+  // Weakref to the underlying COM object since it holds a strong ref back
+  // to ourselves
+  internal var identity: UnsafeMutablePointer<C_IInspectable>?
+}
+
 open class WinRTClass : CustomQueryInterface, Equatable {
     public init() {}
 

--- a/tests/test_app/IdentityTests.swift
+++ b/tests/test_app/IdentityTests.swift
@@ -29,10 +29,50 @@ class IdentityTests: XCTestCase {
         XCTAssertEqual(abi1, abi2)
     }
   }
+
+  public func testIdentityCopyTo() throws {
+    let obj = MyObj()
+    let wrapper = try XCTUnwrap(__ABI_.AnyWrapper(obj))
+    let wrapper2 = try XCTUnwrap(__ABI_.AnyWrapper(obj))
+    var copy: UnsafeMutablePointer<C_IInspectable>?
+    var copy2: UnsafeMutablePointer<C_IInspectable>?
+    defer {
+      _ = copy?.pointee.lpVtbl.pointee.Release(copy)
+      _ = copy2?.pointee.lpVtbl.pointee.Release(copy2)
+    }
+
+    wrapper.copyTo(&copy)
+    wrapper2.copyTo(&copy2)
+    XCTAssertEqual(copy, copy2)
+  }
+
+  // This test verifies that even after releasing the last reference
+  // from WinRT, that the original identity still persists and is valid.
+  // This is common in collection accessors, where the object is retrieved
+  // and then immediately released.
+  public func testIdentityAfterRelease() throws {
+    let obj = MyObj()
+    var copy2: UnsafeMutablePointer<C_IInspectable>?
+
+    var wrapper:__ABI_.AnyWrapper? = try XCTUnwrap(__ABI_.AnyWrapper(obj))
+    var copy: UnsafeMutablePointer<C_IInspectable>?
+
+    wrapper?.copyTo(&copy)
+    _ = copy?.pointee.lpVtbl.pointee.Release(copy)
+    wrapper = nil
+
+
+    let wrapper2 = try XCTUnwrap(__ABI_.AnyWrapper(obj))
+    wrapper2.copyTo(&copy2)
+    XCTAssertEqual(copy, copy2)
+    _ = copy2?.pointee.lpVtbl.pointee.Release(copy2)
+  }
 }
 
 var identityTests: [XCTestCaseEntry] = [
   testCase([
-    ("testIdentity", IdentityTests.testIdentity)
+    ("testIdentity", IdentityTests.testIdentity),
+    ("testIdentityCopyTo", IdentityTests.testIdentityCopyTo),
+    ("testIdentityAfterRelease", IdentityTests.testIdentityAfterRelease)
   ])
 ]

--- a/tests/test_app/IdentityTests.swift
+++ b/tests/test_app/IdentityTests.swift
@@ -1,0 +1,38 @@
+import test_component
+import XCTest
+
+class MyObj: WinRTObject {
+  override public init() {
+    super.init()
+  }
+}
+
+class ABIHelper {
+    static func toABI(_ obj1: __ABI_.AnyWrapper, _ obj2: __ABI_.AnyWrapper, _ body: (UnsafeMutablePointer<C_IInspectable>, UnsafeMutablePointer<C_IInspectable>) -> Void) throws {
+        try obj1.toABI { abi1 in
+            try obj2.toABI { abi2 in
+                body(abi1, abi2)
+            }
+        }
+    }
+}
+
+class IdentityTests: XCTestCase {
+  public func testIdentity() throws {
+    let obj = MyObj()
+    let wrapper = try XCTUnwrap(__ABI_.AnyWrapper(obj))
+    let wrapper2 = try XCTUnwrap(__ABI_.AnyWrapper(obj))
+
+    // Since `identity` is internal and we don't have access to internals we just check that pointers from different wrappers
+    // are the same
+    try ABIHelper.toABI(wrapper, wrapper2) { (abi1, abi2) in
+        XCTAssertEqual(abi1, abi2)
+    }
+  }
+}
+
+var identityTests: [XCTestCaseEntry] = [
+  testCase([
+    ("testIdentity", IdentityTests.testIdentity)
+  ])
+]

--- a/tests/test_app/MemoryManagementTests.swift
+++ b/tests/test_app/MemoryManagementTests.swift
@@ -51,6 +51,24 @@ class MemoryManagementTests : XCTestCase {
         }()
         XCTAssertNil(weakDerived)
     }
+
+    func testWinRTObject() throws {
+        weak var weakDerived: MyObj? = nil
+        try {
+            let obj = MyObj()
+            weakDerived = obj
+
+            // wrapping MyObj will create the identity pointer. make sure
+            // this doesn't cause a leak
+            let wrapper = try XCTUnwrap(__ABI_.AnyWrapper(obj))
+            var copy: UnsafeMutablePointer<C_IInspectable>?
+            defer {
+              _ = copy?.pointee.lpVtbl.pointee.Release(copy)
+            }
+            wrapper.copyTo(&copy)
+        }()
+        XCTAssertNil(weakDerived)
+    }
 }
 
 var memoryManagementTests: [XCTestCaseEntry] = [
@@ -59,5 +77,6 @@ var memoryManagementTests: [XCTestCaseEntry] = [
     ("testNonAggregatedObject", MemoryManagementTests.testNonAggregatedObject),
     ("testReturningAggregatedObject", MemoryManagementTests.testReturningAggregatedObject),
     ("testReturningNonAggregatedObject", MemoryManagementTests.testReturningNonAggregatedObject),
+    ("testWinRTObject", MemoryManagementTests.testWinRTObject)
   ])
 ]

--- a/tests/test_app/main.swift
+++ b/tests/test_app/main.swift
@@ -460,7 +460,7 @@ var tests: [XCTestCaseEntry] = [
     ("testUnicode", SwiftWinRTTests.testUnicode),
     ("testErrorInfo", SwiftWinRTTests.testErrorInfo),
   ])
-] + valueBoxingTests + eventTests + collectionTests + aggregationTests + asyncTests + memoryManagementTests + bufferTests
+] + valueBoxingTests + eventTests + collectionTests + aggregationTests + asyncTests + memoryManagementTests + bufferTests + identityTests
 
 RoInitialize(RO_INIT_MULTITHREADED)
 XCTMain(tests)


### PR DESCRIPTION
This PR add support for object identity via the `WinRTObject` class.

Since WinRT Object's have to keep a strong ref to their identity, in order for it to remain valid during the lifetime of the object. I re-used the same logic we use for `WinRTClass` and made it more generic. 

When wrapping a swift object. we check if it is a `WinRTObject` if it is, we store the weak reference on the wrapper. When retrieving the abi object, we check if it has identity. if it does.

Note: this intentionally doesn't require all objects that implement a `WinRTInterface` to also support the notion of identity. While that is probably a righteous change to eventually have, i went down that route and decided it was slightly too large of a change for now

## Testing
Added a couple tests for identity and also added a memory management test to make sure we aren't leaking the `WinRTObject`