### PR TITLE
Pin gha-setup-vsdevenv

### DIFF
--- a/.github/actions/windows-build/action.yml
+++ b/.github/actions/windows-build/action.yml
@@ -10,7 +10,7 @@ runs:
 
   steps:
   - name: Configure VC++ build for amd64
-    uses: compnerd/gha-setup-vsdevenv@main
+    uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557
     with:
       arch: amd64
 


### PR DESCRIPTION
The action `compnerd/gha-setup-swift` was modified to skip calling `compnerd/gha-setup-vsdevenv` internally when swift is newer than 5.9, because this previously only done as part of a workaround where the swift compiler's module maps could not be located.  This is problematic because the latter sets environment variables necessary for the build, including PATH.

These actions were both pinned to `main` resulting in incompatible versions being used. They're now both pinned to the explicit commits on main (at the time of writing). 