### PR TITLE
Mark enums as Sendable

### DIFF
--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -48,7 +48,7 @@ namespace swiftwinrt
         }
         w.write("}\n");
 
-        w.write("extension %: ^@retroactive Hashable, ^@retroactive Codable {}\n\n", get_full_swift_type_name(w, type));
+        w.write("extension %: ^@retroactive Hashable, ^@retroactive Codable, ^@retroactive Sendable {}\n\n", get_full_swift_type_name(w, type));
     }
 
     static void write_guid_value(writer& w, std::vector<FixedArgSig> const& args)

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
@@ -503,5 +503,5 @@ extension test_component.CollectionChange {
         CollectionChange_ItemChanged
     }
 }
-extension test_component.CollectionChange: @retroactive Hashable, @retroactive Codable {}
+extension test_component.CollectionChange: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -728,7 +728,7 @@ extension test_component.AsyncStatus {
         __x_ABI_CWindows_CFoundation_CAsyncStatus_Started
     }
 }
-extension test_component.AsyncStatus: @retroactive Hashable, @retroactive Codable {}
+extension test_component.AsyncStatus: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.PropertyType {
     public static var empty : test_component.PropertyType {
@@ -855,5 +855,5 @@ extension test_component.PropertyType {
         __x_ABI_CWindows_CFoundation_CPropertyType_OtherTypeArray
     }
 }
-extension test_component.PropertyType: @retroactive Hashable, @retroactive Codable {}
+extension test_component.PropertyType: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties.swift
@@ -786,7 +786,7 @@ extension test_component.PhotoOrientation {
         __x_ABI_CWindows_CStorage_CFileProperties_CPhotoOrientation_Rotate90
     }
 }
