### PR TITLE
Revert "Set compilers in presets"

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,5 +14,5 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/windows-build
         with:
-          config: debug-msvc
+          config: debug
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -30,21 +30,7 @@
             "installDir": "${sourceDir}/out/debug",
             "inherits": [ "base" ],
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_C_COMPILER": "clang-cl",
-                "CMAKE_CXX_COMPILER": "clang-cl"
-            }
-        },
-        {
-            "name": "debug-msvc",
-            "displayName": "Debug (MSVC)",
-            "binaryDir": "${sourceDir}/build/debug-msvc",
-            "installDir": "${sourceDir}/out/debug-msvc",
-            "inherits": [ "base" ],
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl"
+                "CMAKE_BUILD_TYPE": "Debug"
             }
         },
         {
@@ -54,9 +40,7 @@
             "installDir": "${sourceDir}/out/release",
             "inherits": [ "base" ],
             "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Release",
-                "CMAKE_C_COMPILER": "cl",
-                "CMAKE_CXX_COMPILER": "cl"
+                "CMAKE_BUILD_TYPE": "Release"
             }
         }
     ],
@@ -64,10 +48,6 @@
       {
         "name": "debug",
         "configurePreset": "debug"
-      },
-      {
-        "name": "debug-msvc",
-        "configurePreset": "debug-msvc"
       },
       {
         "name": "release",

--- a/swiftwinrt/CMakeLists.txt
+++ b/swiftwinrt/CMakeLists.txt
@@ -1,5 +1,8 @@
 project(swiftwinrt)
 
+set(CMAKE_C_COMPILER cl)
+set(CMAKE_CXX_COMPILER cl)
+
 set(SWIFTWINRT_VERSION_STRING "0.0.1")
 set(MicrosoftWindowsWinMD_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/winmd/src)
 

--- a/tests/test_component/cpp/CMakeLists.txt
+++ b/tests/test_component/cpp/CMakeLists.txt
@@ -1,6 +1,19 @@
 project(test_component_cpp)
 include(nuget)
 
+# For debug builds, build with clang which enables us to use DWARF symbols
+# and debug both Swift and C++ code using lldb.
+if (${CMAKE_BUILD_TYPE} STREQUAL "DEBUG")
+    set(CMAKE_C_COMPILER clang-cl)
+    set(CMAKE_CXX_COMPILER clang-cl)
+else()
+    # For release builds don't use clang because the C++/WinRT generated code doesn't compile.
+    # It's not immediately clear if this is an issue with C++/WinRT or the compilation flags
+    # being used. But we are only using clang in debug builds to make debugging easier, so
+    # using this little hack for now.
+    set(CMAKE_C_COMPILER cl)
+    set(CMAKE_CXX_COMPILER cl)
+endif()
 set(H_FILE
     ${CMAKE_TEST_COMPONENT_OUTPUT}/test_component.h
 )


### PR DESCRIPTION
Reverts thebrowsercompany/swift-winrt#151

This breaks local developer workflows in swift/winrt since it forces swiftwinrt.exe to build using clang when you want to debug using LLDB, which it can't do. reverting seems to work fine locally, sending up this PR to see if it passes CI