### PR TITLE
Make static functions throw just like instance functions

### DIFF
--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -2265,7 +2265,7 @@ public init<Composable: ComposableImpl>(
         {
             w.write("return ");
         }
-        w.write("try! _%.%Impl(%)\n",
+        w.write("try _%.%Impl(%)\n",
             statics.swift_type_name(),
             func_name,
             bind<write_implementation_args>(method));
@@ -2293,7 +2293,7 @@ public init<Composable: ComposableImpl>(
                 }
 
                 write_documentation_comment(w, type, method.def.Name());
-                w.write("%func %(%)% {\n",
+                w.write("%func %(%) throws% {\n",
                     modifier_for(type, statics, method),
                     get_swift_name(method),
                     bind<write_function_params>(method, write_type_params::swift_allow_implicit_unwrap),

--- a/tests/test_app/AggregationTests.swift
+++ b/tests/test_app/AggregationTests.swift
@@ -35,16 +35,16 @@ class AggregationTests : XCTestCase {
 
   public func testComposedTypesAsInput() throws {
     let appDerived = AppDerived()
-    StaticClass.takeBase(appDerived)
+    try StaticClass.takeBase(appDerived)
     XCTAssertEqual(appDerived.count, 1, "derive from base count not expected")
 
     let appDerived2 = AppDerived2()
 
-    StaticClass.takeBase(appDerived2)
+    try StaticClass.takeBase(appDerived2)
     XCTAssertEqual(appDerived2.count, 1, "derived from derived count not expected")
 
     let appDerived3 = AppDerived3()
-    StaticClass.takeBase(appDerived3)
+    try StaticClass.takeBase(appDerived3)
     XCTAssertEqual(appDerived3.count, 1, "derived from multiple interfaces count not expected")
     XCTAssertEqual(appDerived3.beforeCount, 1, "before count not expected")
   }
@@ -134,7 +134,7 @@ class AggregationTests : XCTestCase {
 
   public func testAggregatedObjectUnwrappedAsAny() throws {
     let derived = AppDerived()
-    Class.takeBaseAndGiveToCallbackAsObject(derived) { sender in
+    try Class.takeBaseAndGiveToCallbackAsObject(derived) { sender in
       let base = sender as? AppDerived
       XCTAssertNotNil(derived)
       XCTAssertIdentical(base, derived)

--- a/tests/test_app/AsyncTests.swift
+++ b/tests/test_app/AsyncTests.swift
@@ -5,14 +5,14 @@ import Foundation
 
 class AsyncTests : XCTestCase {
   public func testAwaitAlreadyCompleted() throws {
-    let asyncOperation = AsyncMethods.getCompletedAsync(42)!
+    let asyncOperation = try AsyncMethods.getCompletedAsync(42)!
     XCTAssertEqual(asyncOperation.status, .completed)
     let result = try asyncBlock(timeout: 1) { try await asyncOperation.get() }
     XCTAssertEqual(result, 42)
   }
 
   public func testAwaitAlreadyFailed() throws {
-    let asyncOperation = AsyncMethods.getCompletedWithErrorAsync(E_LAYOUTCYCLE)!
+    let asyncOperation = try AsyncMethods.getCompletedWithErrorAsync(E_LAYOUTCYCLE)!
     XCTAssertEqual(asyncOperation.status, .error)
     do {
       _ = try asyncBlock(timeout: 1) { try await asyncOperation.get() }
@@ -23,7 +23,7 @@ class AsyncTests : XCTestCase {
   }
 
   public func testAwaitCompletionWithSuspension() throws {
-    let asyncOperation = AsyncMethods.getPendingAsync()!
+    let asyncOperation = try AsyncMethods.getPendingAsync()!
     runAfter(delay: 0.05) { try? asyncOperation.complete(42) }
     let result = try asyncBlock(timeout: 1) { try await asyncOperation.get() }
     XCTAssertEqual(asyncOperation.status, .completed)
@@ -31,7 +31,7 @@ class AsyncTests : XCTestCase {
   }
 
   public func testAwaitFailureWithSuspension() throws {
-    let asyncOperation = AsyncMethods.getPendingAsync()!
+    let asyncOperation = try AsyncMethods.getPendingAsync()!
     runAfter(delay: 0.05) { try? asyncOperation.completeWithError(E_LAYOUTCYCLE) }
     do {
       _ = try asyncBlock(timeout: 1) { try await asyncOperation.get() }

--- a/tests/test_app/BufferTests.swift
+++ b/tests/test_app/BufferTests.swift
@@ -46,7 +46,7 @@ class BufferTests : XCTestCase {
         XCTAssertEqual(buffer.capacity, 10)
         XCTAssertEqual(buffer.data.count, 10)
         for (i, byte) in buffer.data.enumerated() {
-            XCTAssertEqual(byte, BufferTester.getDataFrom(buffer, UInt32(i)))
+            XCTAssertEqual(byte, try BufferTester.getDataFrom(buffer, UInt32(i)))
         }
     }
 
@@ -67,7 +67,7 @@ class BufferTests : XCTestCase {
         XCTAssertEqual(swiftBuffer.data, winrtBuffer.data)
 
         for (i, byte) in swiftBuffer.data.enumerated() {
-            XCTAssertEqual(byte, BufferTester.getDataFrom(swiftBuffer, UInt32(i)))
+            XCTAssertEqual(byte, try BufferTester.getDataFrom(swiftBuffer, UInt32(i)))
         }
     }
 }

--- a/tests/test_app/CollectionTests.swift
+++ b/tests/test_app/CollectionTests.swift
@@ -7,7 +7,7 @@ class CollectionTests : XCTestCase {
   public func testVector_asInput() throws {
     let array = ["Hello", "Goodbye", "Goodnight"]
 
-    let result = CollectionTester.inVector(array.toVector())
+    let result = try CollectionTester.inVector(array.toVector())
     XCTAssertEqual(result, "Hello")
   }
 
@@ -46,14 +46,14 @@ class CollectionTests : XCTestCase {
     let person = Person(firstName: "John", lastName: "Doe", age: 42)
     let array:[Any?] = [person, "Goodbye", 1]
 
-    CollectionTester.getObjectAt(array.toVector(), 0) { 
+    try CollectionTester.getObjectAt(array.toVector(), 0) { 
         XCTAssertEqual($0 as! Person, person)
     }
   }
 
-  public func testMap_asInput() {
+  public func testMap_asInput() throws {
     let dictionary = ["A": "Alpha"]
-    let value = CollectionTester.inMap(dictionary.toMap())
+    let value = try CollectionTester.inMap(dictionary.toMap())
     XCTAssertEqual(value, "Alpha")
   }
   
@@ -75,7 +75,7 @@ class CollectionTests : XCTestCase {
     XCTAssert(map.insert("A", "Aleph")) // Returns true if replacing
     XCTAssert(map.hasKey("A"))
     XCTAssertEqual(map.lookup("A"), "Aleph")
-    let value = CollectionTester.inMap(map)
+    let value = try CollectionTester.inMap(map)
     XCTAssertEqual(value, "Aleph")
   }
 }
@@ -91,4 +91,3 @@ var collectionTests: [XCTestCaseEntry] = [
     ("testVectorObject_toCallback", CollectionTests.testVectorObject_toCallback),
   ])
 ]
-

--- a/tests/test_app/EventTests.swift
+++ b/tests/test_app/EventTests.swift
@@ -54,23 +54,23 @@ class EventTests : XCTestCase {
       static_count+=1
     })
 
-    Simple.fireStaticEvent()
+    try Simple.fireStaticEvent()
     XCTAssertEqual(static_count, 1)
-    Simple.fireStaticEvent()
+    try Simple.fireStaticEvent()
     XCTAssertEqual(static_count, 2)
 
     // dispose of the handlers and make sure we
     // aren't getting more events
     disposable.dispose()
 
-    Simple.fireStaticEvent()
+    try Simple.fireStaticEvent()
     XCTAssertEqual(static_count, 2)
 
     disposable.append(Simple.staticEvent.addHandler { (_,_) in
       static_count+=1
     })
 
-    Simple.fireStaticEvent()
+    try Simple.fireStaticEvent()
     XCTAssertEqual(static_count, 3)
   }
 

--- a/tests/test_app/main.swift
+++ b/tests/test_app/main.swift
@@ -125,10 +125,10 @@ class SwiftWinRTTests : XCTestCase {
     XCTAssertEqual(classy.enumProperty, Fruit.pineapple, "fruit should be Pineapple")
   }
 
-  public func testStaticMethods() {
-    Class.staticTest()
+  public func testStaticMethods() throws {
+    try Class.staticTest()
 
-    var result = Class.staticTestReturn()
+    var result = try Class.staticTestReturn()
     print("result: ", result);
     XCTAssertEqual(result, 42);
 
@@ -137,11 +137,11 @@ class SwiftWinRTTests : XCTestCase {
     XCTAssertEqual(result, 18);
 
     print("calling static class methods")
-    let output = StaticClass.inEnum(Signed.first)
+    let output = try StaticClass.inEnum(Signed.first)
     print("result: ", output)
     XCTAssertEqual(output, "First")
 
-    let fruit = StaticClass.enumProperty
+    let fruit = try StaticClass.enumProperty
     print("result: ", fruit)
     XCTAssertEqual(fruit, Fruit.orange, "expected Orange!")
 
@@ -150,7 +150,7 @@ class SwiftWinRTTests : XCTestCase {
 
     let putNonBlittableStruct = NonBlittableStruct(first: "From", second: "Swift!", third: 1, fourth: "Yay!")
 
-    let putStructResult = StaticClass.inNonBlittableStruct(putNonBlittableStruct)
+    let putStructResult = try StaticClass.inNonBlittableStruct(putNonBlittableStruct)
     print("result: ", putStructResult)
     XCTAssertEqual(putStructResult, "FromSwift!Yay!")
   }
@@ -316,7 +316,7 @@ class SwiftWinRTTests : XCTestCase {
   public func testNonDefaultMethods() throws {
     Class.staticPropertyFloat = 4.0
     XCTAssertEqual(Class.staticPropertyFloat, 4.0)
-    XCTAssertEqual(Class.staticTestReturnFloat(), 42.24)
+    XCTAssertEqual(try Class.staticTestReturnFloat(), 42.24)
     let classy = Class()
     classy.method()
   }
@@ -392,24 +392,24 @@ class SwiftWinRTTests : XCTestCase {
     _ = try classy.inString("\u{E909}")
   }
 
-  public func testNullValues() {
-    XCTAssertTrue(NullValues.isObjectNull(nil))
-    XCTAssertTrue(NullValues.isInterfaceNull(nil))
-    XCTAssertTrue(NullValues.isGenericInterfaceNull(nil))
-    XCTAssertTrue(NullValues.isClassNull(nil))
-    XCTAssertTrue(NullValues.isDelegateNull(nil))
+  public func testNullValues() throws {
+    XCTAssertTrue(try NullValues.isObjectNull(nil))
+    XCTAssertTrue(try NullValues.isInterfaceNull(nil))
+    XCTAssertTrue(try NullValues.isGenericInterfaceNull(nil))
+    XCTAssertTrue(try NullValues.isClassNull(nil))
+    XCTAssertTrue(try NullValues.isDelegateNull(nil))
 
-    XCTAssertFalse(NullValues.isObjectNull(NoopClosable()))
-    XCTAssertFalse(NullValues.isInterfaceNull(NoopClosable()))
-    XCTAssertFalse(NullValues.isGenericInterfaceNull([""].toVector()))
-    XCTAssertFalse(NullValues.isClassNull(NoopClosable()))
-    XCTAssertFalse(NullValues.isDelegateNull({}))
+    XCTAssertFalse(try NullValues.isObjectNull(NoopClosable()))
+    XCTAssertFalse(try NullValues.isInterfaceNull(NoopClosable()))
+    XCTAssertFalse(try NullValues.isGenericInterfaceNull([""].toVector()))
+    XCTAssertFalse(try NullValues.isClassNull(NoopClosable()))
+    XCTAssertFalse(try NullValues.isDelegateNull({}))
 
-    XCTAssertNil(NullValues.getNullObject())
-    XCTAssertNil(NullValues.getNullInterface())
-    XCTAssertNil(NullValues.getNullGenericInterface())
-    XCTAssertNil(NullValues.getNullClass())
-    XCTAssertNil(NullValues.getNullDelegate())
+    XCTAssertNil(try NullValues.getNullObject())
+    XCTAssertNil(try NullValues.getNullInterface())
+    XCTAssertNil(try NullValues.getNullGenericInterface())
+    XCTAssertNil(try NullValues.getNullClass())
+    XCTAssertNil(try NullValues.getNullDelegate())
   }
 
   public func testCasing() {

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -134,13 +134,13 @@ public final class Uri : WinRTClass, IStringable {
     }
     private static let _IUriEscapeStatics: __ABI_Windows_Foundation.IUriEscapeStatics = try! RoGetActivationFactory("Windows.Foundation.Uri")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.unescapecomponent)
-    public static func unescapeComponent(_ toUnescape: String) -> String {
-        return try! _IUriEscapeStatics.UnescapeComponentImpl(toUnescape)
+    public static func unescapeComponent(_ toUnescape: String) throws -> String {
+        return try _IUriEscapeStatics.UnescapeComponentImpl(toUnescape)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.escapecomponent)
-    public static func escapeComponent(_ toEscape: String) -> String {
-        return try! _IUriEscapeStatics.EscapeComponentImpl(toEscape)
+    public static func escapeComponent(_ toEscape: String) throws -> String {
+        return try _IUriEscapeStatics.EscapeComponentImpl(toEscape)
     }
 
     private static let _IUriRuntimeClassFactory: __ABI_Windows_Foundation.IUriRuntimeClassFactory = try! RoGetActivationFactory("Windows.Foundation.Uri")

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams.swift
@@ -41,13 +41,13 @@ public final class Buffer : WinRTClass, IBufferByteAccess, IBuffer {
 
     private static let _IBufferStatics: __ABI_Windows_Storage_Streams.IBufferStatics = try! RoGetActivationFactory("Windows.Storage.Streams.Buffer")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.buffer.createcopyfrommemorybuffer)
-    public static func createCopyFromMemoryBuffer(_ input: test_component.AnyIMemoryBuffer!) -> Buffer! {
-        return try! _IBufferStatics.CreateCopyFromMemoryBufferImpl(input)
+    public static func createCopyFromMemoryBuffer(_ input: test_component.AnyIMemoryBuffer!) throws -> Buffer! {
+        return try _IBufferStatics.CreateCopyFromMemoryBufferImpl(input)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.buffer.creatememorybufferoveribuffer)
-    public static func createMemoryBufferOverIBuffer(_ input: AnyIBuffer!) -> test_component.MemoryBuffer! {
-        return try! _IBufferStatics.CreateMemoryBufferOverIBufferImpl(input)
+    public static func createMemoryBufferOverIBuffer(_ input: AnyIBuffer!) throws -> test_component.MemoryBuffer! {
+        return try _IBufferStatics.CreateMemoryBufferOverIBufferImpl(input)
     }
 
     private lazy var _IBufferByteAccess: __ABI_.IBufferByteAccess! = getInterfaceForCaching()

--- a/tests/test_component/Sources/test_component/Windows.Storage.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.swift
@@ -25,73 +25,73 @@ public typealias StreamedFileFailureMode = __x_ABI_CWindows_CStorage_CStreamedFi
 public final class PathIO {
     private static let _IPathIOStatics: __ABI_Windows_Storage.IPathIOStatics = try! RoGetActivationFactory("Windows.Storage.PathIO")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readtextasync)
-    public static func readTextAsync(_ absolutePath: String) -> AnyIAsyncOperation<String>! {
-        return try! _IPathIOStatics.ReadTextAsyncImpl(absolutePath)
+    public static func readTextAsync(_ absolutePath: String) throws -> AnyIAsyncOperation<String>! {
+        return try _IPathIOStatics.ReadTextAsyncImpl(absolutePath)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readtextasync)
-    public static func readTextAsync(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) -> AnyIAsyncOperation<String>! {
-        return try! _IPathIOStatics.ReadTextWithEncodingAsyncImpl(absolutePath, encoding)
+    public static func readTextAsync(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> AnyIAsyncOperation<String>! {
+        return try _IPathIOStatics.ReadTextWithEncodingAsyncImpl(absolutePath, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writetextasync)
-    public static func writeTextAsync(_ absolutePath: String, _ contents: String) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.WriteTextAsyncImpl(absolutePath, contents)
+    public static func writeTextAsync(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction! {
+        return try _IPathIOStatics.WriteTextAsyncImpl(absolutePath, contents)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writetextasync)
-    public static func writeTextAsync(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.WriteTextWithEncodingAsyncImpl(absolutePath, contents, encoding)
+    public static func writeTextAsync(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction! {
+        return try _IPathIOStatics.WriteTextWithEncodingAsyncImpl(absolutePath, contents, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendtextasync)
-    public static func appendTextAsync(_ absolutePath: String, _ contents: String) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.AppendTextAsyncImpl(absolutePath, contents)
+    public static func appendTextAsync(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction! {
+        return try _IPathIOStatics.AppendTextAsyncImpl(absolutePath, contents)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendtextasync)
-    public static func appendTextAsync(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.AppendTextWithEncodingAsyncImpl(absolutePath, contents, encoding)
+    public static func appendTextAsync(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction! {
+        return try _IPathIOStatics.AppendTextWithEncodingAsyncImpl(absolutePath, contents, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readlinesasync)
-    public static func readLinesAsync(_ absolutePath: String) -> AnyIAsyncOperation<AnyIVector<String>?>! {
-        return try! _IPathIOStatics.ReadLinesAsyncImpl(absolutePath)
+    public static func readLinesAsync(_ absolutePath: String) throws -> AnyIAsyncOperation<AnyIVector<String>?>! {
+        return try _IPathIOStatics.ReadLinesAsyncImpl(absolutePath)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readlinesasync)
-    public static func readLinesAsync(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) -> AnyIAsyncOperation<AnyIVector<String>?>! {
-        return try! _IPathIOStatics.ReadLinesWithEncodingAsyncImpl(absolutePath, encoding)
+    public static func readLinesAsync(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> AnyIAsyncOperation<AnyIVector<String>?>! {
+        return try _IPathIOStatics.ReadLinesWithEncodingAsyncImpl(absolutePath, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writelinesasync)
-    public static func writeLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.WriteLinesAsyncImpl(absolutePath, lines)
+    public static func writeLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!) throws -> test_component.AnyIAsyncAction! {
+        return try _IPathIOStatics.WriteLinesAsyncImpl(absolutePath, lines)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writelinesasync)
-    public static func writeLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!, _ encoding: test_component.UnicodeEncoding) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.WriteLinesWithEncodingAsyncImpl(absolutePath, lines, encoding)
+    public static func writeLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction! {
+        return try _IPathIOStatics.WriteLinesWithEncodingAsyncImpl(absolutePath, lines, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendlinesasync)
-    public static func appendLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.AppendLinesAsyncImpl(absolutePath, lines)
+    public static func appendLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!) throws -> test_component.AnyIAsyncAction! {
+        return try _IPathIOStatics.AppendLinesAsyncImpl(absolutePath, lines)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendlinesasync)
-    public static func appendLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!, _ encoding: test_component.UnicodeEncoding) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.AppendLinesWithEncodingAsyncImpl(absolutePath, lines, encoding)
+    public static func appendLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction! {
+        return try _IPathIOStatics.AppendLinesWithEncodingAsyncImpl(absolutePath, lines, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readbufferasync)
-    public static func readBufferAsync(_ absolutePath: String) -> AnyIAsyncOperation<test_component.AnyIBuffer?>! {
-        return try! _IPathIOStatics.ReadBufferAsyncImpl(absolutePath)
+    public static func readBufferAsync(_ absolutePath: String) throws -> AnyIAsyncOperation<test_component.AnyIBuffer?>! {
+        return try _IPathIOStatics.ReadBufferAsyncImpl(absolutePath)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writebufferasync)
-    public static func writeBufferAsync(_ absolutePath: String, _ buffer: test_component.AnyIBuffer!) -> test_component.AnyIAsyncAction! {
-        return try! _IPathIOStatics.WriteBufferAsyncImpl(absolutePath, buffer)
+    public static func writeBufferAsync(_ absolutePath: String, _ buffer: test_component.AnyIBuffer!) throws -> test_component.AnyIAsyncAction! {
+        return try _IPathIOStatics.WriteBufferAsyncImpl(absolutePath, buffer)
     }
 
 }
@@ -125,33 +125,33 @@ public final class StorageFile : WinRTClass, IStorageItem, test_component.IRando
     }
     private static let _IStorageFileStatics: __ABI_Windows_Storage.IStorageFileStatics = try! RoGetActivationFactory("Windows.Storage.StorageFile")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getfilefrompathasync)
-    public static func getFileFromPathAsync(_ path: String) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.GetFileFromPathAsyncImpl(path)
+    public static func getFileFromPathAsync(_ path: String) throws -> AnyIAsyncOperation<StorageFile?>! {
+        return try _IStorageFileStatics.GetFileFromPathAsyncImpl(path)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getfilefromapplicationuriasync)
-    public static func getFileFromApplicationUriAsync(_ uri: test_component.Uri!) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.GetFileFromApplicationUriAsyncImpl(uri)
+    public static func getFileFromApplicationUriAsync(_ uri: test_component.Uri!) throws -> AnyIAsyncOperation<StorageFile?>! {
+        return try _IStorageFileStatics.GetFileFromApplicationUriAsyncImpl(uri)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.createstreamedfileasync)
-    public static func createStreamedFileAsync(_ displayNameWithExtension: String, _ dataRequested: StreamedFileDataRequestedHandler!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.CreateStreamedFileAsyncImpl(displayNameWithExtension, dataRequested, thumbnail)
+    public static func createStreamedFileAsync(_ displayNameWithExtension: String, _ dataRequested: StreamedFileDataRequestedHandler!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) throws -> AnyIAsyncOperation<StorageFile?>! {
+        return try _IStorageFileStatics.CreateStreamedFileAsyncImpl(displayNameWithExtension, dataRequested, thumbnail)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.replacewithstreamedfileasync)
-    public static func replaceWithStreamedFileAsync(_ fileToReplace: AnyIStorageFile!, _ dataRequested: StreamedFileDataRequestedHandler!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.ReplaceWithStreamedFileAsyncImpl(fileToReplace, dataRequested, thumbnail)
+    public static func replaceWithStreamedFileAsync(_ fileToReplace: AnyIStorageFile!, _ dataRequested: StreamedFileDataRequestedHandler!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) throws -> AnyIAsyncOperation<StorageFile?>! {
+        return try _IStorageFileStatics.ReplaceWithStreamedFileAsyncImpl(fileToReplace, dataRequested, thumbnail)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.createstreamedfilefromuriasync)
-    public static func createStreamedFileFromUriAsync(_ displayNameWithExtension: String, _ uri: test_component.Uri!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.CreateStreamedFileFromUriAsyncImpl(displayNameWithExtension, uri, thumbnail)
+    public static func createStreamedFileFromUriAsync(_ displayNameWithExtension: String, _ uri: test_component.Uri!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) throws -> AnyIAsyncOperation<StorageFile?>! {
+        return try _IStorageFileStatics.CreateStreamedFileFromUriAsyncImpl(displayNameWithExtension, uri, thumbnail)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.replacewithstreamedfilefromuriasync)
-    public static func replaceWithStreamedFileFromUriAsync(_ fileToReplace: AnyIStorageFile!, _ uri: test_component.Uri!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) -> AnyIAsyncOperation<StorageFile?>! {
-        return try! _IStorageFileStatics.ReplaceWithStreamedFileFromUriAsyncImpl(fileToReplace, uri, thumbnail)
+    public static func replaceWithStreamedFileFromUriAsync(_ fileToReplace: AnyIStorageFile!, _ uri: test_component.Uri!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) throws -> AnyIAsyncOperation<StorageFile?>! {
+        return try _IStorageFileStatics.ReplaceWithStreamedFileFromUriAsyncImpl(fileToReplace, uri, thumbnail)
     }
 
     private lazy var _IStorageItem: __ABI_Windows_Storage.IStorageItem! = getInterfaceForCaching()
@@ -406,8 +406,8 @@ public final class StorageFolder : WinRTClass, IStorageItem, IStorageFolder, tes
     }
     private static let _IStorageFolderStatics: __ABI_Windows_Storage.IStorageFolderStatics = try! RoGetActivationFactory("Windows.Storage.StorageFolder")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfolderfrompathasync)
-    public static func getFolderFromPathAsync(_ path: String) -> AnyIAsyncOperation<StorageFolder?>! {
-        return try! _IStorageFolderStatics.GetFolderFromPathAsyncImpl(path)
+    public static func getFolderFromPathAsync(_ path: String) throws -> AnyIAsyncOperation<StorageFolder?>! {
+        return try _IStorageFolderStatics.GetFolderFromPathAsyncImpl(path)
     }
 
     private lazy var _IStorageItem: __ABI_Windows_Storage.IStorageItem! = getInterfaceForCaching()

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -10,16 +10,16 @@ public typealias SwiftifiableNames = __x_ABI_Ctest__component_CSwiftifiableNames
 public typealias Unsigned = __x_ABI_Ctest__component_CUnsigned
 public final class AsyncMethods {
     private static let _IAsyncMethodsStatics: __ABI_test_component.IAsyncMethodsStatics = try! RoGetActivationFactory("test_component.AsyncMethods")
-    public static func getCompletedAsync(_ result: Int32) -> AnyIAsyncOperation<Int32>! {
-        return try! _IAsyncMethodsStatics.GetCompletedAsyncImpl(result)
+    public static func getCompletedAsync(_ result: Int32) throws -> AnyIAsyncOperation<Int32>! {
+        return try _IAsyncMethodsStatics.GetCompletedAsyncImpl(result)
     }
 
-    public static func getCompletedWithErrorAsync(_ errorCode: HRESULT) -> AnyIAsyncOperation<Int32>! {
-        return try! _IAsyncMethodsStatics.GetCompletedWithErrorAsyncImpl(errorCode)
+    public static func getCompletedWithErrorAsync(_ errorCode: HRESULT) throws -> AnyIAsyncOperation<Int32>! {
+        return try _IAsyncMethodsStatics.GetCompletedWithErrorAsyncImpl(errorCode)
     }
 
-    public static func getPendingAsync() -> AsyncOperationInt! {
-        return try! _IAsyncMethodsStatics.GetPendingAsyncImpl()
+    public static func getPendingAsync() throws -> AsyncOperationInt! {
+        return try _IAsyncMethodsStatics.GetPendingAsyncImpl()
     }
 
 }
@@ -146,8 +146,8 @@ open class Base : WinRTClass {
     }
 
     private static let _IBaseStatics: __ABI_test_component.IBaseStatics = try! RoGetActivationFactory("test_component.Base")
-    public class func createFromString(_ value: String) -> Base! {
-        return try! _IBaseStatics.CreateFromStringImpl(value)
+    public class func createFromString(_ value: String) throws -> Base! {
+        return try _IBaseStatics.CreateFromStringImpl(value)
     }
 
     public func doTheThing() throws {
@@ -425,8 +425,8 @@ open class BaseNoOverrides : WinRTClass {
     }
 
     private static let _IBaseNoOverridesStatics: __ABI_test_component.IBaseNoOverridesStatics = try! RoGetActivationFactory("test_component.BaseNoOverrides")
-    public class func createFromString(_ value: String) -> BaseNoOverrides! {
-        return try! _IBaseNoOverridesStatics.CreateFromStringImpl(value)
+    public class func createFromString(_ value: String) throws -> BaseNoOverrides! {
+        return try _IBaseNoOverridesStatics.CreateFromStringImpl(value)
     }
 
     internal enum IBaseNoOverrides : ComposableImpl {
@@ -570,8 +570,8 @@ public final class BaseObservableCollection : WinRTClass, IObservableVector, IVe
 
 public final class BufferTester {
     private static let _IBufferTesterStatics: __ABI_test_component.IBufferTesterStatics = try! RoGetActivationFactory("test_component.BufferTester")
-    public static func getDataFrom(_ buffer: test_component.AnyIBuffer!, _ index: UInt32) -> UInt8 {
-        return try! _IBufferTesterStatics.GetDataFromImpl(buffer, index)
+    public static func getDataFrom(_ buffer: test_component.AnyIBuffer!, _ index: UInt32) throws -> UInt8 {
+        return try _IBufferTesterStatics.GetDataFromImpl(buffer, index)
     }
 
 }
@@ -638,16 +638,16 @@ public final class Class : WinRTClass, IBasic {
     }
 
     private static let _IClassStatics: __ABI_test_component.IClassStatics = try! RoGetActivationFactory("test_component.Class")
-    public static func staticTest() {
-        try! _IClassStatics.StaticTestImpl()
+    public static func staticTest() throws {
+        try _IClassStatics.StaticTestImpl()
     }
 
-    public static func staticTestReturn() -> Int32 {
-        return try! _IClassStatics.StaticTestReturnImpl()
+    public static func staticTestReturn() throws -> Int32 {
+        return try _IClassStatics.StaticTestReturnImpl()
     }
 
-    public static func takeBaseAndGiveToCallbackAsObject(_ base: Base!, _ callback: test_component.InObjectDelegate!) {
-        try! _IClassStatics.TakeBaseAndGiveToCallbackAsObjectImpl(base, callback)
+    public static func takeBaseAndGiveToCallbackAsObject(_ base: Base!, _ callback: test_component.InObjectDelegate!) throws {
+        try _IClassStatics.TakeBaseAndGiveToCallbackAsObjectImpl(base, callback)
     }
 
     public static var staticProperty : Int32 {
@@ -655,8 +655,8 @@ public final class Class : WinRTClass, IBasic {
     }
 
     private static let _IClassStatics2: __ABI_test_component.IClassStatics2 = try! RoGetActivationFactory("test_component.Class")
-    public static func staticTestReturnFloat() -> Float {
-        return try! _IClassStatics2.StaticTestReturnFloatImpl()
+    public static func staticTestReturnFloat() throws -> Float {
+        return try _IClassStatics2.StaticTestReturnFloatImpl()
     }
 
     public static var staticPropertyFloat : Float {
@@ -842,24 +842,24 @@ public final class CollectionTester : WinRTClass {
     }
 
     private static let _ICollectionTesterStatics: __ABI_test_component.ICollectionTesterStatics = try! RoGetActivationFactory("test_component.CollectionTester")
-    public static func inMap(_ value: AnyIMap<String, String>!) -> String {
-        return try! _ICollectionTesterStatics.InMapImpl(value)
+    public static func inMap(_ value: AnyIMap<String, String>!) throws -> String {
+        return try _ICollectionTesterStatics.InMapImpl(value)
     }
 
-    public static func inMapView(_ value: AnyIMapView<String, String>!) -> String {
-        return try! _ICollectionTesterStatics.InMapViewImpl(value)
+    public static func inMapView(_ value: AnyIMapView<String, String>!) throws -> String {
+        return try _ICollectionTesterStatics.InMapViewImpl(value)
     }
 
-    public static func inVector(_ value: AnyIVector<String>!) -> String {
-        return try! _ICollectionTesterStatics.InVectorImpl(value)
+    public static func inVector(_ value: AnyIVector<String>!) throws -> String {
+        return try _ICollectionTesterStatics.InVectorImpl(value)
     }
 
-    public static func inVectorView(_ value: AnyIVectorView<String>!) -> String {
-        return try! _ICollectionTesterStatics.InVectorViewImpl(value)
+    public static func inVectorView(_ value: AnyIVectorView<String>!) throws -> String {
+        return try _ICollectionTesterStatics.InVectorViewImpl(value)
     }
 
-    public static func getObjectAt(_ value: AnyIVector<Any?>!, _ index: UInt32, _ callback: ObjectHandler!) {
-        try! _ICollectionTesterStatics.GetObjectAtImpl(value, index, callback)
+    public static func getObjectAt(_ value: AnyIVector<Any?>!, _ index: UInt32, _ callback: ObjectHandler!) throws {
+        try _ICollectionTesterStatics.GetObjectAtImpl(value, index, callback)
     }
 
     public func returnStoredStringVector() throws -> AnyIVector<String>! {
@@ -940,8 +940,8 @@ public final class Derived : test_component.Base {
     }
 
     private static let _IDerivedStatics: __ABI_test_component.IDerivedStatics = try! RoGetActivationFactory("test_component.Derived")
-    override public static func createFromString(_ value: String) -> Derived! {
-        return try! _IDerivedStatics.CreateFromStringImpl(value)
+    override public static func createFromString(_ value: String) throws -> Derived! {
+        return try _IDerivedStatics.CreateFromStringImpl(value)
     }
 
     public var prop : Int32 {
@@ -1099,44 +1099,44 @@ public final class NoopClosable : WinRTClass, test_component.IClosable {
 
 public final class NullValues {
     private static let _INullValuesStatics: __ABI_test_component.INullValuesStatics = try! RoGetActivationFactory("test_component.NullValues")
-    public static func isObjectNull(_ value: Any!) -> Bool {
-        return try! _INullValuesStatics.IsObjectNullImpl(value)
+    public static func isObjectNull(_ value: Any!) throws -> Bool {
+        return try _INullValuesStatics.IsObjectNullImpl(value)
     }
 
-    public static func isInterfaceNull(_ value: test_component.AnyIClosable!) -> Bool {
-        return try! _INullValuesStatics.IsInterfaceNullImpl(value)
+    public static func isInterfaceNull(_ value: test_component.AnyIClosable!) throws -> Bool {
+        return try _INullValuesStatics.IsInterfaceNullImpl(value)
     }
 
-    public static func isGenericInterfaceNull(_ value: AnyIVector<String>!) -> Bool {
-        return try! _INullValuesStatics.IsGenericInterfaceNullImpl(value)
+    public static func isGenericInterfaceNull(_ value: AnyIVector<String>!) throws -> Bool {
+        return try _INullValuesStatics.IsGenericInterfaceNullImpl(value)
     }
 
-    public static func isClassNull(_ value: NoopClosable!) -> Bool {
-        return try! _INullValuesStatics.IsClassNullImpl(value)
+    public static func isClassNull(_ value: NoopClosable!) throws -> Bool {
+        return try _INullValuesStatics.IsClassNullImpl(value)
     }
 
-    public static func isDelegateNull(_ value: VoidToVoidDelegate!) -> Bool {
-        return try! _INullValuesStatics.IsDelegateNullImpl(value)
+    public static func isDelegateNull(_ value: VoidToVoidDelegate!) throws -> Bool {
+        return try _INullValuesStatics.IsDelegateNullImpl(value)
     }
 
-    public static func getNullObject() -> Any! {
-        return try! _INullValuesStatics.GetNullObjectImpl()
+    public static func getNullObject() throws -> Any! {
+        return try _INullValuesStatics.GetNullObjectImpl()
     }
 
-    public static func getNullInterface() -> test_component.AnyIClosable! {
-        return try! _INullValuesStatics.GetNullInterfaceImpl()
+    public static func getNullInterface() throws -> test_component.AnyIClosable! {
+        return try _INullValuesStatics.GetNullInterfaceImpl()
     }
 
-    public static func getNullGenericInterface() -> AnyIVector<String>! {
-        return try! _INullValuesStatics.GetNullGenericInterfaceImpl()
+    public static func getNullGenericInterface() throws -> AnyIVector<String>! {
+        return try _INullValuesStatics.GetNullGenericInterfaceImpl()
     }
 
-    public static func getNullClass() -> NoopClosable! {
-        return try! _INullValuesStatics.GetNullClassImpl()
+    public static func getNullClass() throws -> NoopClosable! {
+        return try _INullValuesStatics.GetNullClassImpl()
     }
 
-    public static func getNullDelegate() -> VoidToVoidDelegate! {
-        return try! _INullValuesStatics.GetNullDelegateImpl()
+    public static func getNullDelegate() throws -> VoidToVoidDelegate! {
+        return try _INullValuesStatics.GetNullDelegateImpl()
     }
 
 }
@@ -1170,8 +1170,8 @@ public final class Simple : WinRTClass {
     }
 
     private static let _ISimpleStatics: __ABI_test_component.ISimpleStatics = try! RoGetActivationFactory("test_component.Simple")
-    public static func fireStaticEvent() {
-        try! _ISimpleStatics.FireStaticEventImpl()
+    public static func fireStaticEvent() throws {
+        try _ISimpleStatics.FireStaticEventImpl()
     }
 
     public static var staticEvent : Event<EventHandler<Any?>> = {
@@ -1288,16 +1288,16 @@ public final class Simple : WinRTClass {
 
 public final class StaticClass {
     private static let _IStaticClassStatics: __ABI_test_component.IStaticClassStatics = try! RoGetActivationFactory("test_component.StaticClass")
-    public static func inEnum(_ value: Signed) -> String {
-        return try! _IStaticClassStatics.InEnumImpl(value)
+    public static func inEnum(_ value: Signed) throws -> String {
+        return try _IStaticClassStatics.InEnumImpl(value)
     }
 
-    public static func inNonBlittableStruct(_ value: NonBlittableStruct) -> String {
-        return try! _IStaticClassStatics.InNonBlittableStructImpl(value)
+    public static func inNonBlittableStruct(_ value: NonBlittableStruct) throws -> String {
+        return try _IStaticClassStatics.InNonBlittableStructImpl(value)
     }
 
-    public static func takeBase(_ base: Base!) {
-        try! _IStaticClassStatics.TakeBaseImpl(base)
+    public static func takeBase(_ base: Base!) throws {
+        try _IStaticClassStatics.TakeBaseImpl(base)
     }
 
     public static var enumProperty : Fruit {


### PR DESCRIPTION
Currently instance functions throw but static functions do not. There is no reason for this difference, so align on making all functions throw to make their errors possible to handle.

Fixes #145