### PR TITLE
Add test for IVector being IIterable

### DIFF
--- a/tests/test_app/CollectionTests.swift
+++ b/tests/test_app/CollectionTests.swift
@@ -42,6 +42,10 @@ class CollectionTests : XCTestCase {
     XCTAssertEqual(vector2[2], "Goodnight")
   }
 
+  public func testArrayVectorIsIterable() throws {
+    XCTAssertNotNil(try CollectionTester.vectorToIterable(["a", "b", "c"].toVector()))
+  }
+
   public func testVectorObject_toCallback() throws {
     let person = Person(firstName: "John", lastName: "Doe", age: 42)
     let array:[Any?] = [person, "Goodbye", 1]
@@ -88,6 +92,7 @@ var collectionTests: [XCTestCaseEntry] = [
     ("testVector_asInput", CollectionTests.testVector_asInput),
     ("testVector_asReturn", CollectionTests.testVector_asReturn),
     ("testVector_mutate", CollectionTests.testVector_mutate),
+    ("testArrayVectorIsIterable", CollectionTests.testArrayVectorIsIterable),
     ("testVectorObject_toCallback", CollectionTests.testVectorObject_toCallback),
   ])
 ]

--- a/tests/test_app/CollectionTests.swift
+++ b/tests/test_app/CollectionTests.swift
@@ -43,7 +43,7 @@ class CollectionTests : XCTestCase {
   }
 
   public func testArrayVectorIsIterable() throws {
-    XCTAssertNotNil(try CollectionTester.vectorToIterable(["a", "b", "c"].toVector()))
+    XCTAssertNotNil(try CollectionTester.vectorAsIterable(["a", "b", "c"].toVector()))
   }
 
   public func testVectorObject_toCallback() throws {

--- a/tests/test_app/CollectionTests.swift
+++ b/tests/test_app/CollectionTests.swift
@@ -43,6 +43,7 @@ class CollectionTests : XCTestCase {
   }
 
   public func testArrayVectorIsIterable() throws {
+    try XCTSkipIf(true, "TODO(#159)")
     XCTAssertNotNil(try CollectionTester.vectorAsIterable(["a", "b", "c"].toVector()))
   }
 

--- a/tests/test_component/cpp/CollectionTester.cpp
+++ b/tests/test_component/cpp/CollectionTester.cpp
@@ -40,6 +40,11 @@ namespace winrt::test_component::implementation
         callback(item);
     }
 
+    winrt::Windows::Foundation::Collections::IIterable<hstring> CollectionTester::VectorAsIterable(winrt::Windows::Foundation::Collections::IVector<hstring> const& value)
+    {
+        return value.as<Windows::Foundation::Collections::IIterable<hstring>>();
+    }
+
     Windows::Foundation::Collections::IVector<hstring> CollectionTester::ReturnStoredStringVector()
     {
         if (m_vector.Size() == 0)

--- a/tests/test_component/cpp/CollectionTester.h
+++ b/tests/test_component/cpp/CollectionTester.h
@@ -14,6 +14,7 @@ namespace winrt::test_component::implementation
         static hstring InVector(winrt::Windows::Foundation::Collections::IVector<hstring> const& value);
         static hstring InVectorView(winrt::Windows::Foundation::Collections::IVectorView<hstring> const& value);
         static void GetObjectAt(winrt::Windows::Foundation::Collections::IVector<winrt::Windows::Foundation::IInspectable> const& value, uint32_t index, winrt::test_component::ObjectHandler const& callback);
+        static winrt::Windows::Foundation::Collections::IIterable<hstring> VectorAsIterable(winrt::Windows::Foundation::Collections::IVector<hstring> const& value);
 
         winrt::Windows::Foundation::Collections::IVector<hstring> ReturnStoredStringVector();
         winrt::Windows::Foundation::Collections::IMap<hstring, hstring> ReturnMapFromStringToString();

--- a/tests/test_component/cpp/CollectionTester.idl
+++ b/tests/test_component/cpp/CollectionTester.idl
@@ -14,6 +14,7 @@ namespace test_component
         static String InVector(Windows.Foundation.Collections.IVector<String> value);
         static String InVectorView(Windows.Foundation.Collections.IVectorView<String> value);
         static void GetObjectAt(Windows.Foundation.Collections.IVector<Object> value, UInt32 index, ObjectHandler callback);
+        static Windows.Foundation.Collections.IIterable<String> VectorAsIterable(Windows.Foundation.Collections.IVector<String> value);
 
         Windows.Foundation.Collections.IVector<String> ReturnStoredStringVector();
         Windows.Foundation.Collections.IMap<String, String> ReturnMapFromStringToString();


### PR DESCRIPTION
Adds a skipped test that would pass if #159 were implemented.

I believe this doesn't work and would be nontrivial to implement. When a Swift-implemented `IVector<T>` is passed to WinRT, we create a COM-exposable wrapper specific to top-level interface, `IVector<T>`, but that wrapper does not know how to provide additional required interfaces, `IIterable<T>` in this case. More generally, the wrapper would have no way to know that the Swift object implements other interfaces (for example `IClosable`). `IVector<T>`'s queryInterface cannot respond to `IIterable<T>` because the GUID and wrapper types are different for each `T`.