### PR TITLE
Add support for an escape hatch when properties fail

### DIFF
--- a/swiftwinrt/Resources/Support/Error.swift
+++ b/swiftwinrt/Resources/Support/Error.swift
@@ -189,6 +189,9 @@ public func failWith(err: HRESULT) -> HRESULT {
 /// Handle any failing WinRT API call that is not marked with `throws`. This call can be used to catch exceptions
 /// from non-throwing WinRT calls such as properties or event registrations in the abnormal case where handling these
 /// failures is required.
+///
+/// Example Usage:
+///    let curentPackage = try? withFailingCall(Package.current)
 public func withFailingCall<Result>(_ call: @autoclosure () -> Result) throws -> Result {
   let error = getLastError()
   defer { clearLastError() }
@@ -257,7 +260,10 @@ fileprivate func setLastError(_ error: Error){
   checkErrorLock.lock()
   defer { checkErrorLock.unlock() }
   guard let lastError else {
-    fatalError(error.description)
+    fatalError("""
+Unhandled WinRT Error @ \(error.description)
+  This error can be handled via `withFailingCall`
+""")
   }
   lastError.error = error
 }

--- a/swiftwinrt/Resources/Support/Error.swift
+++ b/swiftwinrt/Resources/Support/Error.swift
@@ -262,7 +262,7 @@ fileprivate func setLastError(_ error: Error){
   guard let lastError else {
     fatalError("""
 Unhandled WinRT Error @ \(error.description)
-  This error can be handled via `withFailingCall`
+  Note: If this error is expected and needs to be handled, use `withFailingCall`
 """)
   }
   lastError.error = error

--- a/swiftwinrt/Resources/Support/WinRTProtocols.swift
+++ b/swiftwinrt/Resources/Support/WinRTProtocols.swift
@@ -48,6 +48,8 @@ open class WinRTClass : CustomQueryInterface, Equatable {
       identity = nil
       _inner = nil
     }
+
+    internal var failureCallback: ((SUPPORT_MODULE.Error) throws -> ())?
 }
 
 public func ==<T: WinRTClass>(_ lhs: T, _ rhs: T) -> Bool {

--- a/swiftwinrt/code_writers/type_writers.h
+++ b/swiftwinrt/code_writers/type_writers.h
@@ -46,6 +46,7 @@ namespace swiftwinrt
     // Writes the existential version of an interface, such as AnyIClosable for "any IClosable"
     void write_swift_interface_existential_identifier(writer& w, metadata_type const& iface);
 
+    void write_default_value(writer& w, metadata_type const& sig, projection_layer layer);
     void write_default_init_assignment(writer& w, metadata_type const& sig, projection_layer layer);
 
     write_type_params swift_write_type_params_for(metadata_type const& type);

--- a/tests/test_app/ErrorHandlingTests.swift
+++ b/tests/test_app/ErrorHandlingTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+import test_component
+import Foundation
+
+func AssertThrows(_ expression: @autoclosure () throws -> ()) {
+  do {
+    try expression()
+    XCTFail("No error was thrown")
+  } catch {
+    // expected
+  }
+}
+
+class ErrorHandlingTests : XCTestCase {
+  public func testErrorInfo() {
+    let message = "You are doing a bad thing"
+    do {
+      let classy = Class()
+      try classy.fail(message)
+    } catch {
+      XCTAssertEqual("\(error)", message)
+    }
+  }
+  public func testNoExcept() throws {
+    let classy = Class()
+    classy.noexceptVoid()
+    classy.method()
+    XCTAssertEqual(classy.noexceptInt32(), 123)
+    XCTAssertEqual(classy.noexceptString(), "123")
+  }
+
+  public func testHandleFailedPropertyGet() throws {
+    let failure = Failure()
+    AssertThrows(_ = try withFailingCall(failure.failedProperty))
+  }
+
+  public func testHandleFailedPropertySet() throws {
+    let failure = Failure()
+    AssertThrows(try withFailingCall(failure.failedProperty = "123"))
+  }
+
+  public func testHandleFailedStaticPropertyGet() throws {
+    AssertThrows(_ = try withFailingCall(Failure.failedStaticProperty))
+  }
+
+  public func testHandleFailedStaticMethod() throws {
+    AssertThrows(try withFailingCall(Failure.failedStaticMethod()))
+  }
+}
+
+var errorHandlingTests: [XCTestCaseEntry] = [
+  testCase([
+    ("testErrorInfo", ErrorHandlingTests.testErrorInfo),
+    ("testNoExcept", ErrorHandlingTests.testNoExcept),
+    ("testHandleFailedPropertyGet", ErrorHandlingTests.testHandleFailedPropertyGet),
+    ("testHandleFailedPropertySet", ErrorHandlingTests.testHandleFailedPropertySet),
+    ("testHandleFailedStaticPropertyGet", ErrorHandlingTests.testHandleFailedStaticPropertyGet),
+    ("testHandleFailedStaticMethod", ErrorHandlingTests.testHandleFailedStaticMethod)
+  ])
+]

--- a/tests/test_app/main.swift
+++ b/tests/test_app/main.swift
@@ -422,24 +422,6 @@ class SwiftWinRTTests : XCTestCase {
     print("\(SwiftifiableNames.r8g8b8a8Typeless)")
     print("\(SwiftifiableNames.uuid)")
   }
-
-  public func testErrorInfo() {
-    let message = "You are doing a bad thing"
-    do {
-      let classy = Class()
-      try classy.fail(message)
-    } catch {
-      XCTAssertEqual("\(error)", message)
-    }
-  }
-
-  public func testNoExcept() throws {
-    let classy = Class()
-    classy.noexceptVoid()
-    classy.method()
-    XCTAssertEqual(classy.noexceptInt32(), 123)
-    XCTAssertEqual(classy.noexceptString(), "123")
-  }
 }
 
 var tests: [XCTestCaseEntry] = [
@@ -457,10 +439,9 @@ var tests: [XCTestCaseEntry] = [
     ("testOutParams", SwiftWinRTTests.testOutParams),
     ("testStaticMethods", SwiftWinRTTests.testStaticMethods),
     ("testStructWithIReference", SwiftWinRTTests.testStructWithIReference),
-    ("testUnicode", SwiftWinRTTests.testUnicode),
-    ("testErrorInfo", SwiftWinRTTests.testErrorInfo),
+    ("testUnicode", SwiftWinRTTests.testUnicode)
   ])
-] + valueBoxingTests + eventTests + collectionTests + aggregationTests + asyncTests + memoryManagementTests + bufferTests
+] + valueBoxingTests + eventTests + collectionTests + aggregationTests + asyncTests + memoryManagementTests + bufferTests + errorHandlingTests
 
 RoInitialize(RO_INIT_MULTITHREADED)
 XCTMain(tests)

--- a/tests/test_app/test_app.exe.manifest
+++ b/tests/test_app/test_app.exe.manifest
@@ -66,5 +66,9 @@
                   name="test_component.BufferTester"
                   threadingModel="both"
                   xmlns="urn:schemas-microsoft-com:winrt.v1" />
+            <activatableClass
+                  name="test_component.Failure"
+                  threadingModel="both"
+                  xmlns="urn:schemas-microsoft-com:winrt.v1" />
       </file>
 </assembly>

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -180,6 +180,18 @@ typedef interface __x_ABI_Ctest__component_CIVoidToVoidDelegate __x_ABI_Ctest__c
 
 #endif // ____x_ABI_Ctest__component_CIEventTesterFactory_FWD_DEFINED__
 
+#ifndef ____x_ABI_Ctest__component_CIFailure_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CIFailure_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CIFailure __x_ABI_Ctest__component_CIFailure;
+
+#endif // ____x_ABI_Ctest__component_CIFailure_FWD_DEFINED__
+
+#ifndef ____x_ABI_Ctest__component_CIFailureStatics_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CIFailureStatics_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CIFailureStatics __x_ABI_Ctest__component_CIFailureStatics;
+
+#endif // ____x_ABI_Ctest__component_CIFailureStatics_FWD_DEFINED__
+
 #ifndef ____x_ABI_Ctest__component_CIIAmImplementable_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CIIAmImplementable_FWD_DEFINED__
     typedef interface __x_ABI_Ctest__component_CIIAmImplementable __x_ABI_Ctest__component_CIIAmImplementable;
@@ -3608,6 +3620,75 @@ struct __x_ABI_Ctest__component_CStructWithIReference
     
     EXTERN_C const IID IID___x_ABI_Ctest__component_CIEventTesterFactory;
 #endif /* !defined(____x_ABI_Ctest__component_CIEventTesterFactory_INTERFACE_DEFINED__) */
+    
+#if !defined(____x_ABI_Ctest__component_CIFailure_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CIFailure_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CIFailureVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIFailure* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIFailure* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIFailure* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIFailure* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIFailure* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIFailure* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* get_FailedProperty)(__x_ABI_Ctest__component_CIFailure* This,
+        HSTRING* value);
+    HRESULT (STDMETHODCALLTYPE* put_FailedProperty)(__x_ABI_Ctest__component_CIFailure* This,
+        HSTRING value);
+
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CIFailureVtbl;
+
+    interface __x_ABI_Ctest__component_CIFailure
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CIFailureVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CIFailure;
+#endif /* !defined(____x_ABI_Ctest__component_CIFailure_INTERFACE_DEFINED__) */
+    
+#if !defined(____x_ABI_Ctest__component_CIFailureStatics_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CIFailureStatics_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CIFailureStaticsVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIFailureStatics* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIFailureStatics* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIFailureStatics* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIFailureStatics* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIFailureStatics* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIFailureStatics* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* FailedStaticMethod)(__x_ABI_Ctest__component_CIFailureStatics* This);
+    HRESULT (STDMETHODCALLTYPE* get_FailedStaticProperty)(__x_ABI_Ctest__component_CIFailureStatics* This,
+        boolean* value);
+
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CIFailureStaticsVtbl;
+
+    interface __x_ABI_Ctest__component_CIFailureStatics
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CIFailureStaticsVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CIFailureStatics;
+#endif /* !defined(____x_ABI_Ctest__component_CIFailureStatics_INTERFACE_DEFINED__) */
     
 #if !defined(____x_ABI_Ctest__component_CIIAmImplementable_INTERFACE_DEFINED__)
     #define ____x_ABI_Ctest__component_CIIAmImplementable_INTERFACE_DEFINED__

--- a/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
@@ -638,7 +638,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         open func GetStringImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetString(pThis, &value))
             }
@@ -943,7 +943,7 @@ public enum __ABI_Windows_Foundation {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIStringable }
 
         open func ToStringImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIStringable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ToString(pThis, &value))
             }
@@ -995,7 +995,7 @@ public enum __ABI_Windows_Foundation {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIUriEscapeStatics }
 
         internal func UnescapeComponentImpl(_ toUnescape: String) throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             let _toUnescape = try! HString(toUnescape)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriEscapeStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.UnescapeComponent(pThis, _toUnescape.get(), &value))
@@ -1004,7 +1004,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func EscapeComponentImpl(_ toEscape: String) throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             let _toEscape = try! HString(toEscape)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriEscapeStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.EscapeComponent(pThis, _toEscape.get(), &value))
@@ -1018,7 +1018,7 @@ public enum __ABI_Windows_Foundation {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIUriRuntimeClass }
 
         internal func get_AbsoluteUriImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AbsoluteUri(pThis, &value))
             }
@@ -1026,7 +1026,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_DisplayUriImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayUri(pThis, &value))
             }
@@ -1034,7 +1034,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_DomainImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Domain(pThis, &value))
             }
@@ -1042,7 +1042,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_ExtensionImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Extension(pThis, &value))
             }
@@ -1050,7 +1050,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_FragmentImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Fragment(pThis, &value))
             }
@@ -1058,7 +1058,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_HostImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Host(pThis, &value))
             }
@@ -1066,7 +1066,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_PasswordImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Password(pThis, &value))
             }
@@ -1074,7 +1074,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_PathImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Path(pThis, &value))
             }
@@ -1082,7 +1082,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_QueryImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Query(pThis, &value))
             }
@@ -1099,7 +1099,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_RawUriImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_RawUri(pThis, &value))
             }
@@ -1107,7 +1107,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_SchemeNameImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_SchemeName(pThis, &value))
             }
@@ -1115,7 +1115,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_UserNameImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_UserName(pThis, &value))
             }
@@ -1188,7 +1188,7 @@ public enum __ABI_Windows_Foundation {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIUriRuntimeClassWithAbsoluteCanonicalUri }
 
         internal func get_AbsoluteCanonicalUriImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClassWithAbsoluteCanonicalUri.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AbsoluteCanonicalUri(pThis, &value))
             }
@@ -1196,7 +1196,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         internal func get_DisplayIriImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClassWithAbsoluteCanonicalUri.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayIri(pThis, &value))
             }
@@ -1209,7 +1209,7 @@ public enum __ABI_Windows_Foundation {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderEntry }
 
         open func get_NameImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Name(pThis, &value))
             }
@@ -1217,7 +1217,7 @@ public enum __ABI_Windows_Foundation {
         }
 
         open func get_ValueImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &value))
             }
@@ -1274,7 +1274,7 @@ public enum __ABI_Windows_Foundation {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass }
 
         internal func GetFirstValueByNameImpl(_ name: String) throws -> String {
-            var phstrValue: HSTRING?
+            var phstrValue: HSTRING? = nil
             let _name = try! HString(name)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetFirstValueByName(pThis, _name.get(), &phstrValue))

--- a/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
@@ -34,8 +34,8 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncaction.completed)
         fileprivate var completed : AsyncActionCompletedHandler! {
-            get { try! _default.get_CompletedImpl() }
-            set { try! _default.put_CompletedImpl(newValue) }
+            get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+            set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
         }
 
         private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -51,17 +51,17 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncaction.errorcode)
         fileprivate var errorCode : HRESULT {
-            get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+            get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncaction.id)
         fileprivate var id : UInt32 {
-            get { try! _IAsyncInfo.get_IdImpl() }
+            get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncaction.status)
         fileprivate var status : AsyncStatus {
-            get { try! _IAsyncInfo.get_StatusImpl() }
+            get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
         }
 
     }
