### PR TITLE
Remove an extra string copy while constructing HString

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,18 +4,18 @@
             "type": "swift-lldb",
             "request": "launch",
             "name": "test_app",
-            "program": "${workspaceFolder:swiftwinrt}\\out\\${command:cmake.activeBuildPresetName}\\bin\\test_app.exe",
+            "program": "${workspaceFolder}\\out\\${command:cmake.activeBuildPresetName}\\bin\\test_app.exe",
             "args": [],
-            "cwd": "${workspaceFolder:swiftwinrt}/tests",
+            "cwd": "${workspaceFolder}/tests",
             "preLaunchTask": "Install"
         },
         {
             "type": "cppvsdbg",
             "request": "launch",
             "name": "test_app (pdb)",
-            "program": "${workspaceFolder:swiftwinrt}\\out\\${command:cmake.activeBuildPresetName}\\bin\\test_app",
+            "program": "${workspaceFolder}\\out\\${command:cmake.activeBuildPresetName}\\bin\\test_app",
             "args": [],
-            "cwd": "${workspaceFolder:swiftwinrt}/tests",
+            "cwd": "${workspaceFolder}/tests",
             "preLaunchTask": "Install"
         }
     ]

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -47,20 +47,15 @@
                 "CMAKE_CXX_COMPILER": "cl"
             }
         }
+    ],
+    "buildPresets": [
+      {
+        "name": "debug",
+        "configurePreset": "debug"
       },
       {
         "name": "release",
         "configurePreset": "release"
       }
-  ],
-  "buildPresets": [
-    {
-      "name": "debug",
-      "configurePreset": "debug"
-    },
-    {
-      "name": "release",
-      "configurePreset": "release"
-    }
-  ]
+    ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -47,15 +47,20 @@
                 "CMAKE_CXX_COMPILER": "cl"
             }
         }
-    ],
-    "buildPresets": [
-      {
-        "name": "debug",
-        "configurePreset": "debug"
       },
       {
         "name": "release",
         "configurePreset": "release"
       }
-    ]
+  ],
+  "buildPresets": [
+    {
+      "name": "debug",
+      "configurePreset": "debug"
+    },
+    {
+      "name": "release",
+      "configurePreset": "release"
+    }
+  ]
 }

--- a/swiftwinrt/Resources/Support/HString.swift
+++ b/swiftwinrt/Resources/Support/HString.swift
@@ -10,11 +10,26 @@ final public class HString {
   internal private(set) var hString: HSTRING?
   
   public init(_ string: String) throws {
-    self.hString = try string.withCString(encodedAs: UTF16.self) {
-      var result: HSTRING?
-      try CHECKED(WindowsCreateString($0, UINT32(wcslen($0)), &result))
-      return result
-    }
+
+    let codeUnitCount = string.utf16.count
+    var pointer: UnsafeMutablePointer<UInt16>? = nil
+    var hStringBuffer: HSTRING_BUFFER? = nil
+
+    try CHECKED(WindowsPreallocateStringBuffer(UInt32(codeUnitCount), &pointer, &hStringBuffer));
+
+    guard let pointer else { throw Error(hr: E_FAIL) }
+        _ = UnsafeMutableBufferPointer(start: pointer, count: codeUnitCount).initialize(from: string.utf16)
+
+    var hString: HSTRING?
+        do { 
+            try CHECKED(WindowsPromoteStringBuffer(hStringBuffer, &hString));
+        }
+        catch {
+            WindowsDeleteStringBuffer(hStringBuffer)
+            throw error
+        }
+
+    self.hString = hString
   }
 
   public init(_ hString: HSTRING?) throws {

--- a/swiftwinrt/Resources/Support/HString.swift
+++ b/swiftwinrt/Resources/Support/HString.swift
@@ -10,26 +10,25 @@ final public class HString {
   internal private(set) var hString: HSTRING?
   
   public init(_ string: String) throws {
-
     let codeUnitCount = string.utf16.count
     var pointer: UnsafeMutablePointer<UInt16>? = nil
     var hStringBuffer: HSTRING_BUFFER? = nil
 
+    // Note: Methods like String.withCString are not used here because they do a copy to create a null
+    // terminated string, and requires an additional copy to create an HSTRING. Instead, a single copy is
+    // done by using WindowsPreallocateStringBuffer to allocate a buffer and directly copying the string into it.
     try CHECKED(WindowsPreallocateStringBuffer(UInt32(codeUnitCount), &pointer, &hStringBuffer));
-
     guard let pointer else { throw Error(hr: E_FAIL) }
-        _ = UnsafeMutableBufferPointer(start: pointer, count: codeUnitCount).initialize(from: string.utf16)
-
-    var hString: HSTRING?
-        do { 
-            try CHECKED(WindowsPromoteStringBuffer(hStringBuffer, &hString));
-        }
-        catch {
-            WindowsDeleteStringBuffer(hStringBuffer)
-            throw error
-        }
-
-    self.hString = hString
+      _ = UnsafeMutableBufferPointer(start: pointer, count: codeUnitCount).initialize(from: string.utf16)
+    
+    do {
+      var hString: HSTRING? = nil
+      try CHECKED(WindowsPromoteStringBuffer(hStringBuffer, &hString));
+      self.hString = hString
+    } catch {
+      WindowsDeleteStringBuffer(hStringBuffer)
+      throw error
+    }
   }
 
   public init(_ hString: HSTRING?) throws {


### PR DESCRIPTION
When an `HString `is currently constructed, the `withCString` method makes a copy of the source string for null termination. Then `WindowsCreateString` created a second copy.  An `HSTRING` doesn't need a null terminated string for construction, so remove `withCString ` and use a single allocation by `WindowsPreallocateStringBuffer`. 

The contents of the source string are copied into the `HSTRING_BUFFER` created by `WindowsPreallocateStringBuffer`, and an `HSTRING` is created from that buffer using `WindowsPromoteStringBuffer`.

Fixes DEVIN-1237