### PR TITLE
Swap order of _inner and identity cleanup

### DIFF
--- a/.github/actions/windows-build/action.yml
+++ b/.github/actions/windows-build/action.yml
@@ -15,7 +15,7 @@ runs:
       arch: amd64
 
   - name: Install private Swift toolchain
-    uses: compnerd/gha-setup-swift@main
+    uses: compnerd/gha-setup-swift@81f383b35a86e6e966de139be25b451d4f7dd953
     with:
       github-repo: thebrowsercompany/swift-build
       github-token: ${{ inputs.GITHUB_TOKEN }}

--- a/swiftwinrt/Resources/Support/WinRTProtocols.swift
+++ b/swiftwinrt/Resources/Support/WinRTProtocols.swift
@@ -43,10 +43,10 @@ open class WinRTClass : CustomQueryInterface, Equatable {
     }
 
     deinit {
-      // ensure we release the identity pointer before releasing _inner. releasing the _inner
+      // ensure we release the _inner pointer before releasing identity. releasing the _inner
       // cleans up the underlying COM object.
-      identity = nil
       _inner = nil
+      identity = nil
     }
 }
 

--- a/swiftwinrt/Resources/Support/WinRTProtocols.swift
+++ b/swiftwinrt/Resources/Support/WinRTProtocols.swift
@@ -44,7 +44,8 @@ open class WinRTClass : CustomQueryInterface, Equatable {
 
     deinit {
       // ensure we release the _inner pointer before releasing identity. releasing the _inner
-      // cleans up the underlying COM object.
+      // cleans up the underlying COM object, which might be holding a reference to the identity pointer.
+
       _inner = nil
       identity = nil
     }


### PR DESCRIPTION
We have seen a couple of instances of what looks like overrelease/memory corruption when subclassing across the WinRT bridge. It seems like swapping the order of the deinitialization here has an effect. I don't totally understand the model here so cc @stevenbrix to help explain