@@ -101,17 +101,17 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncinfo.errorcode)
         fileprivate var errorCode : HRESULT {
-            get { try! _default.get_ErrorCodeImpl() }
+            get { _tryWinRT(0, try _default.get_ErrorCodeImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncinfo.id)
         fileprivate var id : UInt32 {
-            get { try! _default.get_IdImpl() }
+            get { _tryWinRT(0, try _default.get_IdImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncinfo.status)
         fileprivate var status : AsyncStatus {
-            get { try! _default.get_StatusImpl() }
+            get { _tryWinRT(.init(0), try _default.get_StatusImpl()) }
         }
 
     }
@@ -207,7 +207,7 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.imemorybufferreference.capacity)
         fileprivate var capacity : UInt32 {
-            get { try! _default.get_CapacityImpl() }
+            get { _tryWinRT(0, try _default.get_CapacityImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.imemorybufferreference.closed)
@@ -386,12 +386,12 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iwwwformurldecoderentry.name)
         fileprivate var name : String {
-            get { try! _default.get_NameImpl() }
+            get { _tryWinRT("", try _default.get_NameImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iwwwformurldecoderentry.value)
         fileprivate var value : String {
-            get { try! _default.get_ValueImpl() }
+            get { _tryWinRT("", try _default.get_ValueImpl()) }
         }
 
     }

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
@@ -77,7 +77,7 @@ public enum __IMPL_Windows_Foundation_Collections {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ipropertyset.size)
         fileprivate var size : UInt32 {
-            get { try! _IMap.get_SizeImpl() }
+            get { _tryWinRT(0, try _IMap.get_SizeImpl()) }
         }
 
         private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()
@@ -113,12 +113,12 @@ public enum __IMPL_Windows_Foundation_Collections {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorchangedeventargs.collectionchange)
         fileprivate var collectionChange : CollectionChange {
-            get { try! _default.get_CollectionChangeImpl() }
+            get { _tryWinRT(.init(0), try _default.get_CollectionChangeImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorchangedeventargs.index)
         fileprivate var index : UInt32 {
-            get { try! _default.get_IndexImpl() }
+            get { _tryWinRT(0, try _default.get_IndexImpl()) }
         }
 
     }

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
@@ -87,7 +87,7 @@ public final class PropertySet : WinRTClass, IObservableMap, IMap, IIterable, IP
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.propertyset.size)
     public var size : UInt32 {
-        get { try! _IMap.get_SizeImpl() }
+        get { _tryWinRT(0, try _IMap.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()
@@ -171,7 +171,7 @@ public final class StringMap : WinRTClass, IMap, IIterable, IObservableMap {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.stringmap.size)
     public var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_String! = getInterfaceForCaching()
@@ -283,7 +283,7 @@ public final class ValueSet : WinRTClass, IObservableMap, IMap, IIterable, IProp
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.valueset.size)
     public var size : UInt32 {
-        get { try! _IMap.get_SizeImpl() }
+        get { _tryWinRT(0, try _IMap.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -135,12 +135,12 @@ public final class Uri : WinRTClass, IStringable {
     private static let _IUriEscapeStatics: __ABI_Windows_Foundation.IUriEscapeStatics = try! RoGetActivationFactory("Windows.Foundation.Uri")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.unescapecomponent)
     public static func unescapeComponent(_ toUnescape: String) -> String {
-        return try! _IUriEscapeStatics.UnescapeComponentImpl(toUnescape)
+        return _tryWinRT("", try _IUriEscapeStatics.UnescapeComponentImpl(toUnescape))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.escapecomponent)
     public static func escapeComponent(_ toEscape: String) -> String {
-        return try! _IUriEscapeStatics.EscapeComponentImpl(toEscape)
+        return _tryWinRT("", try _IUriEscapeStatics.EscapeComponentImpl(toEscape))
     }
 
     private static let _IUriRuntimeClassFactory: __ABI_Windows_Foundation.IUriRuntimeClassFactory = try! RoGetActivationFactory("Windows.Foundation.Uri")
@@ -164,88 +164,88 @@ public final class Uri : WinRTClass, IStringable {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.absoluteuri)
     public var absoluteUri : String {
-        get { try! _default.get_AbsoluteUriImpl() }
+        get { _tryWinRT("", try _default.get_AbsoluteUriImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.displayuri)
     public var displayUri : String {
-        get { try! _default.get_DisplayUriImpl() }
+        get { _tryWinRT("", try _default.get_DisplayUriImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.domain)
     public var domain : String {
-        get { try! _default.get_DomainImpl() }
+        get { _tryWinRT("", try _default.get_DomainImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.extension)
     public var `extension` : String {
-        get { try! _default.get_ExtensionImpl() }
+        get { _tryWinRT("", try _default.get_ExtensionImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.fragment)
     public var fragment : String {
-        get { try! _default.get_FragmentImpl() }
+        get { _tryWinRT("", try _default.get_FragmentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.host)
     public var host : String {
-        get { try! _default.get_HostImpl() }
+        get { _tryWinRT("", try _default.get_HostImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.password)
     public var password : String {
-        get { try! _default.get_PasswordImpl() }
+        get { _tryWinRT("", try _default.get_PasswordImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.path)
     public var path : String {
-        get { try! _default.get_PathImpl() }
+        get { _tryWinRT("", try _default.get_PathImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.port)
     public var port : Int32 {
-        get { try! _default.get_PortImpl() }
+        get { _tryWinRT(0, try _default.get_PortImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.query)
     public var query : String {
-        get { try! _default.get_QueryImpl() }
+        get { _tryWinRT("", try _default.get_QueryImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.queryparsed)
     public var queryParsed : WwwFormUrlDecoder! {
-        get { try! _default.get_QueryParsedImpl() }
+        get { _tryWinRT(nil, try _default.get_QueryParsedImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.rawuri)
     public var rawUri : String {
-        get { try! _default.get_RawUriImpl() }
+        get { _tryWinRT("", try _default.get_RawUriImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.schemename)
     public var schemeName : String {
-        get { try! _default.get_SchemeNameImpl() }
+        get { _tryWinRT("", try _default.get_SchemeNameImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.suspicious)
     public var suspicious : Bool {
-        get { try! _default.get_SuspiciousImpl() }
+        get { _tryWinRT(false, try _default.get_SuspiciousImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.username)
     public var userName : String {
-        get { try! _default.get_UserNameImpl() }
+        get { _tryWinRT("", try _default.get_UserNameImpl()) }
     }
 
     private lazy var _IUriRuntimeClassWithAbsoluteCanonicalUri: __ABI_Windows_Foundation.IUriRuntimeClassWithAbsoluteCanonicalUri! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.absolutecanonicaluri)
     public var absoluteCanonicalUri : String {
-        get { try! _IUriRuntimeClassWithAbsoluteCanonicalUri.get_AbsoluteCanonicalUriImpl() }
+        get { _tryWinRT("", try _IUriRuntimeClassWithAbsoluteCanonicalUri.get_AbsoluteCanonicalUriImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.displayiri)
     public var displayIri : String {
-        get { try! _IUriRuntimeClassWithAbsoluteCanonicalUri.get_DisplayIriImpl() }
+        get { _tryWinRT("", try _IUriRuntimeClassWithAbsoluteCanonicalUri.get_DisplayIriImpl()) }
     }
 
     private lazy var _IStringable: __ABI_Windows_Foundation.IStringable! = getInterfaceForCaching()
@@ -335,7 +335,7 @@ public final class WwwFormUrlDecoder : WinRTClass, IIterable, IVectorView {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.wwwformurldecoder.size)
     public var size : UInt32 {
-        get { try! _IVectorView.get_SizeImpl() }
+        get { _tryWinRT(0, try _IVectorView.get_SizeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.wwwformurldecoder.getfirstvaluebyname)

--- a/tests/test_component/Sources/test_component/Windows.Storage+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage+ABI.swift
@@ -255,7 +255,7 @@ public enum __ABI_Windows_Storage {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFile }
 
         open func get_FileTypeImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_FileType(pThis, &value))
             }
@@ -263,7 +263,7 @@ public enum __ABI_Windows_Storage {
         }
 
         open func get_ContentTypeImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ContentType(pThis, &value))
             }
@@ -1126,7 +1126,7 @@ public enum __ABI_Windows_Storage {
         }
 
         open func get_NameImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Name(pThis, &value))
             }
@@ -1134,7 +1134,7 @@ public enum __ABI_Windows_Storage {
         }
 
         open func get_PathImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Path(pThis, &value))
             }
@@ -1395,7 +1395,7 @@ public enum __ABI_Windows_Storage {
         }
 
         open func get_DisplayNameImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayName(pThis, &value))
             }
@@ -1403,7 +1403,7 @@ public enum __ABI_Windows_Storage {
         }
 
         open func get_DisplayTypeImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayType(pThis, &value))
             }
@@ -1411,7 +1411,7 @@ public enum __ABI_Windows_Storage {
         }
 
         open func get_FolderRelativeIdImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_FolderRelativeId(pThis, &value))
             }
@@ -1686,7 +1686,7 @@ public enum __ABI_Windows_Storage {
         }
 
         internal func get_PathImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Path(pThis, &value))
             }
@@ -1694,7 +1694,7 @@ public enum __ABI_Windows_Storage {
         }
 
         internal func get_PreviousPathImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_PreviousPath(pThis, &value))
             }
@@ -1773,7 +1773,7 @@ public enum __ABI_Windows_Storage {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageProvider }
 
         internal func get_IdImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageProvider.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Id(pThis, &value))
             }
@@ -1781,7 +1781,7 @@ public enum __ABI_Windows_Storage {
         }
 
         internal func get_DisplayNameImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageProvider.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayName(pThis, &value))
             }

--- a/tests/test_component/Sources/test_component/Windows.Storage+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage+Impl.swift
@@ -79,12 +79,12 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.contenttype)
         fileprivate var contentType : String {
-            get { try! _default.get_ContentTypeImpl() }
+            get { _tryWinRT("", try _default.get_ContentTypeImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.filetype)
         fileprivate var fileType : String {
-            get { try! _default.get_FileTypeImpl() }
+            get { _tryWinRT("", try _default.get_FileTypeImpl()) }
         }
 
         private lazy var _IStorageItem: __ABI_Windows_Storage.IStorageItem! = getInterfaceForCaching()
@@ -120,22 +120,22 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.attributes)
         fileprivate var attributes : FileAttributes {
-            get { try! _IStorageItem.get_AttributesImpl() }
+            get { _tryWinRT(.init(0), try _IStorageItem.get_AttributesImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.datecreated)
         fileprivate var dateCreated : test_component.DateTime {
-            get { try! _IStorageItem.get_DateCreatedImpl() }
+            get { _tryWinRT(.init(), try _IStorageItem.get_DateCreatedImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.name)
         fileprivate var name : String {
-            get { try! _IStorageItem.get_NameImpl() }
+            get { _tryWinRT("", try _IStorageItem.get_NameImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.path)
         fileprivate var path : String {
-            get { try! _IStorageItem.get_PathImpl() }
+            get { _tryWinRT("", try _IStorageItem.get_PathImpl()) }
         }
 
         private lazy var _IRandomAccessStreamReference: __ABI_Windows_Storage_Streams.IRandomAccessStreamReference! = getInterfaceForCaching()
@@ -212,7 +212,7 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefilepropertieswithavailability.isavailable)
         fileprivate var isAvailable : Bool {
-            get { try! _default.get_IsAvailableImpl() }
+            get { _tryWinRT(false, try _default.get_IsAvailableImpl()) }
         }
 
     }
@@ -323,22 +323,22 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.attributes)
         fileprivate var attributes : FileAttributes {
-            get { try! _IStorageItem.get_AttributesImpl() }
+            get { _tryWinRT(.init(0), try _IStorageItem.get_AttributesImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.datecreated)
         fileprivate var dateCreated : test_component.DateTime {
-            get { try! _IStorageItem.get_DateCreatedImpl() }
+            get { _tryWinRT(.init(), try _IStorageItem.get_DateCreatedImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.name)
         fileprivate var name : String {
-            get { try! _IStorageItem.get_NameImpl() }
+            get { _tryWinRT("", try _IStorageItem.get_NameImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.path)
         fileprivate var path : String {
-            get { try! _IStorageItem.get_PathImpl() }
+            get { _tryWinRT("", try _IStorageItem.get_PathImpl()) }
         }
 
     }
@@ -428,22 +428,22 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.attributes)
         fileprivate var attributes : FileAttributes {
-            get { try! _default.get_AttributesImpl() }
+            get { _tryWinRT(.init(0), try _default.get_AttributesImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.datecreated)
         fileprivate var dateCreated : test_component.DateTime {
-            get { try! _default.get_DateCreatedImpl() }
+            get { _tryWinRT(.init(), try _default.get_DateCreatedImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.name)
         fileprivate var name : String {
-            get { try! _default.get_NameImpl() }
+            get { _tryWinRT("", try _default.get_NameImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.path)
         fileprivate var path : String {
-            get { try! _default.get_PathImpl() }
+            get { _tryWinRT("", try _default.get_PathImpl()) }
         }
 
     }
@@ -514,22 +514,22 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.attributes)
         fileprivate var attributes : FileAttributes {
-            get { try! _IStorageItem.get_AttributesImpl() }
+            get { _tryWinRT(.init(0), try _IStorageItem.get_AttributesImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.datecreated)
         fileprivate var dateCreated : test_component.DateTime {
-            get { try! _IStorageItem.get_DateCreatedImpl() }
+            get { _tryWinRT(.init(), try _IStorageItem.get_DateCreatedImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.name)
         fileprivate var name : String {
-            get { try! _IStorageItem.get_NameImpl() }
+            get { _tryWinRT("", try _IStorageItem.get_NameImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.path)
         fileprivate var path : String {
-            get { try! _IStorageItem.get_PathImpl() }
+            get { _tryWinRT("", try _IStorageItem.get_PathImpl()) }
         }
 
     }
@@ -574,22 +574,22 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties.displayname)
         fileprivate var displayName : String {
-            get { try! _default.get_DisplayNameImpl() }
+            get { _tryWinRT("", try _default.get_DisplayNameImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties.displaytype)
         fileprivate var displayType : String {
-            get { try! _default.get_DisplayTypeImpl() }
+            get { _tryWinRT("", try _default.get_DisplayTypeImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties.folderrelativeid)
         fileprivate var folderRelativeId : String {
-            get { try! _default.get_FolderRelativeIdImpl() }
+            get { _tryWinRT("", try _default.get_FolderRelativeIdImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties.properties)
         fileprivate var properties : test_component.StorageItemContentProperties! {
-            get { try! _default.get_PropertiesImpl() }
+            get { _tryWinRT(nil, try _default.get_PropertiesImpl()) }
         }
 
     }
@@ -650,22 +650,22 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.displayname)
         fileprivate var displayName : String {
-            get { try! _IStorageItemProperties.get_DisplayNameImpl() }
+            get { _tryWinRT("", try _IStorageItemProperties.get_DisplayNameImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.displaytype)
         fileprivate var displayType : String {
-            get { try! _IStorageItemProperties.get_DisplayTypeImpl() }
+            get { _tryWinRT("", try _IStorageItemProperties.get_DisplayTypeImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.folderrelativeid)
         fileprivate var folderRelativeId : String {
-            get { try! _IStorageItemProperties.get_FolderRelativeIdImpl() }
+            get { _tryWinRT("", try _IStorageItemProperties.get_FolderRelativeIdImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.properties)
         fileprivate var properties : test_component.StorageItemContentProperties! {
-            get { try! _IStorageItemProperties.get_PropertiesImpl() }
+            get { _tryWinRT(nil, try _IStorageItemProperties.get_PropertiesImpl()) }
         }
 
     }
@@ -695,7 +695,7 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.provider)
         fileprivate var provider : StorageProvider! {
-            get { try! _default.get_ProviderImpl() }
+            get { _tryWinRT(nil, try _default.get_ProviderImpl()) }
         }
 
         private lazy var _IStorageItemProperties: __ABI_Windows_Storage.IStorageItemProperties! = getInterfaceForCaching()
@@ -716,22 +716,22 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.displayname)
         fileprivate var displayName : String {
-            get { try! _IStorageItemProperties.get_DisplayNameImpl() }
+            get { _tryWinRT("", try _IStorageItemProperties.get_DisplayNameImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.displaytype)
         fileprivate var displayType : String {
-            get { try! _IStorageItemProperties.get_DisplayTypeImpl() }
+            get { _tryWinRT("", try _IStorageItemProperties.get_DisplayTypeImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.folderrelativeid)
         fileprivate var folderRelativeId : String {
-            get { try! _IStorageItemProperties.get_FolderRelativeIdImpl() }
+            get { _tryWinRT("", try _IStorageItemProperties.get_FolderRelativeIdImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.properties)
         fileprivate var properties : test_component.StorageItemContentProperties! {
-            get { try! _IStorageItemProperties.get_PropertiesImpl() }
+            get { _tryWinRT(nil, try _IStorageItemProperties.get_PropertiesImpl()) }
         }
 
     }

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+ABI.swift
@@ -78,7 +78,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_TitleImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
             }
@@ -102,7 +102,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_CommentImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Comment(pThis, &value))
             }
@@ -175,7 +175,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_TitleImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
             }
@@ -208,7 +208,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_CameraManufacturerImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_CameraManufacturer(pThis, &value))
             }
@@ -223,7 +223,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_CameraModelImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_CameraModel(pThis, &value))
             }
@@ -260,7 +260,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties }
 
         internal func get_AlbumImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Album(pThis, &value))
             }
@@ -275,7 +275,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_ArtistImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Artist(pThis, &value))
             }
@@ -313,7 +313,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_TitleImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
             }
@@ -358,7 +358,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_AlbumArtistImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AlbumArtist(pThis, &value))
             }
@@ -391,7 +391,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_SubtitleImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Subtitle(pThis, &value))
             }
@@ -415,7 +415,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_PublisherImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Publisher(pThis, &value))
             }
@@ -699,7 +699,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_TitleImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
             }
@@ -714,7 +714,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_SubtitleImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Subtitle(pThis, &value))
             }
@@ -738,7 +738,7 @@ public enum __ABI_Windows_Storage_FileProperties {
         }
 
         internal func get_PublisherImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Publisher(pThis, &value))
             }

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties.swift
@@ -44,17 +44,17 @@ public final class BasicProperties : WinRTClass, IStorageItemExtraProperties {
     }
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.basicproperties.datemodified)
     public var dateModified : test_component.DateTime {
-        get { try! _default.get_DateModifiedImpl() }
+        get { _tryWinRT(.init(), try _default.get_DateModifiedImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.basicproperties.itemdate)
     public var itemDate : test_component.DateTime {
-        get { try! _default.get_ItemDateImpl() }
+        get { _tryWinRT(.init(), try _default.get_ItemDateImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.basicproperties.size)
     public var size : UInt64 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IStorageItemExtraProperties: __ABI_Windows_Storage_FileProperties.IStorageItemExtraProperties! = getInterfaceForCaching()
@@ -124,24 +124,24 @@ public final class DocumentProperties : WinRTClass, IStorageItemExtraProperties 
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.documentproperties.author)
     public var author : AnyIVector<String>! {
-        get { try! _default.get_AuthorImpl() }
+        get { _tryWinRT(nil, try _default.get_AuthorImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.documentproperties.comment)
     public var comment : String {
-        get { try! _default.get_CommentImpl() }
-        set { try! _default.put_CommentImpl(newValue) }
+        get { _tryWinRT("", try _default.get_CommentImpl()) }
+        set { _tryWinRT(try _default.put_CommentImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.documentproperties.keywords)
     public var keywords : AnyIVector<String>! {
-        get { try! _default.get_KeywordsImpl() }
+        get { _tryWinRT(nil, try _default.get_KeywordsImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.documentproperties.title)
     public var title : String {
-        get { try! _default.get_TitleImpl() }
-        set { try! _default.put_TitleImpl(newValue) }
+        get { _tryWinRT("", try _default.get_TitleImpl()) }
+        set { _tryWinRT(try _default.put_TitleImpl(newValue)) }
     }
 
     deinit {
@@ -195,67 +195,67 @@ public final class ImageProperties : WinRTClass, IStorageItemExtraProperties {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.cameramanufacturer)
     public var cameraManufacturer : String {
-        get { try! _default.get_CameraManufacturerImpl() }
-        set { try! _default.put_CameraManufacturerImpl(newValue) }
+        get { _tryWinRT("", try _default.get_CameraManufacturerImpl()) }
+        set { _tryWinRT(try _default.put_CameraManufacturerImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.cameramodel)
     public var cameraModel : String {
-        get { try! _default.get_CameraModelImpl() }
-        set { try! _default.put_CameraModelImpl(newValue) }
+        get { _tryWinRT("", try _default.get_CameraModelImpl()) }
+        set { _tryWinRT(try _default.put_CameraModelImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.datetaken)
     public var dateTaken : test_component.DateTime {
-        get { try! _default.get_DateTakenImpl() }
-        set { try! _default.put_DateTakenImpl(newValue) }
+        get { _tryWinRT(.init(), try _default.get_DateTakenImpl()) }
+        set { _tryWinRT(try _default.put_DateTakenImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.height)
     public var height : UInt32 {
-        get { try! _default.get_HeightImpl() }
+        get { _tryWinRT(0, try _default.get_HeightImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.keywords)
     public var keywords : AnyIVector<String>! {
-        get { try! _default.get_KeywordsImpl() }
+        get { _tryWinRT(nil, try _default.get_KeywordsImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.latitude)
     public var latitude : Double? {
-        get { try! _default.get_LatitudeImpl() }
+        get { _tryWinRT(nil, try _default.get_LatitudeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.longitude)
     public var longitude : Double? {
-        get { try! _default.get_LongitudeImpl() }
+        get { _tryWinRT(nil, try _default.get_LongitudeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.orientation)
     public var orientation : PhotoOrientation {
-        get { try! _default.get_OrientationImpl() }
+        get { _tryWinRT(.init(0), try _default.get_OrientationImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.peoplenames)
     public var peopleNames : AnyIVectorView<String>! {
-        get { try! _default.get_PeopleNamesImpl() }
+        get { _tryWinRT(nil, try _default.get_PeopleNamesImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.rating)
     public var rating : UInt32 {
-        get { try! _default.get_RatingImpl() }
-        set { try! _default.put_RatingImpl(newValue) }
+        get { _tryWinRT(0, try _default.get_RatingImpl()) }
+        set { _tryWinRT(try _default.put_RatingImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.title)
     public var title : String {
-        get { try! _default.get_TitleImpl() }
-        set { try! _default.put_TitleImpl(newValue) }
+        get { _tryWinRT("", try _default.get_TitleImpl()) }
+        set { _tryWinRT(try _default.put_TitleImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.width)
     public var width : UInt32 {
-        get { try! _default.get_WidthImpl() }
+        get { _tryWinRT(0, try _default.get_WidthImpl()) }
     }
 
     deinit {
@@ -309,91 +309,91 @@ public final class MusicProperties : WinRTClass, IStorageItemExtraProperties {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.album)
     public var album : String {
-        get { try! _default.get_AlbumImpl() }
-        set { try! _default.put_AlbumImpl(newValue) }
+        get { _tryWinRT("", try _default.get_AlbumImpl()) }
+        set { _tryWinRT(try _default.put_AlbumImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.albumartist)
     public var albumArtist : String {
-        get { try! _default.get_AlbumArtistImpl() }
-        set { try! _default.put_AlbumArtistImpl(newValue) }
+        get { _tryWinRT("", try _default.get_AlbumArtistImpl()) }
+        set { _tryWinRT(try _default.put_AlbumArtistImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.artist)
     public var artist : String {
-        get { try! _default.get_ArtistImpl() }
-        set { try! _default.put_ArtistImpl(newValue) }
+        get { _tryWinRT("", try _default.get_ArtistImpl()) }
+        set { _tryWinRT(try _default.put_ArtistImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.bitrate)
     public var bitrate : UInt32 {
-        get { try! _default.get_BitrateImpl() }
+        get { _tryWinRT(0, try _default.get_BitrateImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.composers)
     public var composers : AnyIVector<String>! {
-        get { try! _default.get_ComposersImpl() }
+        get { _tryWinRT(nil, try _default.get_ComposersImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.conductors)
     public var conductors : AnyIVector<String>! {
-        get { try! _default.get_ConductorsImpl() }
+        get { _tryWinRT(nil, try _default.get_ConductorsImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.duration)
     public var duration : test_component.TimeSpan {
-        get { try! _default.get_DurationImpl() }
+        get { _tryWinRT(.init(), try _default.get_DurationImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.genre)
     public var genre : AnyIVector<String>! {
-        get { try! _default.get_GenreImpl() }
+        get { _tryWinRT(nil, try _default.get_GenreImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.producers)
     public var producers : AnyIVector<String>! {
-        get { try! _default.get_ProducersImpl() }
+        get { _tryWinRT(nil, try _default.get_ProducersImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.publisher)
     public var publisher : String {
-        get { try! _default.get_PublisherImpl() }
-        set { try! _default.put_PublisherImpl(newValue) }
+        get { _tryWinRT("", try _default.get_PublisherImpl()) }
+        set { _tryWinRT(try _default.put_PublisherImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.rating)
     public var rating : UInt32 {
-        get { try! _default.get_RatingImpl() }
-        set { try! _default.put_RatingImpl(newValue) }
+        get { _tryWinRT(0, try _default.get_RatingImpl()) }
+        set { _tryWinRT(try _default.put_RatingImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.subtitle)
     public var subtitle : String {
-        get { try! _default.get_SubtitleImpl() }
-        set { try! _default.put_SubtitleImpl(newValue) }
+        get { _tryWinRT("", try _default.get_SubtitleImpl()) }
+        set { _tryWinRT(try _default.put_SubtitleImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.title)
     public var title : String {
-        get { try! _default.get_TitleImpl() }
-        set { try! _default.put_TitleImpl(newValue) }
+        get { _tryWinRT("", try _default.get_TitleImpl()) }
+        set { _tryWinRT(try _default.put_TitleImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.tracknumber)
     public var trackNumber : UInt32 {
-        get { try! _default.get_TrackNumberImpl() }
-        set { try! _default.put_TrackNumberImpl(newValue) }
+        get { _tryWinRT(0, try _default.get_TrackNumberImpl()) }
+        set { _tryWinRT(try _default.put_TrackNumberImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.writers)
     public var writers : AnyIVector<String>! {
-        get { try! _default.get_WritersImpl() }
+        get { _tryWinRT(nil, try _default.get_WritersImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.year)
     public var year : UInt32 {
-        get { try! _default.get_YearImpl() }
-        set { try! _default.put_YearImpl(newValue) }
+        get { _tryWinRT(0, try _default.get_YearImpl()) }
+        set { _tryWinRT(try _default.put_YearImpl(newValue)) }
     }
 
     deinit {
@@ -544,50 +544,50 @@ public final class StorageItemThumbnail : WinRTClass, test_component.IClosable, 
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.canread)
     public var canRead : Bool {
-        get { try! _IRandomAccessStream.get_CanReadImpl() }
+        get { _tryWinRT(false, try _IRandomAccessStream.get_CanReadImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.canwrite)
     public var canWrite : Bool {
-        get { try! _IRandomAccessStream.get_CanWriteImpl() }
+        get { _tryWinRT(false, try _IRandomAccessStream.get_CanWriteImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.position)
     public var position : UInt64 {
-        get { try! _IRandomAccessStream.get_PositionImpl() }
+        get { _tryWinRT(0, try _IRandomAccessStream.get_PositionImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.size)
     public var size : UInt64 {
-        get { try! _IRandomAccessStream.get_SizeImpl() }
-        set { try! _IRandomAccessStream.put_SizeImpl(newValue) }
+        get { _tryWinRT(0, try _IRandomAccessStream.get_SizeImpl()) }
+        set { _tryWinRT(try _IRandomAccessStream.put_SizeImpl(newValue)) }
     }
 
     private lazy var _IContentTypeProvider: __ABI_Windows_Storage_Streams.IContentTypeProvider! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.contenttype)
     public var contentType : String {
-        get { try! _IContentTypeProvider.get_ContentTypeImpl() }
+        get { _tryWinRT("", try _IContentTypeProvider.get_ContentTypeImpl()) }
     }
 
     private lazy var _IThumbnailProperties: __ABI_Windows_Storage_FileProperties.IThumbnailProperties! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.originalheight)
     public var originalHeight : UInt32 {
-        get { try! _IThumbnailProperties.get_OriginalHeightImpl() }
+        get { _tryWinRT(0, try _IThumbnailProperties.get_OriginalHeightImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.originalwidth)
     public var originalWidth : UInt32 {
-        get { try! _IThumbnailProperties.get_OriginalWidthImpl() }
+        get { _tryWinRT(0, try _IThumbnailProperties.get_OriginalWidthImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.returnedsmallercachedsize)
     public var returnedSmallerCachedSize : Bool {
-        get { try! _IThumbnailProperties.get_ReturnedSmallerCachedSizeImpl() }
+        get { _tryWinRT(false, try _IThumbnailProperties.get_ReturnedSmallerCachedSizeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.type)
     public var type : ThumbnailType {
-        get { try! _IThumbnailProperties.get_TypeImpl() }
+        get { _tryWinRT(.init(0), try _IThumbnailProperties.get_TypeImpl()) }
     }
 
     deinit {
@@ -646,87 +646,87 @@ public final class VideoProperties : WinRTClass, IStorageItemExtraProperties {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.bitrate)
     public var bitrate : UInt32 {
-        get { try! _default.get_BitrateImpl() }
+        get { _tryWinRT(0, try _default.get_BitrateImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.directors)
     public var directors : AnyIVector<String>! {
-        get { try! _default.get_DirectorsImpl() }
+        get { _tryWinRT(nil, try _default.get_DirectorsImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.duration)
     public var duration : test_component.TimeSpan {
-        get { try! _default.get_DurationImpl() }
+        get { _tryWinRT(.init(), try _default.get_DurationImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.height)
     public var height : UInt32 {
-        get { try! _default.get_HeightImpl() }
+        get { _tryWinRT(0, try _default.get_HeightImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.keywords)
     public var keywords : AnyIVector<String>! {
-        get { try! _default.get_KeywordsImpl() }
+        get { _tryWinRT(nil, try _default.get_KeywordsImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.latitude)
     public var latitude : Double? {
-        get { try! _default.get_LatitudeImpl() }
+        get { _tryWinRT(nil, try _default.get_LatitudeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.longitude)
     public var longitude : Double? {
-        get { try! _default.get_LongitudeImpl() }
+        get { _tryWinRT(nil, try _default.get_LongitudeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.orientation)
     public var orientation : VideoOrientation {
-        get { try! _default.get_OrientationImpl() }
+        get { _tryWinRT(.init(0), try _default.get_OrientationImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.producers)
     public var producers : AnyIVector<String>! {
-        get { try! _default.get_ProducersImpl() }
+        get { _tryWinRT(nil, try _default.get_ProducersImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.publisher)
     public var publisher : String {
-        get { try! _default.get_PublisherImpl() }
-        set { try! _default.put_PublisherImpl(newValue) }
+        get { _tryWinRT("", try _default.get_PublisherImpl()) }
+        set { _tryWinRT(try _default.put_PublisherImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.rating)
     public var rating : UInt32 {
-        get { try! _default.get_RatingImpl() }
-        set { try! _default.put_RatingImpl(newValue) }
+        get { _tryWinRT(0, try _default.get_RatingImpl()) }
+        set { _tryWinRT(try _default.put_RatingImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.subtitle)
     public var subtitle : String {
-        get { try! _default.get_SubtitleImpl() }
-        set { try! _default.put_SubtitleImpl(newValue) }
+        get { _tryWinRT("", try _default.get_SubtitleImpl()) }
+        set { _tryWinRT(try _default.put_SubtitleImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.title)
     public var title : String {
-        get { try! _default.get_TitleImpl() }
-        set { try! _default.put_TitleImpl(newValue) }
+        get { _tryWinRT("", try _default.get_TitleImpl()) }
+        set { _tryWinRT(try _default.put_TitleImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.width)
     public var width : UInt32 {
-        get { try! _default.get_WidthImpl() }
+        get { _tryWinRT(0, try _default.get_WidthImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.writers)
     public var writers : AnyIVector<String>! {
-        get { try! _default.get_WritersImpl() }
+        get { _tryWinRT(nil, try _default.get_WritersImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.year)
     public var year : UInt32 {
-        get { try! _default.get_YearImpl() }
-        set { try! _default.put_YearImpl(newValue) }
+        get { _tryWinRT(0, try _default.get_YearImpl()) }
+        set { _tryWinRT(try _default.put_YearImpl(newValue)) }
     }
 
     deinit {

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search+ABI.swift
@@ -67,7 +67,7 @@ public enum __ABI_Windows_Storage_Search {
         }
 
         internal func get_ApplicationSearchFilterImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ApplicationSearchFilter(pThis, &value))
             }
@@ -82,7 +82,7 @@ public enum __ABI_Windows_Storage_Search {
         }
 
         internal func get_UserSearchFilterImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_UserSearchFilter(pThis, &value))
             }
@@ -97,7 +97,7 @@ public enum __ABI_Windows_Storage_Search {
         }
 
         internal func get_LanguageImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Language(pThis, &value))
             }
@@ -135,7 +135,7 @@ public enum __ABI_Windows_Storage_Search {
         }
 
         internal func get_GroupPropertyNameImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_GroupPropertyName(pThis, &value))
             }
@@ -151,7 +151,7 @@ public enum __ABI_Windows_Storage_Search {
         }
 
         internal func SaveToStringImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.SaveToString(pThis, &value))
             }

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
@@ -159,7 +159,7 @@ public enum __IMPL_Windows_Storage_Search {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragequeryresultbase.folder)
         fileprivate var folder : test_component.StorageFolder! {
-            get { try! _default.get_FolderImpl() }
+            get { _tryWinRT(nil, try _default.get_FolderImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragequeryresultbase.contentschanged)

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
@@ -75,58 +75,58 @@ public final class QueryOptions : WinRTClass {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.applicationsearchfilter)
     public var applicationSearchFilter : String {
-        get { try! _default.get_ApplicationSearchFilterImpl() }
-        set { try! _default.put_ApplicationSearchFilterImpl(newValue) }
+        get { _tryWinRT("", try _default.get_ApplicationSearchFilterImpl()) }
+        set { _tryWinRT(try _default.put_ApplicationSearchFilterImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.datestackoption)
     public var dateStackOption : DateStackOption {
-        get { try! _default.get_DateStackOptionImpl() }
+        get { _tryWinRT(.init(0), try _default.get_DateStackOptionImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.filetypefilter)
     public var fileTypeFilter : AnyIVector<String>! {
-        get { try! _default.get_FileTypeFilterImpl() }
+        get { _tryWinRT(nil, try _default.get_FileTypeFilterImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.folderdepth)
     public var folderDepth : FolderDepth {
-        get { try! _default.get_FolderDepthImpl() }
-        set { try! _default.put_FolderDepthImpl(newValue) }
+        get { _tryWinRT(.init(0), try _default.get_FolderDepthImpl()) }
+        set { _tryWinRT(try _default.put_FolderDepthImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.grouppropertyname)
     public var groupPropertyName : String {
-        get { try! _default.get_GroupPropertyNameImpl() }
+        get { _tryWinRT("", try _default.get_GroupPropertyNameImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.indexeroption)
     public var indexerOption : IndexerOption {
-        get { try! _default.get_IndexerOptionImpl() }
-        set { try! _default.put_IndexerOptionImpl(newValue) }
+        get { _tryWinRT(.init(0), try _default.get_IndexerOptionImpl()) }
+        set { _tryWinRT(try _default.put_IndexerOptionImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.language)
     public var language : String {
-        get { try! _default.get_LanguageImpl() }
-        set { try! _default.put_LanguageImpl(newValue) }
+        get { _tryWinRT("", try _default.get_LanguageImpl()) }
+        set { _tryWinRT(try _default.put_LanguageImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.sortorder)
     public var sortOrder : AnyIVector<SortEntry>! {
-        get { try! _default.get_SortOrderImpl() }
+        get { _tryWinRT(nil, try _default.get_SortOrderImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.usersearchfilter)
     public var userSearchFilter : String {
-        get { try! _default.get_UserSearchFilterImpl() }
-        set { try! _default.put_UserSearchFilterImpl(newValue) }
+        get { _tryWinRT("", try _default.get_UserSearchFilterImpl()) }
+        set { _tryWinRT(try _default.put_UserSearchFilterImpl(newValue)) }
     }
 
     private lazy var _IQueryOptionsWithProviderFilter: __ABI_Windows_Storage_Search.IQueryOptionsWithProviderFilter! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.storageprovideridfilter)
     public var storageProviderIdFilter : AnyIVector<String>! {
-        get { try! _IQueryOptionsWithProviderFilter.get_StorageProviderIdFilterImpl() }
+        get { _tryWinRT(nil, try _IQueryOptionsWithProviderFilter.get_StorageProviderIdFilterImpl()) }
     }
 
     deinit {
@@ -185,7 +185,7 @@ public final class StorageFileQueryResult : WinRTClass, IStorageQueryResultBase 
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefilequeryresult.folder)
     public var folder : test_component.StorageFolder! {
-        get { try! _IStorageQueryResultBase.get_FolderImpl() }
+        get { _tryWinRT(nil, try _IStorageQueryResultBase.get_FolderImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefilequeryresult.contentschanged)
@@ -287,7 +287,7 @@ public final class StorageFolderQueryResult : WinRTClass, IStorageQueryResultBas
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefolderqueryresult.folder)
     public var folder : test_component.StorageFolder! {
-        get { try! _IStorageQueryResultBase.get_FolderImpl() }
+        get { _tryWinRT(nil, try _IStorageQueryResultBase.get_FolderImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefolderqueryresult.contentschanged)
@@ -382,7 +382,7 @@ public final class StorageItemQueryResult : WinRTClass, IStorageQueryResultBase 
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storageitemqueryresult.folder)
     public var folder : test_component.StorageFolder! {
-        get { try! _IStorageQueryResultBase.get_FolderImpl() }
+        get { _tryWinRT(nil, try _IStorageQueryResultBase.get_FolderImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storageitemqueryresult.contentschanged)

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams+ABI.swift
@@ -168,7 +168,7 @@ public enum __ABI_Windows_Storage_Streams {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIContentTypeProvider }
 
         open func get_ContentTypeImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIContentTypeProvider.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ContentType(pThis, &value))
             }

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams+Impl.swift
@@ -29,13 +29,13 @@ public enum __IMPL_Windows_Storage_Streams {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.ibuffer.capacity)
         fileprivate var capacity : UInt32 {
-            get { try! _default.get_CapacityImpl() }
+            get { _tryWinRT(0, try _default.get_CapacityImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.ibuffer.length)
         fileprivate var length : UInt32 {
-            get { try! _default.get_LengthImpl() }
-            set { try! _default.put_LengthImpl(newValue) }
+            get { _tryWinRT(0, try _default.get_LengthImpl()) }
+            set { _tryWinRT(try _default.put_LengthImpl(newValue)) }
         }
 
         private lazy var _IBufferByteAccess: __ABI_.IBufferByteAccess! = getInterfaceForCaching()
@@ -72,7 +72,7 @@ public enum __IMPL_Windows_Storage_Streams {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.icontenttypeprovider.contenttype)
         fileprivate var contentType : String {
-            get { try! _default.get_ContentTypeImpl() }
+            get { _tryWinRT("", try _default.get_ContentTypeImpl()) }
         }
 
     }
@@ -229,23 +229,23 @@ public enum __IMPL_Windows_Storage_Streams {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.canread)
         fileprivate var canRead : Bool {
-            get { try! _default.get_CanReadImpl() }
+            get { _tryWinRT(false, try _default.get_CanReadImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.canwrite)
         fileprivate var canWrite : Bool {
-            get { try! _default.get_CanWriteImpl() }
+            get { _tryWinRT(false, try _default.get_CanWriteImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.position)
         fileprivate var position : UInt64 {
-            get { try! _default.get_PositionImpl() }
+            get { _tryWinRT(0, try _default.get_PositionImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.size)
         fileprivate var size : UInt64 {
-            get { try! _default.get_SizeImpl() }
-            set { try! _default.put_SizeImpl(newValue) }
+            get { _tryWinRT(0, try _default.get_SizeImpl()) }
+            set { _tryWinRT(try _default.put_SizeImpl(newValue)) }
         }
 
         private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
@@ -372,29 +372,29 @@ public enum __IMPL_Windows_Storage_Streams {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.canread)
         fileprivate var canRead : Bool {
-            get { try! _IRandomAccessStream.get_CanReadImpl() }
+            get { _tryWinRT(false, try _IRandomAccessStream.get_CanReadImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.canwrite)
         fileprivate var canWrite : Bool {
-            get { try! _IRandomAccessStream.get_CanWriteImpl() }
+            get { _tryWinRT(false, try _IRandomAccessStream.get_CanWriteImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.position)
         fileprivate var position : UInt64 {
-            get { try! _IRandomAccessStream.get_PositionImpl() }
+            get { _tryWinRT(0, try _IRandomAccessStream.get_PositionImpl()) }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.size)
         fileprivate var size : UInt64 {
-            get { try! _IRandomAccessStream.get_SizeImpl() }
-            set { try! _IRandomAccessStream.put_SizeImpl(newValue) }
+            get { _tryWinRT(0, try _IRandomAccessStream.get_SizeImpl()) }
+            set { _tryWinRT(try _IRandomAccessStream.put_SizeImpl(newValue)) }
         }
 
         private lazy var _IContentTypeProvider: __ABI_Windows_Storage_Streams.IContentTypeProvider! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.contenttype)
         fileprivate var contentType : String {
-            get { try! _IContentTypeProvider.get_ContentTypeImpl() }
+            get { _tryWinRT("", try _IContentTypeProvider.get_ContentTypeImpl()) }
         }
 
     }

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams.swift
@@ -42,12 +42,12 @@ public final class Buffer : WinRTClass, IBufferByteAccess, IBuffer {
     private static let _IBufferStatics: __ABI_Windows_Storage_Streams.IBufferStatics = try! RoGetActivationFactory("Windows.Storage.Streams.Buffer")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.buffer.createcopyfrommemorybuffer)
     public static func createCopyFromMemoryBuffer(_ input: test_component.AnyIMemoryBuffer!) -> Buffer! {
-        return try! _IBufferStatics.CreateCopyFromMemoryBufferImpl(input)
+        return _tryWinRT(nil, try _IBufferStatics.CreateCopyFromMemoryBufferImpl(input))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.buffer.creatememorybufferoveribuffer)
     public static func createMemoryBufferOverIBuffer(_ input: AnyIBuffer!) -> test_component.MemoryBuffer! {
-        return try! _IBufferStatics.CreateMemoryBufferOverIBufferImpl(input)
+        return _tryWinRT(nil, try _IBufferStatics.CreateMemoryBufferOverIBufferImpl(input))
     }
 
     private lazy var _IBufferByteAccess: __ABI_.IBufferByteAccess! = getInterfaceForCaching()
@@ -59,13 +59,13 @@ public final class Buffer : WinRTClass, IBufferByteAccess, IBuffer {
     }
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.buffer.capacity)
     public var capacity : UInt32 {
-        get { try! _default.get_CapacityImpl() }
+        get { _tryWinRT(0, try _default.get_CapacityImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.buffer.length)
     public var length : UInt32 {
-        get { try! _default.get_LengthImpl() }
-        set { try! _default.put_LengthImpl(newValue) }
+        get { _tryWinRT(0, try _default.get_LengthImpl()) }
+        set { _tryWinRT(try _default.put_LengthImpl(newValue)) }
     }
 
     deinit {

--- a/tests/test_component/Sources/test_component/Windows.Storage.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.swift
@@ -26,72 +26,72 @@ public final class PathIO {
     private static let _IPathIOStatics: __ABI_Windows_Storage.IPathIOStatics = try! RoGetActivationFactory("Windows.Storage.PathIO")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readtextasync)
     public static func readTextAsync(_ absolutePath: String) -> AnyIAsyncOperation<String>! {
-        return try! _IPathIOStatics.ReadTextAsyncImpl(absolutePath)
+        return _tryWinRT(nil, try _IPathIOStatics.ReadTextAsyncImpl(absolutePath))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readtextasync)
     public static func readTextAsync(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) -> AnyIAsyncOperation<String>! {
-        return try! _IPathIOStatics.ReadTextWithEncodingAsyncImpl(absolutePath, encoding)
+        return _tryWinRT(nil, try _IPathIOStatics.ReadTextWithEncodingAsyncImpl(absolutePath, encoding))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writetextasync)
     public static func writeTextAsync(_ absolutePath: String, _ contents: String) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.WriteTextAsyncImpl(absolutePath, contents)
+        return _tryWinRT(nil, try _IPathIOStatics.WriteTextAsyncImpl(absolutePath, contents))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writetextasync)
     public static func writeTextAsync(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.WriteTextWithEncodingAsyncImpl(absolutePath, contents, encoding)
+        return _tryWinRT(nil, try _IPathIOStatics.WriteTextWithEncodingAsyncImpl(absolutePath, contents, encoding))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendtextasync)
     public static func appendTextAsync(_ absolutePath: String, _ contents: String) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.AppendTextAsyncImpl(absolutePath, contents)
+        return _tryWinRT(nil, try _IPathIOStatics.AppendTextAsyncImpl(absolutePath, contents))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendtextasync)
     public static func appendTextAsync(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.AppendTextWithEncodingAsyncImpl(absolutePath, contents, encoding)
+        return _tryWinRT(nil, try _IPathIOStatics.AppendTextWithEncodingAsyncImpl(absolutePath, contents, encoding))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readlinesasync)
     public static func readLinesAsync(_ absolutePath: String) -> AnyIAsyncOperation<AnyIVector<String>?>! {
-        return try! _IPathIOStatics.ReadLinesAsyncImpl(absolutePath)
+        return _tryWinRT(nil, try _IPathIOStatics.ReadLinesAsyncImpl(absolutePath))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readlinesasync)
     public static func readLinesAsync(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) -> AnyIAsyncOperation<AnyIVector<String>?>! {
-        return try! _IPathIOStatics.ReadLinesWithEncodingAsyncImpl(absolutePath, encoding)
+        return _tryWinRT(nil, try _IPathIOStatics.ReadLinesWithEncodingAsyncImpl(absolutePath, encoding))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writelinesasync)
     public static func writeLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.WriteLinesAsyncImpl(absolutePath, lines)
+        return _tryWinRT(nil, try _IPathIOStatics.WriteLinesAsyncImpl(absolutePath, lines))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writelinesasync)
     public static func writeLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!, _ encoding: test_component.UnicodeEncoding) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.WriteLinesWithEncodingAsyncImpl(absolutePath, lines, encoding)
+        return _tryWinRT(nil, try _IPathIOStatics.WriteLinesWithEncodingAsyncImpl(absolutePath, lines, encoding))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendlinesasync)
     public static func appendLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.AppendLinesAsyncImpl(absolutePath, lines)
+        return _tryWinRT(nil, try _IPathIOStatics.AppendLinesAsyncImpl(absolutePath, lines))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendlinesasync)
     public static func appendLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!, _ encoding: test_component.UnicodeEncoding) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.AppendLinesWithEncodingAsyncImpl(absolutePath, lines, encoding)
+        return _tryWinRT(nil, try _IPathIOStatics.AppendLinesWithEncodingAsyncImpl(absolutePath, lines, encoding))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readbufferasync)
     public static func readBufferAsync(_ absolutePath: String) -> AnyIAsyncOperation<test_component.AnyIBuffer?>! {
-        return try! _IPathIOStatics.ReadBufferAsyncImpl(absolutePath)
+        return _tryWinRT(nil, try _IPathIOStatics.ReadBufferAsyncImpl(absolutePath))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writebufferasync)
     public static func writeBufferAsync(_ absolutePath: String, _ buffer: test_component.AnyIBuffer!) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.WriteBufferAsyncImpl(absolutePath, buffer)
+        return _tryWinRT(nil, try _IPathIOStatics.WriteBufferAsyncImpl(absolutePath, buffer))
     }
 
 }
@@ -126,32 +126,32 @@ public final class StorageFile : WinRTClass, IStorageItem, test_component.IRando
     private static let _IStorageFileStatics: __ABI_Windows_Storage.IStorageFileStatics = try! RoGetActivationFactory("Windows.Storage.StorageFile")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getfilefrompathasync)
     public static func getFileFromPathAsync(_ path: String) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.GetFileFromPathAsyncImpl(path)
+        return _tryWinRT(nil, try _IStorageFileStatics.GetFileFromPathAsyncImpl(path))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getfilefromapplicationuriasync)
     public static func getFileFromApplicationUriAsync(_ uri: test_component.Uri!) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.GetFileFromApplicationUriAsyncImpl(uri)
+        return _tryWinRT(nil, try _IStorageFileStatics.GetFileFromApplicationUriAsyncImpl(uri))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.createstreamedfileasync)
     public static func createStreamedFileAsync(_ displayNameWithExtension: String, _ dataRequested: StreamedFileDataRequestedHandler!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.CreateStreamedFileAsyncImpl(displayNameWithExtension, dataRequested, thumbnail)
+        return _tryWinRT(nil, try _IStorageFileStatics.CreateStreamedFileAsyncImpl(displayNameWithExtension, dataRequested, thumbnail))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.replacewithstreamedfileasync)
     public static func replaceWithStreamedFileAsync(_ fileToReplace: AnyIStorageFile!, _ dataRequested: StreamedFileDataRequestedHandler!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.ReplaceWithStreamedFileAsyncImpl(fileToReplace, dataRequested, thumbnail)
+        return _tryWinRT(nil, try _IStorageFileStatics.ReplaceWithStreamedFileAsyncImpl(fileToReplace, dataRequested, thumbnail))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.createstreamedfilefromuriasync)
     public static func createStreamedFileFromUriAsync(_ displayNameWithExtension: String, _ uri: test_component.Uri!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.CreateStreamedFileFromUriAsyncImpl(displayNameWithExtension, uri, thumbnail)
+        return _tryWinRT(nil, try _IStorageFileStatics.CreateStreamedFileFromUriAsyncImpl(displayNameWithExtension, uri, thumbnail))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.replacewithstreamedfilefromuriasync)
     public static func replaceWithStreamedFileFromUriAsync(_ fileToReplace: AnyIStorageFile!, _ uri: test_component.Uri!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.ReplaceWithStreamedFileFromUriAsyncImpl(fileToReplace, uri, thumbnail)
+        return _tryWinRT(nil, try _IStorageFileStatics.ReplaceWithStreamedFileFromUriAsyncImpl(fileToReplace, uri, thumbnail))
     }
 
     private lazy var _IStorageItem: __ABI_Windows_Storage.IStorageItem! = getInterfaceForCaching()
@@ -187,22 +187,22 @@ public final class StorageFile : WinRTClass, IStorageItem, test_component.IRando
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.attributes)
     public var attributes : FileAttributes {
-        get { try! _IStorageItem.get_AttributesImpl() }
+        get { _tryWinRT(.init(0), try _IStorageItem.get_AttributesImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.datecreated)
     public var dateCreated : test_component.DateTime {
-        get { try! _IStorageItem.get_DateCreatedImpl() }
+        get { _tryWinRT(.init(), try _IStorageItem.get_DateCreatedImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.name)
     public var name : String {
-        get { try! _IStorageItem.get_NameImpl() }
+        get { _tryWinRT("", try _IStorageItem.get_NameImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.path)
     public var path : String {
-        get { try! _IStorageItem.get_PathImpl() }
+        get { _tryWinRT("", try _IStorageItem.get_PathImpl()) }
     }
 
     private lazy var _IRandomAccessStreamReference: __ABI_Windows_Storage_Streams.IRandomAccessStreamReference! = getInterfaceForCaching()
@@ -269,12 +269,12 @@ public final class StorageFile : WinRTClass, IStorageItem, test_component.IRando
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.contenttype)
     public var contentType : String {
-        get { try! _default.get_ContentTypeImpl() }
+        get { _tryWinRT("", try _default.get_ContentTypeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.filetype)
     public var fileType : String {
-        get { try! _default.get_FileTypeImpl() }
+        get { _tryWinRT("", try _default.get_FileTypeImpl()) }
     }
 
     private lazy var _IStorageItemProperties: __ABI_Windows_Storage.IStorageItemProperties! = getInterfaceForCaching()
@@ -295,22 +295,22 @@ public final class StorageFile : WinRTClass, IStorageItem, test_component.IRando
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.displayname)
     public var displayName : String {
-        get { try! _IStorageItemProperties.get_DisplayNameImpl() }
+        get { _tryWinRT("", try _IStorageItemProperties.get_DisplayNameImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.displaytype)
     public var displayType : String {
-        get { try! _IStorageItemProperties.get_DisplayTypeImpl() }
+        get { _tryWinRT("", try _IStorageItemProperties.get_DisplayTypeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.folderrelativeid)
     public var folderRelativeId : String {
-        get { try! _IStorageItemProperties.get_FolderRelativeIdImpl() }
+        get { _tryWinRT("", try _IStorageItemProperties.get_FolderRelativeIdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.properties)
     public var properties : test_component.StorageItemContentProperties! {
-        get { try! _IStorageItemProperties.get_PropertiesImpl() }
+        get { _tryWinRT(nil, try _IStorageItemProperties.get_PropertiesImpl()) }
     }
 
     private lazy var _IStorageItemProperties2: __ABI_Windows_Storage.IStorageItemProperties2! = getInterfaceForCaching()
@@ -343,13 +343,13 @@ public final class StorageFile : WinRTClass, IStorageItem, test_component.IRando
     private lazy var _IStorageItemPropertiesWithProvider: __ABI_Windows_Storage.IStorageItemPropertiesWithProvider! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.provider)
     public var provider : StorageProvider! {
-        get { try! _IStorageItemPropertiesWithProvider.get_ProviderImpl() }
+        get { _tryWinRT(nil, try _IStorageItemPropertiesWithProvider.get_ProviderImpl()) }
     }
 
     private lazy var _IStorageFilePropertiesWithAvailability: __ABI_Windows_Storage.IStorageFilePropertiesWithAvailability! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.isavailable)
     public var isAvailable : Bool {
-        get { try! _IStorageFilePropertiesWithAvailability.get_IsAvailableImpl() }
+        get { _tryWinRT(false, try _IStorageFilePropertiesWithAvailability.get_IsAvailableImpl()) }
     }
 
     private lazy var _IStorageFile2: __ABI_Windows_Storage.IStorageFile2! = getInterfaceForCaching()
@@ -407,7 +407,7 @@ public final class StorageFolder : WinRTClass, IStorageItem, IStorageFolder, tes
     private static let _IStorageFolderStatics: __ABI_Windows_Storage.IStorageFolderStatics = try! RoGetActivationFactory("Windows.Storage.StorageFolder")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfolderfrompathasync)
     public static func getFolderFromPathAsync(_ path: String) -> AnyIAsyncOperation<StorageFolder?>! {
-        return try! _IStorageFolderStatics.GetFolderFromPathAsyncImpl(path)
+        return _tryWinRT(nil, try _IStorageFolderStatics.GetFolderFromPathAsyncImpl(path))
     }
 
     private lazy var _IStorageItem: __ABI_Windows_Storage.IStorageItem! = getInterfaceForCaching()
@@ -443,22 +443,22 @@ public final class StorageFolder : WinRTClass, IStorageItem, IStorageFolder, tes
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.attributes)
     public var attributes : FileAttributes {
-        get { try! _IStorageItem.get_AttributesImpl() }
+        get { _tryWinRT(.init(0), try _IStorageItem.get_AttributesImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.datecreated)
     public var dateCreated : test_component.DateTime {
-        get { try! _IStorageItem.get_DateCreatedImpl() }
+        get { _tryWinRT(.init(), try _IStorageItem.get_DateCreatedImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.name)
     public var name : String {
-        get { try! _IStorageItem.get_NameImpl() }
+        get { _tryWinRT("", try _IStorageItem.get_NameImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.path)
     public var path : String {
-        get { try! _IStorageItem.get_PathImpl() }
+        get { _tryWinRT("", try _IStorageItem.get_PathImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createfileasync)
@@ -615,22 +615,22 @@ public final class StorageFolder : WinRTClass, IStorageItem, IStorageFolder, tes
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.displayname)
     public var displayName : String {
-        get { try! _IStorageItemProperties.get_DisplayNameImpl() }
+        get { _tryWinRT("", try _IStorageItemProperties.get_DisplayNameImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.displaytype)
     public var displayType : String {
-        get { try! _IStorageItemProperties.get_DisplayTypeImpl() }
+        get { _tryWinRT("", try _IStorageItemProperties.get_DisplayTypeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.folderrelativeid)
     public var folderRelativeId : String {
-        get { try! _IStorageItemProperties.get_FolderRelativeIdImpl() }
+        get { _tryWinRT("", try _IStorageItemProperties.get_FolderRelativeIdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.properties)
     public var properties : test_component.StorageItemContentProperties! {
-        get { try! _IStorageItemProperties.get_PropertiesImpl() }
+        get { _tryWinRT(nil, try _IStorageItemProperties.get_PropertiesImpl()) }
     }
 
     private lazy var _IStorageItemProperties2: __ABI_Windows_Storage.IStorageItemProperties2! = getInterfaceForCaching()
@@ -669,7 +669,7 @@ public final class StorageFolder : WinRTClass, IStorageItem, IStorageFolder, tes
     private lazy var _IStorageItemPropertiesWithProvider: __ABI_Windows_Storage.IStorageItemPropertiesWithProvider! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.provider)
     public var provider : StorageProvider! {
-        get { try! _IStorageItemPropertiesWithProvider.get_ProviderImpl() }
+        get { _tryWinRT(nil, try _IStorageItemPropertiesWithProvider.get_ProviderImpl()) }
     }
 
     private lazy var _IStorageFolder3: __ABI_Windows_Storage.IStorageFolder3! = getInterfaceForCaching()
@@ -727,17 +727,17 @@ public final class StorageLibraryChange : WinRTClass {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychange.changetype)
     public var changeType : StorageLibraryChangeType {
-        get { try! _default.get_ChangeTypeImpl() }
+        get { _tryWinRT(.init(0), try _default.get_ChangeTypeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychange.path)
     public var path : String {
-        get { try! _default.get_PathImpl() }
+        get { _tryWinRT("", try _default.get_PathImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychange.previouspath)
     public var previousPath : String {
-        get { try! _default.get_PreviousPathImpl() }
+        get { _tryWinRT("", try _default.get_PreviousPathImpl()) }
     }
 
     deinit {
@@ -854,12 +854,12 @@ public final class StorageProvider : WinRTClass {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storageprovider.displayname)
     public var displayName : String {
-        get { try! _default.get_DisplayNameImpl() }
+        get { _tryWinRT("", try _default.get_DisplayNameImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storageprovider.id)
     public var id : String {
-        get { try! _default.get_IdImpl() }
+        get { _tryWinRT("", try _default.get_IdImpl()) }
     }
 
     private lazy var _IStorageProvider2: __ABI_Windows_Storage.IStorageProvider2! = getInterfaceForCaching()
@@ -914,7 +914,7 @@ public final class StorageStreamTransaction : WinRTClass, test_component.IClosab
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagestreamtransaction.stream)
     public var stream : test_component.AnyIRandomAccessStream! {
-        get { try! _default.get_StreamImpl() }
+        get { _tryWinRT(nil, try _default.get_StreamImpl()) }
     }
 
     deinit {

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -107,6 +107,14 @@ private var IID___x_ABI_Ctest__component_CIEventTesterFactory: test_component.II
     .init(Data1: 0x9E6F50EC, Data2: 0x0F53, Data3: 0x5507, Data4: ( 0xB7,0x37,0x14,0x3B,0x1B,0xB3,0x53,0x65 ))// 9E6F50EC-0F53-5507-B737-143B1BB35365
 }
 
+private var IID___x_ABI_Ctest__component_CIFailure: test_component.IID {
+    .init(Data1: 0x394892CA, Data2: 0x3319, Data3: 0x59B1, Data4: ( 0xBC,0xA0,0xFB,0x1C,0xD8,0x8E,0x78,0x86 ))// 394892CA-3319-59B1-BCA0-FB1CD88E7886
+}
+
+private var IID___x_ABI_Ctest__component_CIFailureStatics: test_component.IID {
+    .init(Data1: 0x5C17A9DF, Data2: 0xF43F, Data3: 0x5AE3, Data4: ( 0xBB,0x8A,0xE4,0x67,0x3E,0xF8,0xB6,0x1A ))// 5C17A9DF-F43F-5AE3-BB8A-E4673EF8B61A
+}
+
 private var IID___x_ABI_Ctest__component_CIIAmImplementable: test_component.IID {
     .init(Data1: 0x0B3C0120, Data2: 0xD138, Data3: 0x512B, Data4: ( 0x8D,0x38,0xF5,0x1E,0x35,0xF0,0x65,0xB2 ))// 0B3C0120-D138-512B-8D38-F51E35F065B2
 }
@@ -584,7 +592,7 @@ public enum __ABI_test_component {
         }
 
         internal func InInt32Impl(_ value: Int32) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InInt32(pThis, value, &result))
             }
@@ -592,7 +600,7 @@ public enum __ABI_test_component {
         }
 
         internal func InStringImpl(_ value: String) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InString(pThis, _value.get(), &result))
@@ -601,7 +609,7 @@ public enum __ABI_test_component {
         }
 
         internal func InObjectImpl(_ value: Any?) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             let valueWrapper = __ABI_.AnyWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
@@ -611,7 +619,7 @@ public enum __ABI_test_component {
         }
 
         internal func InEnumImpl(_ value: test_component.Signed) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InEnum(pThis, value, &result))
             }
@@ -728,7 +736,7 @@ public enum __ABI_test_component {
         }
 
         internal func NoexceptStringImpl() throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.NoexceptString(pThis, &result))
             }
@@ -769,7 +777,7 @@ public enum __ABI_test_component {
         }
 
         internal func InCharImpl(_ value: Character) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InChar(pThis, .init(from: value), &result))
             }
@@ -1025,7 +1033,7 @@ public enum __ABI_test_component {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CICollectionTesterStatics }
 
         internal func InMapImpl(_ value: test_component.AnyIMap<String, String>?) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             let valueWrapper = test_component.__x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CICollectionTesterStatics.self) { pThis in
@@ -1035,7 +1043,7 @@ public enum __ABI_test_component {
         }
 
         internal func InMapViewImpl(_ value: test_component.AnyIMapView<String, String>?) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             let valueWrapper = test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CICollectionTesterStatics.self) { pThis in
@@ -1045,7 +1053,7 @@ public enum __ABI_test_component {
         }
 
         internal func InVectorImpl(_ value: test_component.AnyIVector<String>?) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             let valueWrapper = test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CICollectionTesterStatics.self) { pThis in
@@ -1055,7 +1063,7 @@ public enum __ABI_test_component {
         }
 
         internal func InVectorViewImpl(_ value: test_component.AnyIVectorView<String>?) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             let valueWrapper = test_component.__x_ABI_C__FIVectorView_1_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CICollectionTesterStatics.self) { pThis in
@@ -1157,7 +1165,7 @@ public enum __ABI_test_component {
         }
 
         internal func GetResultImpl() throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             _ = try perform(as: __x_ABI_Ctest__component_CIEventTester.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResult(pThis, &result))
             }
@@ -1190,11 +1198,50 @@ public enum __ABI_test_component {
 
     }
 
+    public class IFailure: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIFailure }
+
+        internal func get_FailedPropertyImpl() throws -> String {
+            var value: HSTRING? = nil
+            _ = try perform(as: __x_ABI_Ctest__component_CIFailure.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_FailedProperty(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+        internal func put_FailedPropertyImpl(_ value: String) throws {
+            let _value = try! HString(value)
+            _ = try perform(as: __x_ABI_Ctest__component_CIFailure.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.put_FailedProperty(pThis, _value.get()))
+            }
+        }
+
+    }
+
+    public class IFailureStatics: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIFailureStatics }
+
+        internal func FailedStaticMethodImpl() throws {
+            _ = try perform(as: __x_ABI_Ctest__component_CIFailureStatics.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.FailedStaticMethod(pThis))
+            }
+        }
+
+        internal func get_FailedStaticPropertyImpl() throws -> Bool {
+            var value: boolean = 0
+            _ = try perform(as: __x_ABI_Ctest__component_CIFailureStatics.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_FailedStaticProperty(pThis, &value))
+            }
+            return .init(from: value)
+        }
+
+    }
+
     public class IIAmImplementable: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIIAmImplementable }
 
         open func InInt32Impl(_ value: Int32) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InInt32(pThis, value, &result))
             }
@@ -1202,7 +1249,7 @@ public enum __ABI_test_component {
         }
 
         open func InStringImpl(_ value: String) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InString(pThis, _value.get(), &result))
@@ -1211,7 +1258,7 @@ public enum __ABI_test_component {
         }
 
         open func InObjectImpl(_ value: Any?) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             let valueWrapper = __ABI_.AnyWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
@@ -1221,7 +1268,7 @@ public enum __ABI_test_component {
         }
 
         open func InEnumImpl(_ value: test_component.Signed) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InEnum(pThis, value, &result))
             }
@@ -1438,7 +1485,7 @@ public enum __ABI_test_component {
         OutObject: {
             do {
                 guard let __unwrapped__instance = IIAmImplementableWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-                var value: Any?
+                var value: Any? = nil
                 try __unwrapped__instance.outObject(&value)
                 let valueWrapper = __ABI_.AnyWrapper(value)
                 valueWrapper?.copyTo($1)
@@ -1826,7 +1873,7 @@ public enum __ABI_test_component {
         }
 
         internal func get_StringPropertyImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StringProperty(pThis, &value))
             }
@@ -2016,7 +2063,7 @@ public enum __ABI_test_component {
         }
 
         internal func InEnumImpl(_ value: test_component.Signed) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InEnum(pThis, value, &result))
             }
@@ -2024,7 +2071,7 @@ public enum __ABI_test_component {
         }
 
         internal func InNonBlittableStructImpl(_ value: test_component.NonBlittableStruct) throws -> String {
-            var result: HSTRING?
+            var result: HSTRING? = nil
             let _value = __ABI_test_component._ABI_NonBlittableStruct(from: value)
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InNonBlittableStruct(pThis, _value.val, &result))
@@ -2360,7 +2407,7 @@ public enum __ABI_test_component {
         }
 
         open func get_StructImpl() throws -> String {
-            var value: HSTRING?
+            var value: HSTRING? = nil
             _ = try perform(as: __x_ABI_Ctest__component_CWithKeyword.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Struct(pThis, &value))
             }

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -3094,12 +3094,12 @@ fileprivate class __x_ABI_C__FIIterator_1_IInspectableImpl : IIterator, AbiInter
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : Any? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3221,12 +3221,12 @@ fileprivate class __x_ABI_C__FIIterator_1_GUIDImpl : IIterator, AbiInterfaceImpl
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : Foundation.UUID {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(.init(), try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3292,7 +3292,7 @@ internal class IIteratorString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1_HSTRING }
 
     internal func get_CurrentImpl() throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         _ = try perform(as: __x_ABI_C__FIIterator_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
         }
@@ -3348,12 +3348,12 @@ fileprivate class __x_ABI_C__FIIterator_1_HSTRINGImpl : IIterator, AbiInterfaceI
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : String {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT("", try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3475,12 +3475,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextS
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.TextSegment {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(.init(), try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3604,12 +3604,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_II
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : AnyIKeyValuePair<String, Any?>? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3733,12 +3733,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HS
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : AnyIKeyValuePair<String, String>? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3862,12 +3862,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : AnyIKeyValuePair<String, AnyIVectorView<test_component.TextSegment>?>? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3991,12 +3991,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : AnyIKeyValuePair<String, Base?>? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4120,12 +4120,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFo
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.AnyIWwwFormUrlDecoderEntry? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4249,12 +4249,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageI
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.AnyIStorageItem? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4377,12 +4377,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__C
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.SortEntry {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(.init(), try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4505,12 +4505,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFi
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.StorageFile? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4633,12 +4633,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFo
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.StorageFolder? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4761,12 +4761,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLi
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.StorageLibraryChange? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4889,12 +4889,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseImpl :
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : Base? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5018,12 +5018,12 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicImpl
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : AnyIBasic? {
-        get { try! _default.get_CurrentImpl() }
+        get { _tryWinRT(nil, try _default.get_CurrentImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { _tryWinRT(false, try _default.get_HasCurrentImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5081,7 +5081,7 @@ internal class IKeyValuePairString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable }
 
     internal func get_KeyImpl() throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
@@ -5126,12 +5126,12 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableImpl : IKeyVal
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.key)
     fileprivate var key : String {
-        get { try! _default.get_KeyImpl() }
+        get { _tryWinRT("", try _default.get_KeyImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.value)
     fileprivate var value : Any? {
-        get { try! _default.get_ValueImpl() }
+        get { _tryWinRT(nil, try _default.get_ValueImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5188,7 +5188,7 @@ internal class IKeyValuePairString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING }
 
     internal func get_KeyImpl() throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
@@ -5196,7 +5196,7 @@ internal class IKeyValuePairString_String: test_component.IInspectable {
     }
 
     internal func get_ValueImpl() throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &result))
         }
@@ -5232,12 +5232,12 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGImpl : IKeyValuePai
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.key)
     fileprivate var key : String {
-        get { try! _default.get_KeyImpl() }
+        get { _tryWinRT("", try _default.get_KeyImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.value)
     fileprivate var value : String {
-        get { try! _default.get_ValueImpl() }
+        get { _tryWinRT("", try _default.get_ValueImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5295,7 +5295,7 @@ internal class IKeyValuePairString_IVectorViewTextSegment: test_component.IInspe
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
     internal func get_KeyImpl() throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
@@ -5340,12 +5340,12 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1_
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.key)
     fileprivate var key : String {
-        get { try! _default.get_KeyImpl() }
+        get { _tryWinRT("", try _default.get_KeyImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.value)
     fileprivate var value : AnyIVectorView<test_component.TextSegment>? {
-        get { try! _default.get_ValueImpl() }
+        get { _tryWinRT(nil, try _default.get_ValueImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5402,7 +5402,7 @@ internal class IKeyValuePairString_Base: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase }
 
     internal func get_KeyImpl() throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
@@ -5447,12 +5447,12 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent_
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.key)
     fileprivate var key : String {
-        get { try! _default.get_KeyImpl() }
+        get { _tryWinRT("", try _default.get_KeyImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.value)
     fileprivate var value : Base? {
-        get { try! _default.get_ValueImpl() }
+        get { _tryWinRT(nil, try _default.get_ValueImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5517,7 +5517,7 @@ internal class IMapChangedEventArgsString: test_component.IInspectable {
     }
 
     internal func get_KeyImpl() throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         _ = try perform(as: __x_ABI_C__FIMapChangedEventArgs_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
@@ -5552,12 +5552,12 @@ fileprivate class __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGImpl : IMapChangedEv
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapchangedeventargs-1.collectionchange)
     fileprivate var collectionChange : test_component.CollectionChange {
-        get { try! _default.get_CollectionChangeImpl() }
+        get { _tryWinRT(.init(0), try _default.get_CollectionChangeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapchangedeventargs-1.key)
     fileprivate var key : String {
-        get { try! _default.get_KeyImpl() }
+        get { _tryWinRT("", try _default.get_KeyImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5622,8 +5622,8 @@ internal var __x_ABI_C__FIMapView_2_HSTRING_IInspectableVTable: __x_ABI_C__FIMap
 
     Split: {
         guard let __unwrapped__instance = __x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        var first: test_component.AnyIMapView<String, Any?>?
-        var second: test_component.AnyIMapView<String, Any?>?
+        var first: test_component.AnyIMapView<String, Any?>? = nil
+        var second: test_component.AnyIMapView<String, Any?>? = nil
         __unwrapped__instance.split(&first, &second)
         let firstWrapper = test_component.__x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper(first)
         firstWrapper?.copyTo($1)
@@ -5718,7 +5718,7 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING_IInspectableImpl : IMapView, Ab
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()
@@ -5788,8 +5788,8 @@ internal var __x_ABI_C__FIMapView_2_HSTRING_HSTRINGVTable: __x_ABI_C__FIMapView_
 
     Split: {
         guard let __unwrapped__instance = __x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        var first: test_component.AnyIMapView<String, String>?
-        var second: test_component.AnyIMapView<String, String>?
+        var first: test_component.AnyIMapView<String, String>? = nil
+        var second: test_component.AnyIMapView<String, String>? = nil
         __unwrapped__instance.split(&first, &second)
         let firstWrapper = test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper(first)
         firstWrapper?.copyTo($1)
@@ -5803,7 +5803,7 @@ internal class IMapViewString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMapView_2_HSTRING_HSTRING }
 
     internal func LookupImpl(_ key: String) throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Lookup(pThis, _key.get(), &result))
@@ -5883,7 +5883,7 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING_HSTRINGImpl : IMapView, AbiInte
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_String! = getInterfaceForCaching()
@@ -5954,8 +5954,8 @@ internal var __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CW
 
     Split: {
         guard let __unwrapped__instance = __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        var first: test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>?
-        var second: test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>?
+        var first: test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>? = nil
+        var second: test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>? = nil
         __unwrapped__instance.split(&first, &second)
         let firstWrapper = test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper(first)
         firstWrapper?.copyTo($1)
@@ -6050,7 +6050,7 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_A
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_IVectorViewTextSegment! = getInterfaceForCaching()
@@ -6120,8 +6120,8 @@ internal var __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVTab
 
     Split: {
         guard let __unwrapped__instance = __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        var first: test_component.AnyIMapView<String, test_component.Base?>?
-        var second: test_component.AnyIMapView<String, test_component.Base?>?
+        var first: test_component.AnyIMapView<String, test_component.Base?>? = nil
+        var second: test_component.AnyIMapView<String, test_component.Base?>? = nil
         __unwrapped__instance.split(&first, &second)
         let firstWrapper = test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper(first)
         firstWrapper?.copyTo($1)
@@ -6216,7 +6216,7 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBas
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Base! = getInterfaceForCaching()
@@ -6439,7 +6439,7 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING_IInspectableImpl : IMap, AbiInterfa
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()
@@ -6542,7 +6542,7 @@ internal class IMapString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMap_2_HSTRING_HSTRING }
 
     internal func LookupImpl(_ key: String) throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Lookup(pThis, _key.get(), &result))
@@ -6659,7 +6659,7 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING_HSTRINGImpl : IMap, AbiInterfaceImp
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_String! = getInterfaceForCaching()
@@ -6882,7 +6882,7 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_C
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_IVectorViewTextSegment! = getInterfaceForCaching()
@@ -7102,7 +7102,7 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseImp
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Base! = getInterfaceForCaching()
@@ -7257,7 +7257,7 @@ fileprivate class __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableImpl : IObser
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _IMap.get_SizeImpl() }
+        get { _tryWinRT(0, try _IMap.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()
@@ -7412,7 +7412,7 @@ fileprivate class __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGImpl : IObservable
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _IMap.get_SizeImpl() }
+        get { _tryWinRT(0, try _IMap.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_String! = getInterfaceForCaching()
@@ -7610,7 +7610,7 @@ fileprivate class __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBa
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _IVector.get_SizeImpl() }
+        get { _tryWinRT(0, try _IVector.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableBase! = getInterfaceForCaching()
@@ -7808,7 +7808,7 @@ fileprivate class __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIB
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _IVector.get_SizeImpl() }
+        get { _tryWinRT(0, try _IVector.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIBasic! = getInterfaceForCaching()
@@ -7971,7 +7971,7 @@ fileprivate class __x_ABI_C__FIVectorView_1_IInspectableImpl : IVectorView, AbiI
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableAny! = getInterfaceForCaching()
@@ -8130,7 +8130,7 @@ fileprivate class __x_ABI_C__FIVectorView_1_GUIDImpl : IVectorView, AbiInterface
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableUUID! = getInterfaceForCaching()
@@ -8207,7 +8207,7 @@ internal class IVectorViewString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1_HSTRING }
 
     internal func GetAtImpl(_ index: UInt32) throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         _ = try perform(as: __x_ABI_C__FIVectorView_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
         }
@@ -8290,7 +8290,7 @@ fileprivate class __x_ABI_C__FIVectorView_1_HSTRINGImpl : IVectorView, AbiInterf
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableString! = getInterfaceForCaching()
@@ -8449,7 +8449,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTex
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableTextSegment! = getInterfaceForCaching()
@@ -8612,7 +8612,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWww
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIWwwFormUrlDecoderEntry! = getInterfaceForCaching()
@@ -8775,7 +8775,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorag
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIStorageItem! = getInterfaceForCaching()
@@ -8936,7 +8936,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch_
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableSortEntry! = getInterfaceForCaching()
@@ -9096,7 +9096,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorage
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableStorageFile! = getInterfaceForCaching()
@@ -9256,7 +9256,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorage
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableStorageFolder! = getInterfaceForCaching()
@@ -9416,7 +9416,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorage
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableStorageLibraryChange! = getInterfaceForCaching()
@@ -9576,7 +9576,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseImpl
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableBase! = getInterfaceForCaching()
@@ -9739,7 +9739,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicIm
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIBasic! = getInterfaceForCaching()
@@ -10049,7 +10049,7 @@ fileprivate class __x_ABI_C__FIVector_1_IInspectableImpl : IVector, AbiInterface
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableAny! = getInterfaceForCaching()
@@ -10349,7 +10349,7 @@ fileprivate class __x_ABI_C__FIVector_1_GUIDImpl : IVector, AbiInterfaceImpl {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableUUID! = getInterfaceForCaching()
@@ -10478,7 +10478,7 @@ internal class IVectorString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1_HSTRING }
 
     internal func GetAtImpl(_ index: UInt32) throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
         }
@@ -10653,7 +10653,7 @@ fileprivate class __x_ABI_C__FIVector_1_HSTRINGImpl : IVector, AbiInterfaceImpl 
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableString! = getInterfaceForCaching()
@@ -10958,7 +10958,7 @@ fileprivate class __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSo
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableSortEntry! = getInterfaceForCaching()
@@ -11259,7 +11259,7 @@ fileprivate class __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseImpl : I
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableBase! = getInterfaceForCaching()
@@ -11569,7 +11569,7 @@ fileprivate class __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicImpl :
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIBasic! = getInterfaceForCaching()
@@ -11998,14 +11998,14 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleImpl : IAs
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.progress)
     fileprivate var progress : AsyncOperationProgressHandler<Int32, Double>? {
-        get { try! _default.get_ProgressImpl() }
-        set { try! _default.put_ProgressImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_ProgressImpl()) }
+        set { _tryWinRT(try _default.put_ProgressImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.completed)
     fileprivate var completed : AsyncOperationWithProgressCompletedHandler<Int32, Double>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -12021,17 +12021,17 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleImpl : IAs
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -12189,14 +12189,14 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Impl : 
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.progress)
     fileprivate var progress : AsyncOperationProgressHandler<UInt32, UInt32>? {
-        get { try! _default.get_ProgressImpl() }
-        set { try! _default.put_ProgressImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_ProgressImpl()) }
+        set { _tryWinRT(try _default.put_ProgressImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.completed)
     fileprivate var completed : AsyncOperationWithProgressCompletedHandler<UInt32, UInt32>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -12212,17 +12212,17 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Impl : 
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -12382,14 +12382,14 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CS
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.progress)
     fileprivate var progress : AsyncOperationProgressHandler<test_component.AnyIBuffer?, UInt32>? {
-        get { try! _default.get_ProgressImpl() }
-        set { try! _default.put_ProgressImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_ProgressImpl()) }
+        set { _tryWinRT(try _default.put_ProgressImpl(newValue)) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.completed)
     fileprivate var completed : AsyncOperationWithProgressCompletedHandler<test_component.AnyIBuffer?, UInt32>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -12405,17 +12405,17 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CS
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -12540,8 +12540,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_booleanImpl : IAsyncOperation, A
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<Bool>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -12557,17 +12557,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_booleanImpl : IAsyncOperation, A
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -12692,8 +12692,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_intImpl : IAsyncOperation, AbiIn
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<Int32>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -12709,17 +12709,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_intImpl : IAsyncOperation, AbiIn
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -12804,7 +12804,7 @@ internal class IAsyncOperationString: test_component.IInspectable {
     }
 
     internal func GetResultsImpl() throws -> String {
-        var result: HSTRING?
+        var result: HSTRING? = nil
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
         }
@@ -12844,8 +12844,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_HSTRINGImpl : IAsyncOperation, A
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<String>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -12861,17 +12861,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_HSTRINGImpl : IAsyncOperation, A
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -12996,8 +12996,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_UINT32Impl : IAsyncOperation, Ab
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<UInt32>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -13013,17 +13013,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_UINT32Impl : IAsyncOperation, Ab
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13150,8 +13150,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInsp
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIMap<String, Any?>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -13167,17 +13167,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInsp
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13304,8 +13304,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIVectorView<test_component.AnyIStorageItem?>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -13321,17 +13321,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13458,8 +13458,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIVectorView<test_component.StorageFile?>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -13475,17 +13475,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13612,8 +13612,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIVectorView<test_component.StorageFolder?>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -13629,17 +13629,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13766,8 +13766,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIVectorView<test_component.StorageLibraryChange?>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -13783,17 +13783,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13920,8 +13920,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGImp
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIVector<String>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -13937,17 +13937,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGImp
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14073,8 +14073,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.BasicProperties?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -14090,17 +14090,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14226,8 +14226,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.DocumentProperties?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -14243,17 +14243,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14379,8 +14379,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.ImageProperties?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -14396,17 +14396,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14532,8 +14532,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.MusicProperties?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -14549,17 +14549,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14685,8 +14685,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.StorageItemThumbnail?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -14702,17 +14702,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14838,8 +14838,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.VideoProperties?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -14855,17 +14855,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14992,8 +14992,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CISt
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.AnyIStorageItem?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -15009,17 +15009,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CISt
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15144,8 +15144,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSea
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.IndexedState>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -15161,17 +15161,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSea
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15297,8 +15297,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.StorageFile?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -15314,17 +15314,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15450,8 +15450,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.StorageFolder?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -15467,17 +15467,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15603,8 +15603,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.StorageStreamTransaction?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -15620,17 +15620,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15757,8 +15757,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.AnyIBuffer?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -15774,17 +15774,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15911,8 +15911,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.AnyIInputStream?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -15928,17 +15928,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -16065,8 +16065,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStream?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -16082,17 +16082,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -16219,8 +16219,8 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStreamWithContentType?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_CompletedImpl()) }
+        set { _tryWinRT(try _default.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -16236,17 +16236,17 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -171,13 +171,13 @@ public enum __IMPL_test_component {
         }
 
         fileprivate var enumProperty : Fruit {
-            get { try! _default.get_EnumPropertyImpl() }
-            set { try! _default.put_EnumPropertyImpl(newValue) }
+            get { _tryWinRT(.init(0), try _default.get_EnumPropertyImpl()) }
+            set { _tryWinRT(try _default.put_EnumPropertyImpl(newValue)) }
         }
 
         fileprivate var id : Foundation.UUID? {
-            get { try! _default.get_IdImpl() }
-            set { try! _default.put_IdImpl(newValue) }
+            get { _tryWinRT(nil, try _default.get_IdImpl()) }
+            set { _tryWinRT(try _default.put_IdImpl(newValue)) }
         }
 
         fileprivate lazy var implementableEvent : Event<test_component.InDelegate> = {
@@ -354,8 +354,8 @@ public enum __IMPL_test_component {
         }
 
         fileprivate var `struct` : String {
-            get { try! _default.get_StructImpl() }
-            set { try! _default.put_StructImpl(newValue) }
+            get { _tryWinRT("", try _default.get_StructImpl()) }
+            set { _tryWinRT(try _default.put_StructImpl(newValue)) }
         }
 
         fileprivate lazy var `repeat` : Event<EventHandler<Any?>> = {

--- a/tests/test_component/Sources/test_component/test_component+MakeFromAbi.swift
+++ b/tests/test_component/Sources/test_component/test_component+MakeFromAbi.swift
@@ -359,6 +359,10 @@ fileprivate func makeEventTesterFrom(abi: test_component.IInspectable) -> Any {
     return EventTester(fromAbi: abi)
 }
 
+fileprivate func makeFailureFrom(abi: test_component.IInspectable) -> Any {
+    return Failure(fromAbi: abi)
+}
+
 fileprivate func makeNoopClosableFrom(abi: test_component.IInspectable) -> Any {
     return NoopClosable(fromAbi: abi)
 }
@@ -470,6 +474,7 @@ public class __MakeFromAbi: MakeFromAbi {
             case "Derived": return makeDerivedFrom(abi: abi)
             case "DerivedFromNoConstructor": return makeDerivedFromNoConstructorFrom(abi: abi)
             case "EventTester": return makeEventTesterFrom(abi: abi)
+            case "Failure": return makeFailureFrom(abi: abi)
             case "NoopClosable": return makeNoopClosableFrom(abi: abi)
             case "Simple": return makeSimpleFrom(abi: abi)
             case "UnsealedDerived": return makeUnsealedDerivedFrom(abi: abi)

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -11,15 +11,15 @@ public typealias Unsigned = __x_ABI_Ctest__component_CUnsigned
 public final class AsyncMethods {
     private static let _IAsyncMethodsStatics: __ABI_test_component.IAsyncMethodsStatics = try! RoGetActivationFactory("test_component.AsyncMethods")
     public static func getCompletedAsync(_ result: Int32) -> AnyIAsyncOperation<Int32>! {
-        return try! _IAsyncMethodsStatics.GetCompletedAsyncImpl(result)
+        return _tryWinRT(nil, try _IAsyncMethodsStatics.GetCompletedAsyncImpl(result))
     }
 
     public static func getCompletedWithErrorAsync(_ errorCode: HRESULT) -> AnyIAsyncOperation<Int32>! {
-        return try! _IAsyncMethodsStatics.GetCompletedWithErrorAsyncImpl(errorCode)
+        return _tryWinRT(nil, try _IAsyncMethodsStatics.GetCompletedWithErrorAsyncImpl(errorCode))
     }
 
     public static func getPendingAsync() -> AsyncOperationInt! {
-        return try! _IAsyncMethodsStatics.GetPendingAsyncImpl()
+        return _tryWinRT(nil, try _IAsyncMethodsStatics.GetPendingAsyncImpl())
     }
 
 }
@@ -65,8 +65,8 @@ public final class AsyncOperationInt : WinRTClass, IAsyncOperationInt, IAsyncOpe
     }
 
     public var completed : AsyncOperationCompletedHandler<Int32>? {
-        get { try! _IAsyncOperation.get_CompletedImpl() }
-        set { try! _IAsyncOperation.put_CompletedImpl(newValue) }
+        get { _tryWinRT(nil, try _IAsyncOperation.get_CompletedImpl()) }
+        set { _tryWinRT(try _IAsyncOperation.put_CompletedImpl(newValue)) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
@@ -79,15 +79,15 @@ public final class AsyncOperationInt : WinRTClass, IAsyncOperationInt, IAsyncOpe
     }
 
     public var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_ErrorCodeImpl()) }
     }
 
     public var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { _tryWinRT(0, try _IAsyncInfo.get_IdImpl()) }
     }
 
     public var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { _tryWinRT(.init(0), try _IAsyncInfo.get_StatusImpl()) }
     }
 
     deinit {
@@ -147,7 +147,7 @@ open class Base : WinRTClass {
 
     private static let _IBaseStatics: __ABI_test_component.IBaseStatics = try! RoGetActivationFactory("test_component.Base")
     public class func createFromString(_ value: String) -> Base! {
-        return try! _IBaseStatics.CreateFromStringImpl(value)
+        return _tryWinRT(nil, try _IBaseStatics.CreateFromStringImpl(value))
     }
 
     public func doTheThing() throws {
@@ -288,7 +288,7 @@ open class BaseCollection : WinRTClass, IVector, IIterable {
     }
 
     public var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableBase! = getInterfaceForCaching()
@@ -367,7 +367,7 @@ public final class BaseMapCollection : WinRTClass, IMap, IIterable {
     }
 
     public var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { _tryWinRT(0, try _default.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Base! = getInterfaceForCaching()
@@ -426,7 +426,7 @@ open class BaseNoOverrides : WinRTClass {
 
     private static let _IBaseNoOverridesStatics: __ABI_test_component.IBaseNoOverridesStatics = try! RoGetActivationFactory("test_component.BaseNoOverrides")
     public class func createFromString(_ value: String) -> BaseNoOverrides! {
-        return try! _IBaseNoOverridesStatics.CreateFromStringImpl(value)
+        return _tryWinRT(nil, try _IBaseNoOverridesStatics.CreateFromStringImpl(value))
     }
 
     internal enum IBaseNoOverrides : ComposableImpl {
@@ -553,7 +553,7 @@ public final class BaseObservableCollection : WinRTClass, IObservableVector, IVe
     }
 
     public var size : UInt32 {
-        get { try! _IVector.get_SizeImpl() }
+        get { _tryWinRT(0, try _IVector.get_SizeImpl()) }
     }
 
     private lazy var _IIterable: IIterableBase! = getInterfaceForCaching()
@@ -571,7 +571,7 @@ public final class BaseObservableCollection : WinRTClass, IObservableVector, IVe
 public final class BufferTester {
     private static let _IBufferTesterStatics: __ABI_test_component.IBufferTesterStatics = try! RoGetActivationFactory("test_component.BufferTester")
     public static func getDataFrom(_ buffer: test_component.AnyIBuffer!, _ index: UInt32) -> UInt8 {
-        return try! _IBufferTesterStatics.GetDataFromImpl(buffer, index)
+        return _tryWinRT(0, try _IBufferTesterStatics.GetDataFromImpl(buffer, index))
     }
 
 }
@@ -639,29 +639,29 @@ public final class Class : WinRTClass, IBasic {
 
     private static let _IClassStatics: __ABI_test_component.IClassStatics = try! RoGetActivationFactory("test_component.Class")
     public static func staticTest() {
-        try! _IClassStatics.StaticTestImpl()
+        _tryWinRT(try _IClassStatics.StaticTestImpl())
     }
 
     public static func staticTestReturn() -> Int32 {
-        return try! _IClassStatics.StaticTestReturnImpl()
+        return _tryWinRT(0, try _IClassStatics.StaticTestReturnImpl())
     }
 
     public static func takeBaseAndGiveToCallbackAsObject(_ base: Base!, _ callback: test_component.InObjectDelegate!) {
-        try! _IClassStatics.TakeBaseAndGiveToCallbackAsObjectImpl(base, callback)
+        _tryWinRT(try _IClassStatics.TakeBaseAndGiveToCallbackAsObjectImpl(base, callback))
     }
 
     public static var staticProperty : Int32 {
-        get { try! _IClassStatics.get_StaticPropertyImpl() }
+        get { _tryWinRT(0, try _IClassStatics.get_StaticPropertyImpl()) }
     }
 
     private static let _IClassStatics2: __ABI_test_component.IClassStatics2 = try! RoGetActivationFactory("test_component.Class")
     public static func staticTestReturnFloat() -> Float {
-        return try! _IClassStatics2.StaticTestReturnFloatImpl()
+        return _tryWinRT(0.0, try _IClassStatics2.StaticTestReturnFloatImpl())
     }
 
     public static var staticPropertyFloat : Float {
-        get { try! _IClassStatics2.get_StaticPropertyFloatImpl() }
-        set { try! _IClassStatics2.put_StaticPropertyFloatImpl(newValue) }
+        get { _tryWinRT(0.0, try _IClassStatics2.get_StaticPropertyFloatImpl()) }
+        set { _tryWinRT(try _IClassStatics2.put_StaticPropertyFloatImpl(newValue)) }
     }
 
     public func setDelegate(_ value: AnyISimpleDelegate!) throws {
@@ -761,33 +761,33 @@ public final class Class : WinRTClass, IBasic {
     }
 
     public var baseNoOverridesProperty : BaseNoOverrides! {
-        get { try! _default.get_BaseNoOverridesPropertyImpl() }
-        set { try! _default.put_BaseNoOverridesPropertyImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_BaseNoOverridesPropertyImpl()) }
+        set { _tryWinRT(try _default.put_BaseNoOverridesPropertyImpl(newValue)) }
     }
 
     public var baseProperty : Base! {
-        get { try! _default.get_BasePropertyImpl() }
-        set { try! _default.put_BasePropertyImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_BasePropertyImpl()) }
+        set { _tryWinRT(try _default.put_BasePropertyImpl(newValue)) }
     }
 
     public var enumProperty : Fruit {
-        get { try! _default.get_EnumPropertyImpl() }
-        set { try! _default.put_EnumPropertyImpl(newValue) }
+        get { _tryWinRT(.init(0), try _default.get_EnumPropertyImpl()) }
+        set { _tryWinRT(try _default.put_EnumPropertyImpl(newValue)) }
     }
 
     public var id : Foundation.UUID? {
-        get { try! _default.get_IdImpl() }
-        set { try! _default.put_IdImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_IdImpl()) }
+        set { _tryWinRT(try _default.put_IdImpl(newValue)) }
     }
 
     public var implementation : AnyIBasic! {
-        get { try! _default.get_ImplementationImpl() }
-        set { try! _default.put_ImplementationImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_ImplementationImpl()) }
+        set { _tryWinRT(try _default.put_ImplementationImpl(newValue)) }
     }
 
     public var startValue : Int32? {
-        get { try! _default.get_StartValueImpl() }
-        set { try! _default.put_StartValueImpl(newValue) }
+        get { _tryWinRT(nil, try _default.get_StartValueImpl()) }
+        set { _tryWinRT(try _default.put_StartValueImpl(newValue)) }
     }
 
     public lazy var deferrableEvent : Event<TypedEventHandler<Class?, DeferrableEventArgs?>> = {
@@ -843,23 +843,23 @@ public final class CollectionTester : WinRTClass {
 
     private static let _ICollectionTesterStatics: __ABI_test_component.ICollectionTesterStatics = try! RoGetActivationFactory("test_component.CollectionTester")
     public static func inMap(_ value: AnyIMap<String, String>!) -> String {
-        return try! _ICollectionTesterStatics.InMapImpl(value)
+        return _tryWinRT("", try _ICollectionTesterStatics.InMapImpl(value))
     }
 
     public static func inMapView(_ value: AnyIMapView<String, String>!) -> String {
-        return try! _ICollectionTesterStatics.InMapViewImpl(value)
+        return _tryWinRT("", try _ICollectionTesterStatics.InMapViewImpl(value))
     }
 
     public static func inVector(_ value: AnyIVector<String>!) -> String {
-        return try! _ICollectionTesterStatics.InVectorImpl(value)
+        return _tryWinRT("", try _ICollectionTesterStatics.InVectorImpl(value))
     }
 
     public static func inVectorView(_ value: AnyIVectorView<String>!) -> String {
-        return try! _ICollectionTesterStatics.InVectorViewImpl(value)
+        return _tryWinRT("", try _ICollectionTesterStatics.InVectorViewImpl(value))
     }
 
     public static func getObjectAt(_ value: AnyIVector<Any?>!, _ index: UInt32, _ callback: ObjectHandler!) {
-        try! _ICollectionTesterStatics.GetObjectAtImpl(value, index, callback)
+        _tryWinRT(try _ICollectionTesterStatics.GetObjectAtImpl(value, index, callback))
     }
 
     public func returnStoredStringVector() throws -> AnyIVector<String>! {
@@ -941,12 +941,12 @@ public final class Derived : test_component.Base {
 
     private static let _IDerivedStatics: __ABI_test_component.IDerivedStatics = try! RoGetActivationFactory("test_component.Derived")
     override public static func createFromString(_ value: String) -> Derived! {
-        return try! _IDerivedStatics.CreateFromStringImpl(value)
+        return _tryWinRT(nil, try _IDerivedStatics.CreateFromStringImpl(value))
     }
 
     public var prop : Int32 {
-        get { try! _default.get_PropImpl() }
-        set { try! _default.put_PropImpl(newValue) }
+        get { _tryWinRT(0, try _default.get_PropImpl()) }
+        set { _tryWinRT(try _default.put_PropImpl(newValue)) }
     }
 
     internal enum IBaseOverrides : ComposableImpl {
@@ -1049,7 +1049,54 @@ public final class EventTester : WinRTClass {
     }
 
     public var count : Int32 {
-        get { try! _default.get_CountImpl() }
+        get { _tryWinRT(0, try _default.get_CountImpl()) }
+    }
+
+    deinit {
+        _default = nil
+    }
+}
+
+public final class Failure : WinRTClass {
+    private typealias SwiftABI = __ABI_test_component.IFailure
+    private typealias CABI = __x_ABI_Ctest__component_CIFailure
+    private lazy var _default: SwiftABI! = getInterfaceForCaching()
+    @_spi(WinRTInternal)
+    override public func _getABI<T>() -> UnsafeMutablePointer<T>? {
+        if T.self == CABI.self {
+            return RawPointer(_default)
+        }
+        return super._getABI()
+    }
+
+    @_spi(WinRTInternal)
+    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIFailure>?) -> Failure? {
+        guard let abi = abi else { return nil }
+        return .init(fromAbi: test_component.IInspectable(abi))
+    }
+
+    @_spi(WinRTInternal)
+    public init(fromAbi: test_component.IInspectable) {
+        super.init(fromAbi)
+    }
+
+    private static let _defaultFactory: test_component.IActivationFactory = try! RoGetActivationFactory("test_component.Failure")
+    override public init() {
+        super.init(try! Self._defaultFactory.ActivateInstance())
+    }
+
+    private static let _IFailureStatics: __ABI_test_component.IFailureStatics = try! RoGetActivationFactory("test_component.Failure")
+    public static func failedStaticMethod() {
+        _tryWinRT(try _IFailureStatics.FailedStaticMethodImpl())
+    }
+
+    public static var failedStaticProperty : Bool {
+        get { _tryWinRT(false, try _IFailureStatics.get_FailedStaticPropertyImpl()) }
+    }
+
+    public var failedProperty : String {
+        get { _tryWinRT("", try _default.get_FailedPropertyImpl()) }
+        set { _tryWinRT(try _default.put_FailedPropertyImpl(newValue)) }
     }
 
     deinit {
@@ -1100,43 +1147,43 @@ public final class NoopClosable : WinRTClass, test_component.IClosable {
 public final class NullValues {
     private static let _INullValuesStatics: __ABI_test_component.INullValuesStatics = try! RoGetActivationFactory("test_component.NullValues")
     public static func isObjectNull(_ value: Any!) -> Bool {
-        return try! _INullValuesStatics.IsObjectNullImpl(value)
+        return _tryWinRT(false, try _INullValuesStatics.IsObjectNullImpl(value))
     }
 
     public static func isInterfaceNull(_ value: test_component.AnyIClosable!) -> Bool {
-        return try! _INullValuesStatics.IsInterfaceNullImpl(value)
+        return _tryWinRT(false, try _INullValuesStatics.IsInterfaceNullImpl(value))
     }
 
     public static func isGenericInterfaceNull(_ value: AnyIVector<String>!) -> Bool {
-        return try! _INullValuesStatics.IsGenericInterfaceNullImpl(value)
+        return _tryWinRT(false, try _INullValuesStatics.IsGenericInterfaceNullImpl(value))
     }
 
     public static func isClassNull(_ value: NoopClosable!) -> Bool {
-        return try! _INullValuesStatics.IsClassNullImpl(value)
+        return _tryWinRT(false, try _INullValuesStatics.IsClassNullImpl(value))
     }
 
     public static func isDelegateNull(_ value: VoidToVoidDelegate!) -> Bool {
-        return try! _INullValuesStatics.IsDelegateNullImpl(value)
+        return _tryWinRT(false, try _INullValuesStatics.IsDelegateNullImpl(value))
     }
 
     public static func getNullObject() -> Any! {
-        return try! _INullValuesStatics.GetNullObjectImpl()
+        return _tryWinRT(nil, try _INullValuesStatics.GetNullObjectImpl())
     }
 
     public static func getNullInterface() -> test_component.AnyIClosable! {
-        return try! _INullValuesStatics.GetNullInterfaceImpl()
+        return _tryWinRT(nil, try _INullValuesStatics.GetNullInterfaceImpl())
     }
 
     public static func getNullGenericInterface() -> AnyIVector<String>! {
-        return try! _INullValuesStatics.GetNullGenericInterfaceImpl()
+        return _tryWinRT(nil, try _INullValuesStatics.GetNullGenericInterfaceImpl())
     }
 
     public static func getNullClass() -> NoopClosable! {
-        return try! _INullValuesStatics.GetNullClassImpl()
+        return _tryWinRT(nil, try _INullValuesStatics.GetNullClassImpl())
     }
 
     public static func getNullDelegate() -> VoidToVoidDelegate! {
-        return try! _INullValuesStatics.GetNullDelegateImpl()
+        return _tryWinRT(nil, try _INullValuesStatics.GetNullDelegateImpl())
     }
 
 }
@@ -1171,7 +1218,7 @@ public final class Simple : WinRTClass {
 
     private static let _ISimpleStatics: __ABI_test_component.ISimpleStatics = try! RoGetActivationFactory("test_component.Simple")
     public static func fireStaticEvent() {
-        try! _ISimpleStatics.FireStaticEventImpl()
+        _tryWinRT(try _ISimpleStatics.FireStaticEventImpl())
     }
 
     public static var staticEvent : Event<EventHandler<Any?>> = {
@@ -1226,23 +1273,23 @@ public final class Simple : WinRTClass {
     }
 
     public var blittableStructProperty : BlittableStruct {
-        get { try! _default.get_BlittableStructPropertyImpl() }
-        set { try! _default.put_BlittableStructPropertyImpl(newValue) }
+        get { _tryWinRT(.init(), try _default.get_BlittableStructPropertyImpl()) }
+        set { _tryWinRT(try _default.put_BlittableStructPropertyImpl(newValue)) }
     }
 
     public var nonBlittableStructProperty : NonBlittableStruct {
-        get { try! _default.get_NonBlittableStructPropertyImpl() }
-        set { try! _default.put_NonBlittableStructPropertyImpl(newValue) }
+        get { _tryWinRT(.init(), try _default.get_NonBlittableStructPropertyImpl()) }
+        set { _tryWinRT(try _default.put_NonBlittableStructPropertyImpl(newValue)) }
     }
 
     public var stringProperty : String {
-        get { try! _default.get_StringPropertyImpl() }
-        set { try! _default.put_StringPropertyImpl(newValue) }
+        get { _tryWinRT("", try _default.get_StringPropertyImpl()) }
+        set { _tryWinRT(try _default.put_StringPropertyImpl(newValue)) }
     }
 
     public var structWithReferenceProperty : StructWithIReference {
-        get { try! _default.get_StructWithReferencePropertyImpl() }
-        set { try! _default.put_StructWithReferencePropertyImpl(newValue) }
+        get { _tryWinRT(.init(), try _default.get_StructWithReferencePropertyImpl()) }
+        set { _tryWinRT(try _default.put_StructWithReferencePropertyImpl(newValue)) }
     }
 
     public lazy var inEvent : Event<test_component.InDelegate> = {
@@ -1289,20 +1336,20 @@ public final class Simple : WinRTClass {
 public final class StaticClass {
     private static let _IStaticClassStatics: __ABI_test_component.IStaticClassStatics = try! RoGetActivationFactory("test_component.StaticClass")
     public static func inEnum(_ value: Signed) -> String {
-        return try! _IStaticClassStatics.InEnumImpl(value)
+        return _tryWinRT("", try _IStaticClassStatics.InEnumImpl(value))
     }
 
     public static func inNonBlittableStruct(_ value: NonBlittableStruct) -> String {
-        return try! _IStaticClassStatics.InNonBlittableStructImpl(value)
+        return _tryWinRT("", try _IStaticClassStatics.InNonBlittableStructImpl(value))
     }
 
     public static func takeBase(_ base: Base!) {
-        try! _IStaticClassStatics.TakeBaseImpl(base)
+        _tryWinRT(try _IStaticClassStatics.TakeBaseImpl(base))
     }
 
     public static var enumProperty : Fruit {
-        get { try! _IStaticClassStatics.get_EnumPropertyImpl() }
-        set { try! _IStaticClassStatics.put_EnumPropertyImpl(newValue) }
+        get { _tryWinRT(.init(0), try _IStaticClassStatics.get_EnumPropertyImpl()) }
+        set { _tryWinRT(try _IStaticClassStatics.put_EnumPropertyImpl(newValue)) }
     }
 
 }
@@ -1369,8 +1416,8 @@ open class UnsealedDerived : test_component.Base {
     }
 
     public var prop : Int32 {
-        get { try! _default.get_PropImpl() }
-        set { try! _default.put_PropImpl(newValue) }
+        get { _tryWinRT(0, try _default.get_PropImpl()) }
+        set { _tryWinRT(try _default.put_PropImpl(newValue)) }
     }
 
     private lazy var _IUnsealedDerivedOverloads2: __ABI_test_component.IUnsealedDerivedOverloads2! = getInterfaceForCaching()
@@ -1717,8 +1764,8 @@ public struct StructWithEnum: Hashable, Codable {
 }
 
 public struct StructWithIReference: Hashable, Codable {
-    public var value1: Int32?
-    public var value2: Int32?
+    public var value1: Int32? = nil
+    public var value2: Int32? = nil
     public init() {}
     public init(value1: Int32?, value2: Int32?) {
         self.value1 = value1

--- a/tests/test_component/cpp/CMakeLists.txt
+++ b/tests/test_component/cpp/CMakeLists.txt
@@ -106,7 +106,7 @@ add_custom_command(
   COMMAND midlrt.exe /metadata_dir $ENV{SystemRoot}/system32/winmetadata /winrt /winmd ${WINMD_FILE} /h ${H_FILE} /ns_prefix /nomidl ${MIDL_FILE}
   COMMAND ${CPPWINRT_EXE_PATH} -input ${WINMD_FILE} -comp ${CPP_WINRT_OUTPUT_DIR} -output ${CPP_WINRT_OUTPUT_DIR} -include test_component -include Microsoft.UI.Xaml.Interop -verbose -opt -lib test -overwrite -reference ${CMAKE_SYSTEM_VERSION} -name test_component
   COMMAND ${CPPWINRT_EXE_PATH} -output ${CPP_WINRT_OUTPUT_DIR} -include Windows.Foundation -opt -verbose -reference ${CMAKE_SYSTEM_VERSION}
-  DEPENDS ${MIDL_FILE} NullValues.idl Keywords.idl EventTester.idl CollectionTester.idl BufferTests.idl
+  DEPENDS ${MIDL_FILE} NullValues.idl Keywords.idl EventTester.idl CollectionTester.idl BufferTests.idl ErrorHandlingTests.idl
   MAIN_DEPENDENCY ${MIDL_FILE}
   VERBATIM
 )
@@ -136,6 +136,7 @@ target_sources(test_component_cpp PRIVATE
     Derived.cpp
     DerivedFromNoConstructor.cpp
     EventTester.cpp
+    Failure.cpp
     module.cpp
     ${CPPWINRT_OUTPUT}
     #Optional.cpp

--- a/tests/test_component/cpp/Class.h
+++ b/tests/test_component/cpp/Class.h
@@ -170,7 +170,6 @@ namespace winrt::test_component::implementation
             if (m_basicImpl){
                 m_basicImpl.Method();
             }
-            printf("Method called!\n");
         }
 
         test_component::IBasic Implementation()

--- a/tests/test_component/cpp/ErrorHandlingTests.idl
+++ b/tests/test_component/cpp/ErrorHandlingTests.idl
@@ -1,0 +1,14 @@
+// Methods for testing passing in and returning null values.
+import "Windows.Foundation.idl";
+
+namespace test_component
+{
+    runtimeclass Failure
+    {
+        Failure();
+        static void FailedStaticMethod();
+        static Boolean FailedStaticProperty{ get; };
+
+        String FailedProperty { get; set;};
+    }
+}

--- a/tests/test_component/cpp/Failure.cpp
+++ b/tests/test_component/cpp/Failure.cpp
@@ -1,0 +1,23 @@
+#include "pch.h"
+#include "Failure.h"
+#include "Failure.g.cpp"
+
+namespace winrt::test_component::implementation
+{
+    void Failure::FailedStaticMethod()
+    {
+        throw hresult_not_implemented();
+    }
+    bool Failure::FailedStaticProperty()
+    {
+        throw hresult_not_implemented();
+    }
+    hstring Failure::FailedProperty()
+    {
+        throw hresult_not_implemented();
+    }
+    void Failure::FailedProperty(hstring const& value)
+    {
+        throw hresult_not_implemented();
+    }
+}

--- a/tests/test_component/cpp/Failure.h
+++ b/tests/test_component/cpp/Failure.h
@@ -1,0 +1,21 @@
+#pragma once
+#include "Failure.g.h"
+
+namespace winrt::test_component::implementation
+{
+    struct Failure : FailureT<Failure>
+    {
+        Failure() = default;
+
+        static void FailedStaticMethod();
+        static bool FailedStaticProperty();
+        hstring FailedProperty();
+        void FailedProperty(hstring const& value);
+    };
+}
+namespace winrt::test_component::factory_implementation
+{
+    struct Failure : FailureT<Failure, implementation::Failure>
+    {
+    };
+}

--- a/tests/test_component/cpp/test_component.idl
+++ b/tests/test_component/cpp/test_component.idl
@@ -4,6 +4,7 @@
 #include "EventTester.idl"
 #include "Keywords.idl"
 #include "NullValues.idl"
+#include "ErrorHandlingTests.idl"
 
 import "Windows.Foundation.idl";
 // import "Windows.Foundation.Numerics.idl";


### PR DESCRIPTION
Right now you can't easily handle property get/sets that fail. The current design would require the developer to do something like this:

`let foo = try obj._default.get_Foo()`

While not the worse, you then would need to know which internal interface to invoke the property on Also, the internals aren't exposed (mainly due to export limit issues). While we could fix that issue for cmake, export limits are always going to be an issue for SPM, so I think it makes sense to not require the solution to expose all of those.

## Solution
Provide a `withFailingCall` method that developers can use if they need to gracefully handle an error. What this does is it allocates a `LastErrorHolder` object, which is checked whenever a WinRT method fails. If there is a `LastErrorHolder`, it is given the error of the winrt method call. `withFailingCall` then checks for the error and throws the exception. Here is the implementation of the method:

```
public func withFailingCall<Result>(_ call: @autoclosure () -> Result) throws -> Result {
  let error = getLastError()
  defer { clearLastError() }
  let result = call()
  if let error = error.error {
    throw error
  }
  return result
}
```

## Usage

Property get: `let foo = try withFailingCall(obj.foo)`
Property set: `try withFailingCall(obj.foo = "invalid")`


## Changes
1. `_tryWinRT` methods were added for generated code to invoke. These methods capture the file and line of the caller and add that to the exception information so you know which line failed.
2. an error message is provided when one of these errors is unhandled, telling the developer of the possible workaround:

An example of the message:

```
test_component/ERROR.swift:263: Fatal error: Unhandled WinRT Error @ test_component/test_component.swift: 1098 - 0x80004001 - Not implemented

  Note: If this error is expected and needs to be handled, use `withFailingCall`
  ```