-extension test_component.PhotoOrientation: @retroactive Hashable, @retroactive Codable {}
+extension test_component.PhotoOrientation: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.PropertyPrefetchOptions {
     public static var none : test_component.PropertyPrefetchOptions {
@@ -808,7 +808,7 @@ extension test_component.PropertyPrefetchOptions {
         __x_ABI_CWindows_CStorage_CFileProperties_CPropertyPrefetchOptions_BasicProperties
     }
 }
-extension test_component.PropertyPrefetchOptions: @retroactive Hashable, @retroactive Codable {}
+extension test_component.PropertyPrefetchOptions: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.ThumbnailMode {
     public static var picturesView : test_component.ThumbnailMode {
@@ -830,7 +830,7 @@ extension test_component.ThumbnailMode {
         __x_ABI_CWindows_CStorage_CFileProperties_CThumbnailMode_SingleItem
     }
 }
-extension test_component.ThumbnailMode: @retroactive Hashable, @retroactive Codable {}
+extension test_component.ThumbnailMode: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.ThumbnailOptions {
     public static var none : test_component.ThumbnailOptions {
@@ -846,7 +846,7 @@ extension test_component.ThumbnailOptions {
         __x_ABI_CWindows_CStorage_CFileProperties_CThumbnailOptions_UseCurrentScale
     }
 }
-extension test_component.ThumbnailOptions: @retroactive Hashable, @retroactive Codable {}
+extension test_component.ThumbnailOptions: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.ThumbnailType {
     public static var image : test_component.ThumbnailType {
@@ -856,7 +856,7 @@ extension test_component.ThumbnailType {
         __x_ABI_CWindows_CStorage_CFileProperties_CThumbnailType_Icon
     }
 }
-extension test_component.ThumbnailType: @retroactive Hashable, @retroactive Codable {}
+extension test_component.ThumbnailType: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.VideoOrientation {
     public static var normal : test_component.VideoOrientation {
@@ -872,5 +872,5 @@ extension test_component.VideoOrientation {
         __x_ABI_CWindows_CStorage_CFileProperties_CVideoOrientation_Rotate270
     }
 }
-extension test_component.VideoOrientation: @retroactive Hashable, @retroactive Codable {}
+extension test_component.VideoOrientation: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
@@ -543,7 +543,7 @@ extension test_component.CommonFileQuery {
         __x_ABI_CWindows_CStorage_CSearch_CCommonFileQuery_OrderByDate
     }
 }
-extension test_component.CommonFileQuery: @retroactive Hashable, @retroactive Codable {}
+extension test_component.CommonFileQuery: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.CommonFolderQuery {
     public static var defaultQuery : test_component.CommonFolderQuery {
@@ -586,7 +586,7 @@ extension test_component.CommonFolderQuery {
         __x_ABI_CWindows_CStorage_CSearch_CCommonFolderQuery_GroupByType
     }
 }
-extension test_component.CommonFolderQuery: @retroactive Hashable, @retroactive Codable {}
+extension test_component.CommonFolderQuery: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.DateStackOption {
     public static var none : test_component.DateStackOption {
@@ -599,7 +599,7 @@ extension test_component.DateStackOption {
         __x_ABI_CWindows_CStorage_CSearch_CDateStackOption_Month
     }
 }
-extension test_component.DateStackOption: @retroactive Hashable, @retroactive Codable {}
+extension test_component.DateStackOption: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.FolderDepth {
     public static var shallow : test_component.FolderDepth {
@@ -609,7 +609,7 @@ extension test_component.FolderDepth {
         __x_ABI_CWindows_CStorage_CSearch_CFolderDepth_Deep
     }
 }
-extension test_component.FolderDepth: @retroactive Hashable, @retroactive Codable {}
+extension test_component.FolderDepth: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.IndexedState {
     public static var unknown : test_component.IndexedState {
@@ -625,7 +625,7 @@ extension test_component.IndexedState {
         __x_ABI_CWindows_CStorage_CSearch_CIndexedState_FullyIndexed
     }
 }
-extension test_component.IndexedState: @retroactive Hashable, @retroactive Codable {}
+extension test_component.IndexedState: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.IndexerOption {
     public static var useIndexerWhenAvailable : test_component.IndexerOption {
@@ -641,5 +641,5 @@ extension test_component.IndexerOption {
         __x_ABI_CWindows_CStorage_CSearch_CIndexerOption_OnlyUseIndexerAndOptimizeForIndexedProperties
     }
 }
-extension test_component.IndexerOption: @retroactive Hashable, @retroactive Codable {}
+extension test_component.IndexerOption: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams.swift
@@ -284,7 +284,7 @@ extension test_component.InputStreamOptions {
         __x_ABI_CWindows_CStorage_CStreams_CInputStreamOptions_ReadAhead
     }
 }
-extension test_component.InputStreamOptions: @retroactive Hashable, @retroactive Codable {}
+extension test_component.InputStreamOptions: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.UnicodeEncoding {
     public static var utf8 : test_component.UnicodeEncoding {
@@ -297,5 +297,5 @@ extension test_component.UnicodeEncoding {
         __x_ABI_CWindows_CStorage_CStreams_CUnicodeEncoding_Utf16BE
     }
 }
-extension test_component.UnicodeEncoding: @retroactive Hashable, @retroactive Codable {}
+extension test_component.UnicodeEncoding: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 

--- a/tests/test_component/Sources/test_component/Windows.Storage.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.swift
@@ -1291,7 +1291,7 @@ extension test_component.CreationCollisionOption {
         __x_ABI_CWindows_CStorage_CCreationCollisionOption_OpenIfExists
     }
 }
-extension test_component.CreationCollisionOption: @retroactive Hashable, @retroactive Codable {}
+extension test_component.CreationCollisionOption: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.FileAccessMode {
     public static var read : test_component.FileAccessMode {
@@ -1301,7 +1301,7 @@ extension test_component.FileAccessMode {
         __x_ABI_CWindows_CStorage_CFileAccessMode_ReadWrite
     }
 }
-extension test_component.FileAccessMode: @retroactive Hashable, @retroactive Codable {}
+extension test_component.FileAccessMode: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.FileAttributes {
     public static var normal : test_component.FileAttributes {
@@ -1323,7 +1323,7 @@ extension test_component.FileAttributes {
         __x_ABI_CWindows_CStorage_CFileAttributes_LocallyIncomplete
     }
 }
-extension test_component.FileAttributes: @retroactive Hashable, @retroactive Codable {}
+extension test_component.FileAttributes: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.NameCollisionOption {
     public static var generateUniqueName : test_component.NameCollisionOption {
@@ -1336,7 +1336,7 @@ extension test_component.NameCollisionOption {
         __x_ABI_CWindows_CStorage_CNameCollisionOption_FailIfExists
     }
 }
-extension test_component.NameCollisionOption: @retroactive Hashable, @retroactive Codable {}
+extension test_component.NameCollisionOption: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.StorageDeleteOption {
     public static var `default` : test_component.StorageDeleteOption {
@@ -1346,7 +1346,7 @@ extension test_component.StorageDeleteOption {
         __x_ABI_CWindows_CStorage_CStorageDeleteOption_PermanentDelete
     }
 }
-extension test_component.StorageDeleteOption: @retroactive Hashable, @retroactive Codable {}
+extension test_component.StorageDeleteOption: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.StorageItemTypes {
     public static var none : test_component.StorageItemTypes {
@@ -1359,7 +1359,7 @@ extension test_component.StorageItemTypes {
         __x_ABI_CWindows_CStorage_CStorageItemTypes_Folder
     }
 }
-extension test_component.StorageItemTypes: @retroactive Hashable, @retroactive Codable {}
+extension test_component.StorageItemTypes: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.StorageLibraryChangeType {
     public static var created : test_component.StorageLibraryChangeType {
@@ -1393,7 +1393,7 @@ extension test_component.StorageLibraryChangeType {
         __x_ABI_CWindows_CStorage_CStorageLibraryChangeType_ChangeTrackingLost
     }
 }
-extension test_component.StorageLibraryChangeType: @retroactive Hashable, @retroactive Codable {}
+extension test_component.StorageLibraryChangeType: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.StorageOpenOptions {
     public static var none : test_component.StorageOpenOptions {
@@ -1406,7 +1406,7 @@ extension test_component.StorageOpenOptions {
         __x_ABI_CWindows_CStorage_CStorageOpenOptions_AllowReadersAndWriters
     }
 }
-extension test_component.StorageOpenOptions: @retroactive Hashable, @retroactive Codable {}
+extension test_component.StorageOpenOptions: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.StreamedFileFailureMode {
     public static var failed : test_component.StreamedFileFailureMode {
@@ -1419,5 +1419,5 @@ extension test_component.StreamedFileFailureMode {
         __x_ABI_CWindows_CStorage_CStreamedFileFailureMode_Incomplete
     }
 }
-extension test_component.StreamedFileFailureMode: @retroactive Hashable, @retroactive Codable {}
+extension test_component.StreamedFileFailureMode: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -1982,7 +1982,7 @@ extension test_component.Fruit {
         __x_ABI_Ctest__component_CFruit_Pineapple
     }
 }
-extension test_component.Fruit: @retroactive Hashable, @retroactive Codable {}
+extension test_component.Fruit: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.Keywords {
     public static var `as` : test_component.Keywords {
@@ -2112,7 +2112,7 @@ extension test_component.Keywords {
         __x_ABI_Ctest__component_CKeywords_While
     }
 }
-extension test_component.Keywords: @retroactive Hashable, @retroactive Codable {}
+extension test_component.Keywords: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.Signed {
     public static var first : test_component.Signed {
@@ -2125,7 +2125,7 @@ extension test_component.Signed {
         __x_ABI_Ctest__component_CSigned_Third
     }
 }
-extension test_component.Signed: @retroactive Hashable, @retroactive Codable {}
+extension test_component.Signed: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.SwiftifiableNames {
     public static var camelCase : test_component.SwiftifiableNames {
@@ -2147,7 +2147,7 @@ extension test_component.SwiftifiableNames {
         __x_ABI_Ctest__component_CSwiftifiableNames_UUID
     }
 }
-extension test_component.SwiftifiableNames: @retroactive Hashable, @retroactive Codable {}
+extension test_component.SwiftifiableNames: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 
 extension test_component.Unsigned {
     public static var first : test_component.Unsigned {
@@ -2160,5 +2160,5 @@ extension test_component.Unsigned {
         __x_ABI_Ctest__component_CUnsigned_Third
     }
 }
-extension test_component.Unsigned: @retroactive Hashable, @retroactive Codable {}
+extension test_component.Unsigned: @retroactive Hashable, @retroactive Codable, @retroactive Sendable {}
 


### PR DESCRIPTION
WinRT enums are integers in disguise and projected as typealiases for C enums, so they are always Sendable.