### PR TITLE
fix inner loop by removing clang

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -14,5 +14,5 @@ jobs:
           submodules: recursive
       - uses: ./.github/actions/windows-build
         with:
-          config: debug-msvc
+          config: debug
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -31,18 +31,6 @@
             "inherits": [ "base" ],
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Debug",
-                "CMAKE_C_COMPILER": "clang-cl",
-                "CMAKE_CXX_COMPILER": "clang-cl"
-            }
-        },
-        {
-            "name": "debug-msvc",
-            "displayName": "Debug (MSVC)",
-            "binaryDir": "${sourceDir}/build/debug-msvc",
-            "installDir": "${sourceDir}/out/debug-msvc",
-            "inherits": [ "base" ],
-            "cacheVariables": {
-                "CMAKE_BUILD_TYPE": "Debug",
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl"
             }
@@ -64,10 +52,6 @@
       {
         "name": "debug",
         "configurePreset": "debug"
-      },
-      {
-        "name": "debug-msvc",
-        "configurePreset": "debug-msvc"
       },
       {
         "name": "release",


### PR DESCRIPTION
swift-winrt cant build using clang and #151 also breaks building it in Visual Studio as well as inner-loop for folks trying to debug in VSCode. since the test app is built using SPM, specifying clang doesn't do anything so we should be able to remove it entirely