### PR TITLE
Generate structs as Sendable

### DIFF
--- a/swiftwinrt/code_writers/struct_writers.cpp
+++ b/swiftwinrt/code_writers/struct_writers.cpp
@@ -64,7 +64,7 @@ namespace swiftwinrt
     void write_struct(writer& w, struct_type const& type)
     {
         write_documentation_comment(w, type);
-        w.write("public struct %: Hashable, Codable {\n", type);
+        w.write("public struct %: Hashable, Codable, Sendable {\n", type);
         {
             auto indent_guard1 = w.push_indent();
             for (auto&& field : type.members)

--- a/tests/test_component/Sources/test_component/Windows.Data.Text.swift
+++ b/tests/test_component/Sources/test_component/Windows.Data.Text.swift
@@ -4,7 +4,7 @@ import Foundation
 import Ctest_component
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.data.text.textsegment)
-public struct TextSegment: Hashable, Codable {
+public struct TextSegment: Hashable, Codable, Sendable {
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.data.text.textsegment.startposition)
     public var startPosition: UInt32 = 0
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.data.text.textsegment.length)

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -358,7 +358,7 @@ public typealias DeferralCompletedHandler = () throws -> ()
 public typealias EventHandler<T> = (Any?, T) throws -> ()
 public typealias TypedEventHandler<TSender,TResult> = (TSender, TResult) throws -> ()
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.datetime)
-public struct DateTime: Hashable, Codable {
+public struct DateTime: Hashable, Codable, Sendable {
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.datetime.universaltime)
     public var universalTime: Int64 = 0
     public init() {}
@@ -371,7 +371,7 @@ public struct DateTime: Hashable, Codable {
 }
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.point)
-public struct Point: Hashable, Codable {
+public struct Point: Hashable, Codable, Sendable {
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.point.x)
     public var x: Float = 0.0
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.point.y)
@@ -387,7 +387,7 @@ public struct Point: Hashable, Codable {
 }
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.rect)
-public struct Rect: Hashable, Codable {
+public struct Rect: Hashable, Codable, Sendable {
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.rect.x)
     public var x: Float = 0.0
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.rect.y)
@@ -409,7 +409,7 @@ public struct Rect: Hashable, Codable {
 }
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.size)
-public struct Size: Hashable, Codable {
+public struct Size: Hashable, Codable, Sendable {
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.size.width)
     public var width: Float = 0.0
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.size.height)
@@ -425,7 +425,7 @@ public struct Size: Hashable, Codable {
 }
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.timespan)
-public struct TimeSpan: Hashable, Codable {
+public struct TimeSpan: Hashable, Codable, Sendable {
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.timespan.duration)
     public var duration: Int64 = 0
     public init() {}

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
@@ -428,7 +428,7 @@ public final class StorageItemQueryResult : WinRTClass, IStorageQueryResultBase 
 }
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.sortentry)
-public struct SortEntry: Hashable, Codable {
+public struct SortEntry: Hashable, Codable, Sendable {
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.sortentry.propertyname)
     public var propertyName: String = ""
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.sortentry.ascendingorder)

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -1684,7 +1684,7 @@ public final class WeakReferencer : WinRTClass {
 
 public typealias ObjectHandler = (Any?) throws -> ()
 public typealias VoidToVoidDelegate = () throws -> ()
-public struct BlittableStruct: Hashable, Codable {
+public struct BlittableStruct: Hashable, Codable, Sendable {
     public var first: Int32 = 0
     public var second: Int32 = 0
     public init() {}
@@ -1697,7 +1697,7 @@ public struct BlittableStruct: Hashable, Codable {
     }
 }
 
-public struct NonBlittableBoolStruct: Hashable, Codable {
+public struct NonBlittableBoolStruct: Hashable, Codable, Sendable {
     public var first: Bool = false
     public var second: Bool = false
     public var third: Bool = false
@@ -1714,7 +1714,7 @@ public struct NonBlittableBoolStruct: Hashable, Codable {
     }
 }
 
-public struct NonBlittableStruct: Hashable, Codable {
+public struct NonBlittableStruct: Hashable, Codable, Sendable {
     public var first: String = ""
     public var second: String = ""
     public var third: Int32 = 0
@@ -1731,7 +1731,7 @@ public struct NonBlittableStruct: Hashable, Codable {
     }
 }
 
-public struct SimpleEventArgs: Hashable, Codable {
+public struct SimpleEventArgs: Hashable, Codable, Sendable {
     public var value: Int32 = 0
     public init() {}
     public init(value: Int32) {
@@ -1742,7 +1742,7 @@ public struct SimpleEventArgs: Hashable, Codable {
     }
 }
 
-public struct StructWithEnum: Hashable, Codable {
+public struct StructWithEnum: Hashable, Codable, Sendable {
     public var names: SwiftifiableNames = .init(0)
     public init() {}
     public init(names: SwiftifiableNames) {
@@ -1753,7 +1753,7 @@ public struct StructWithEnum: Hashable, Codable {
     }
 }
 
-public struct StructWithIReference: Hashable, Codable {
+public struct StructWithIReference: Hashable, Codable, Sendable {
     public var value1: Int32?
     public var value2: Int32?
     public init() {}


### PR DESCRIPTION
Structs are `Sendable` by definition:

> Structs are always passed and returned by value. Struct fields may only be primitives, enums, structs, strings, and [IReference<T>](https://learn.microsoft.com/en-us/uwp/api/windows.foundation.ireference-1) (the latter two being the only two heap-allocated field types).
https://learn.microsoft.com/en-us/uwp/winrt-cref/winrt-type-system#structs

Not written on that doc page, but validated by midlrt is that `IReference<T>`'s in structs must be to value types, not to delegates, so the transitive closure of all types referenced by structs will always be sendable.

```
     delegate void SomeDelegate();
        struct OhNoNotInHere
        {
            Windows.Foundation.IReference<SomeDelegate> DelegateReference;
        };
```
```
test_component.idl(483) : error MIDL5105 : [msg]T in IReference<T> must be a value type when IReference is used as a struct field. [context]: test_component.SomeDelegate [ Field 'DelegateReference' of Struct 'test_component.OhNoNotInHere'  ]
```

Fixes #162