### PR TITLE
Remove environment override in CMakePresets

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -18,10 +18,7 @@
                 "CMAKE_SYSTEM_VERSION": "10.0.17763.0",
                 "CMAKE_MODULE_PATH": "${sourceDir}/cmake",
                 "CMAKE_SKIP_INSTALL_ALL_DEPENDENCY": true
-            },
-          "environment": {
-            "PATH": "$penv{DevEnvDir}\\CommonExtensions\\Microsoft\\CMake\\Ninja;$penv{PATH}"
-          }
+            }
         },
         {
             "name": "debug",


### PR DESCRIPTION
Fixes the release CI workflow: https://github.com/thebrowsercompany/swift-winrt/actions/runs/9484234880/job/26133258865

It looks like there was a change/regression in CMake's handling of the `$penv{PATH}` expression, but in any case modifying the path is not necessary because the vs dev environment already includes the path to ninja.exe. We do not need this code for other CMake repos either.