### PR TITLE
capture the language exception

### DIFF
--- a/swiftwinrt/Resources/Support/Error.swift
+++ b/swiftwinrt/Resources/Support/Error.swift
@@ -167,7 +167,7 @@ public struct Error : Swift.Error, CustomStringConvertible {
     self.description = getErrorDescription(expecting: hr) ?? hrToString(hr)
     self.hr = hr
   }
-}
+}   
 
 public func failWith(hr: HRESULT) -> HRESULT {
   return hr
@@ -175,7 +175,7 @@ public func failWith(hr: HRESULT) -> HRESULT {
 
 public func failWith(error: Swift.Error) -> HRESULT {
     var hresult: HRESULT = E_FAIL
-    let message = error.description
+    let message = error.localizedDescription
     if let winrtError = error as? Error {
         hresult = winrtError.hr
     }

--- a/swiftwinrt/Resources/Support/Error.swift
+++ b/swiftwinrt/Resources/Support/Error.swift
@@ -169,6 +169,24 @@ public struct Error : Swift.Error, CustomStringConvertible {
   }
 }
 
-public func failWith(err: HRESULT) -> HRESULT {
-  return err
+public func failWith(hr: HRESULT) -> HRESULT {
+  return hr
+}
+
+public func failWith(error: Swift.Error) -> HRESULT {
+    var hresult: HRESULT = E_FAIL
+    let message = error.description
+    if let winrtError = error as? Error {
+        hresult = winrtError.hr
+    }
+
+    do {
+        try message.withHStringRef {
+            _ = RoOriginateLanguageException(hresult, $0, nil)
+        }
+    } catch {
+        _ = RoOriginateLanguageException(hresult, nil, nil)
+    }
+
+    return hresult
 }

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -2780,7 +2780,7 @@ override % func _getABI<T>() -> UnsafeMutablePointer<T>? {
 
     static void write_not_implementable_vtable_method(writer& w, function_def const& sig)
     {
-        w.write("%: { _, % in return failWith(err: E_NOTIMPL) }", get_abi_name(sig), bind([&](writer& w) {
+        w.write("%: { _, % in return failWith(hr: E_NOTIMPL) }", get_abi_name(sig), bind([&](writer& w) {
             separator s{ w };
             for (auto& param : sig.params)
             {
@@ -2877,7 +2877,7 @@ override % func _getABI<T>() -> UnsafeMutablePointer<T>? {
             w.write("return S_OK\n");
         }
         if (needs_try_catch) {
-            w.write("} catch { return failWith(err: E_FAIL) } \n");
+            w.write("} catch { return failWith(error: error) } \n");
             w.m_indent -= 1;
         }
         w.write("}");

--- a/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
@@ -189,7 +189,7 @@ public enum __ABI_Windows_Foundation {
                 guard let __unwrapped__instance = IAsyncActionWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.getResults()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -289,7 +289,7 @@ public enum __ABI_Windows_Foundation {
                 guard let __unwrapped__instance = IAsyncInfoWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.cancel()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         Close: {
@@ -297,7 +297,7 @@ public enum __ABI_Windows_Foundation {
                 guard let __unwrapped__instance = IAsyncInfoWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.close()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -346,7 +346,7 @@ public enum __ABI_Windows_Foundation {
                 guard let __unwrapped__instance = IClosableWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.close()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -428,7 +428,7 @@ public enum __ABI_Windows_Foundation {
                 let referenceWrapper = __ABI_Windows_Foundation.IMemoryBufferReferenceWrapper(reference)
                 referenceWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -743,7 +743,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getUInt8()
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetInt16: {
@@ -752,7 +752,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getInt16()
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetUInt16: {
@@ -761,7 +761,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getUInt16()
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetInt32: {
@@ -770,7 +770,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getInt32()
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetUInt32: {
@@ -779,7 +779,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getUInt32()
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetInt64: {
@@ -788,7 +788,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getInt64()
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetUInt64: {
@@ -797,7 +797,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getUInt64()
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetSingle: {
@@ -806,7 +806,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getSingle()
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetDouble: {
@@ -815,7 +815,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getDouble()
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetChar16: {
@@ -824,7 +824,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getChar16()
                 $1?.initialize(to: .init(from: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetBoolean: {
@@ -833,7 +833,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getBoolean()
                 $1?.initialize(to: .init(from: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetString: {
@@ -842,7 +842,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getString()
                 $1?.initialize(to: try! HString(value).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetGuid: {
@@ -851,7 +851,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getGuid()
                 $1?.initialize(to: .init(from: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetDateTime: {
@@ -860,7 +860,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getDateTime()
                 $1?.initialize(to: .from(swift: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetTimeSpan: {
@@ -869,7 +869,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getTimeSpan()
                 $1?.initialize(to: .from(swift: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetPoint: {
@@ -878,7 +878,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getPoint()
                 $1?.initialize(to: .from(swift: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetSize: {
@@ -887,7 +887,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getSize()
                 $1?.initialize(to: .from(swift: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetRect: {
@@ -896,46 +896,46 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.getRect()
                 $1?.initialize(to: .from(swift: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
-        GetUInt8Array: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetUInt8Array: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetInt16Array: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetInt16Array: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetUInt16Array: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetUInt16Array: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetInt32Array: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetInt32Array: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetUInt32Array: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetUInt32Array: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetInt64Array: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetInt64Array: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetUInt64Array: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetUInt64Array: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetSingleArray: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetSingleArray: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetDoubleArray: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetDoubleArray: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetChar16Array: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetChar16Array: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetBooleanArray: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetBooleanArray: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetStringArray: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetStringArray: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetInspectableArray: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetInspectableArray: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetGuidArray: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetGuidArray: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetDateTimeArray: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetDateTimeArray: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetTimeSpanArray: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetTimeSpanArray: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetPointArray: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetPointArray: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetSizeArray: { _, _, _ in return failWith(err: E_NOTIMPL) },
+        GetSizeArray: { _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-        GetRectArray: { _, _, _ in return failWith(err: E_NOTIMPL) }
+        GetRectArray: { _, _, _ in return failWith(hr: E_NOTIMPL) }
     )
 
     public typealias IPropertyValueWrapper = InterfaceWrapperBase<__IMPL_Windows_Foundation.IPropertyValueBridge>
@@ -986,7 +986,7 @@ public enum __ABI_Windows_Foundation {
                 let value = try __unwrapped__instance.toString()
                 $1?.initialize(to: try! HString(value).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -1353,7 +1353,7 @@ extension __ABI_Windows_Foundation {
                 let asyncStatus: test_component.AsyncStatus = $2
                 try __unwrapped__instance(asyncInfo, asyncStatus)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 }
@@ -1388,7 +1388,7 @@ extension __ABI_Windows_Foundation {
                 guard let __unwrapped__instance = DeferralCompletedHandlerWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 }

--- a/tests/test_component/Sources/test_component/Windows.Storage+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage+ABI.swift
@@ -435,7 +435,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         OpenTransactedWriteAsync: {
@@ -445,7 +445,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CopyOverloadDefaultNameAndOptions: {
@@ -456,7 +456,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CopyOverloadDefaultOptions: {
@@ -468,7 +468,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(operation)
                 operationWrapper?.copyTo($3)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CopyOverload: {
@@ -481,7 +481,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(operation)
                 operationWrapper?.copyTo($4)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CopyAndReplaceAsync: {
@@ -492,7 +492,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         MoveOverloadDefaultNameAndOptions: {
@@ -503,7 +503,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         MoveOverloadDefaultOptions: {
@@ -515,7 +515,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(operation)
                 operationWrapper?.copyTo($3)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         MoveOverload: {
@@ -528,7 +528,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(operation)
                 operationWrapper?.copyTo($4)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         MoveAndReplaceAsync: {
@@ -539,7 +539,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -604,7 +604,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper(operation)
                 operationWrapper?.copyTo($3)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         OpenTransactedWriteWithOptionsAsync: {
@@ -615,7 +615,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -887,7 +887,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CreateFileAsync: {
@@ -899,7 +899,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(operation)
                 operationWrapper?.copyTo($3)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CreateFolderAsyncOverloadDefaultOptions: {
@@ -910,7 +910,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CreateFolderAsync: {
@@ -922,7 +922,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(operation)
                 operationWrapper?.copyTo($3)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetFileAsync: {
@@ -933,7 +933,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetFolderAsync: {
@@ -944,7 +944,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetItemAsync: {
@@ -955,7 +955,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetFilesAsyncOverloadDefaultOptionsStartAndCount: {
@@ -965,7 +965,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetFoldersAsyncOverloadDefaultOptionsStartAndCount: {
@@ -975,7 +975,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetItemsAsyncOverloadDefaultStartAndCount: {
@@ -985,7 +985,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -1041,7 +1041,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -1203,7 +1203,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         RenameAsync: {
@@ -1215,7 +1215,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(operation)
                 operationWrapper?.copyTo($3)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         DeleteAsyncOverloadDefaultOptions: {
@@ -1225,7 +1225,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         DeleteAsync: {
@@ -1236,7 +1236,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetBasicPropertiesAsync: {
@@ -1246,7 +1246,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         get_Name: {
@@ -1284,7 +1284,7 @@ public enum __ABI_Windows_Storage {
                 let value = try __unwrapped__instance.isOfType(type)
                 $2?.initialize(to: .init(from: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -1349,7 +1349,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         IsEqual: {
@@ -1359,7 +1359,7 @@ public enum __ABI_Windows_Storage {
                 let value = try __unwrapped__instance.isEqual(item)
                 $2?.initialize(to: .init(from: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -1465,7 +1465,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetThumbnailAsyncOverloadDefaultOptions: {
@@ -1477,7 +1477,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper(operation)
                 operationWrapper?.copyTo($3)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetThumbnailAsync: {
@@ -1490,7 +1490,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper(operation)
                 operationWrapper?.copyTo($4)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         get_DisplayName: {
@@ -1592,7 +1592,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetScaledImageAsThumbnailAsyncOverloadDefaultOptions: {
@@ -1604,7 +1604,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper(operation)
                 operationWrapper?.copyTo($3)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetScaledImageAsThumbnailAsync: {
@@ -1617,7 +1617,7 @@ public enum __ABI_Windows_Storage {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper(operation)
                 operationWrapper?.copyTo($4)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -1873,7 +1873,7 @@ public enum __ABI_Windows_Storage {
                 let failureMode: test_component.StreamedFileFailureMode = $1
                 try __unwrapped__instance.failAndClose(failureMode)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -1904,7 +1904,7 @@ extension __ABI_Windows_Storage {
                 let stream: test_component.StreamedFileDataRequest? = .from(abi: ComPtr($1))
                 try __unwrapped__instance(stream)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 }

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+ABI.swift
@@ -567,7 +567,7 @@ public enum __ABI_Windows_Storage_FileProperties {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         SavePropertiesAsync: {
@@ -578,7 +578,7 @@ public enum __ABI_Windows_Storage_FileProperties {
                 let operationWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         SavePropertiesAsyncOverloadDefault: {
@@ -588,7 +588,7 @@ public enum __ABI_Windows_Storage_FileProperties {
                 let operationWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search+ABI.swift
@@ -447,7 +447,7 @@ public enum __ABI_Windows_Storage_Search {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CreateFileQueryOverloadDefault: {
@@ -456,7 +456,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.createFileQuery()
                 value?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CreateFileQuery: {
@@ -466,7 +466,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.createFileQuery(query)
                 value?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CreateFileQueryWithOptions: {
@@ -476,7 +476,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.createFileQueryWithOptions(queryOptions)
                 value?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CreateFolderQueryOverloadDefault: {
@@ -485,7 +485,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.createFolderQuery()
                 value?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CreateFolderQuery: {
@@ -495,7 +495,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.createFolderQuery(query)
                 value?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CreateFolderQueryWithOptions: {
@@ -505,7 +505,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.createFolderQueryWithOptions(queryOptions)
                 value?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CreateItemQuery: {
@@ -514,7 +514,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.createItemQuery()
                 value?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CreateItemQueryWithOptions: {
@@ -524,7 +524,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.createItemQueryWithOptions(queryOptions)
                 value?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetFilesAsync: {
@@ -537,7 +537,7 @@ public enum __ABI_Windows_Storage_Search {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(operation)
                 operationWrapper?.copyTo($4)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetFilesAsyncOverloadDefaultStartAndCount: {
@@ -548,7 +548,7 @@ public enum __ABI_Windows_Storage_Search {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetFoldersAsync: {
@@ -561,7 +561,7 @@ public enum __ABI_Windows_Storage_Search {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(operation)
                 operationWrapper?.copyTo($4)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetFoldersAsyncOverloadDefaultStartAndCount: {
@@ -572,7 +572,7 @@ public enum __ABI_Windows_Storage_Search {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetItemsAsync: {
@@ -584,7 +584,7 @@ public enum __ABI_Windows_Storage_Search {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(operation)
                 operationWrapper?.copyTo($3)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         AreQueryOptionsSupported: {
@@ -594,7 +594,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.areQueryOptionsSupported(queryOptions)
                 $2?.initialize(to: .init(from: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         IsCommonFolderQuerySupported: {
@@ -604,7 +604,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.isCommonFolderQuerySupported(query)
                 $2?.initialize(to: .init(from: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         IsCommonFileQuerySupported: {
@@ -614,7 +614,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.isCommonFileQuerySupported(query)
                 $2?.initialize(to: .init(from: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -781,7 +781,7 @@ public enum __ABI_Windows_Storage_Search {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1_UINT32Wrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         get_Folder: {
@@ -829,7 +829,7 @@ public enum __ABI_Windows_Storage_Search {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1_UINT32Wrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetCurrentQueryOptions: {
@@ -838,7 +838,7 @@ public enum __ABI_Windows_Storage_Search {
                 let value = try __unwrapped__instance.getCurrentQueryOptions()
                 value?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         ApplyNewQueryOptions: {
@@ -847,7 +847,7 @@ public enum __ABI_Windows_Storage_Search {
                 let newQueryOptions: test_component.QueryOptions? = .from(abi: ComPtr($1))
                 try __unwrapped__instance.applyNewQueryOptions(newQueryOptions)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams+ABI.swift
@@ -269,7 +269,7 @@ public enum __ABI_Windows_Storage_Streams {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper(operation)
                 operationWrapper?.copyTo($4)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -323,7 +323,7 @@ public enum __ABI_Windows_Storage_Streams {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -390,7 +390,7 @@ public enum __ABI_Windows_Storage_Streams {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Wrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         FlushAsync: {
@@ -400,7 +400,7 @@ public enum __ABI_Windows_Storage_Streams {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1_booleanWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -534,7 +534,7 @@ public enum __ABI_Windows_Storage_Streams {
                 let streamWrapper = __ABI_Windows_Storage_Streams.IInputStreamWrapper(stream)
                 streamWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         GetOutputStreamAt: {
@@ -545,7 +545,7 @@ public enum __ABI_Windows_Storage_Streams {
                 let streamWrapper = __ABI_Windows_Storage_Streams.IOutputStreamWrapper(stream)
                 streamWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         get_Position: {
@@ -561,7 +561,7 @@ public enum __ABI_Windows_Storage_Streams {
                 let position: UInt64 = $1
                 try __unwrapped__instance.seek(position)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CloneStream: {
@@ -571,7 +571,7 @@ public enum __ABI_Windows_Storage_Streams {
                 let streamWrapper = __ABI_Windows_Storage_Streams.IRandomAccessStreamWrapper(stream)
                 streamWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         get_CanRead: {
@@ -639,7 +639,7 @@ public enum __ABI_Windows_Storage_Streams {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeWrapper(operation)
                 operationWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -306,7 +306,7 @@ public enum __ABI_test_component {
                 let operationWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper(operation)
                 operationWrapper?.copyTo($2)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -362,7 +362,7 @@ public enum __ABI_test_component {
                 let result: Int32 = $1
                 try __unwrapped__instance.complete(result)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         CompleteWithError: {
@@ -371,7 +371,7 @@ public enum __ABI_test_component {
                 let errorCode: HRESULT = $1
                 try __unwrapped__instance.completeWithError(errorCode)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -531,7 +531,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IBasicWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.method()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -1405,7 +1405,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inInt32(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         InString: {
@@ -1415,7 +1415,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inString(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         InObject: {
@@ -1425,7 +1425,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inObject(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         InEnum: {
@@ -1435,7 +1435,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.inEnum(value)
                 $2?.initialize(to: try! HString(result).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         OutInt32: {
@@ -1445,7 +1445,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outInt32(&value)
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         OutString: {
@@ -1455,7 +1455,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outString(&value)
                 $1?.initialize(to: try! HString(value).detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         OutObject: {
@@ -1466,7 +1466,7 @@ public enum __ABI_test_component {
                 let valueWrapper = __ABI_.AnyWrapper(value)
                 valueWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         OutBlittableStruct: {
@@ -1476,7 +1476,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outBlittableStruct(&value)
                 $1?.initialize(to: .from(swift: value))
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         OutNonBlittableStruct: {
@@ -1487,7 +1487,7 @@ public enum __ABI_test_component {
                 let _value = __ABI_test_component._ABI_NonBlittableStruct(from: value)
                 	$1?.initialize(to: _value.detach())
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         OutEnum: {
@@ -1497,7 +1497,7 @@ public enum __ABI_test_component {
                 try __unwrapped__instance.outEnum(&value)
                 $1?.initialize(to: value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         ReturnObject: {
@@ -1507,7 +1507,7 @@ public enum __ABI_test_component {
                 let resultWrapper = __ABI_.AnyWrapper(result)
                 resultWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         ReturnEnum: {
@@ -1516,7 +1516,7 @@ public enum __ABI_test_component {
                 let result = try __unwrapped__instance.returnEnum()
                 $1?.initialize(to: result)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         get_EnumProperty: {
@@ -1569,7 +1569,7 @@ public enum __ABI_test_component {
                 let data: String = .init(from: $1)
                 try __unwrapped__instance.fireEvent(data)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -1621,7 +1621,7 @@ public enum __ABI_test_component {
                 let basics: test_component.AnyIObservableVector<test_component.AnyIBasic?>? = test_component.__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.unwrapFrom(abi: ComPtr($1))
                 try __unwrapped__instance.takeObservable(basics)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -1768,7 +1768,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IReferenceTargetWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.method()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -2018,7 +2018,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = ISimpleDelegateWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.doThis()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         DoThat: {
@@ -2027,7 +2027,7 @@ public enum __ABI_test_component {
                 let val: Int32 = $1
                 try __unwrapped__instance.doThat(val)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -2446,7 +2446,7 @@ public enum __ABI_test_component {
                 let resultWrapper = test_component.__x_ABI_C__FIVector_1_GUIDWrapper(result)
                 resultWrapper?.copyTo($1)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -2534,7 +2534,7 @@ public enum __ABI_test_component {
                 let `extension`: String = .init(from: $1)
                 try __unwrapped__instance.`enum`(`extension`)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         },
 
         get_Struct: {
@@ -2571,7 +2571,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = WithKeywordWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.`subscript`()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 
@@ -2674,7 +2674,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IBaseOverridesWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.onDoTheThing()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
     internal typealias IUnsealedDerivedOverridesWrapper = UnsealedWinRTClassWrapper<test_component.UnsealedDerived.IUnsealedDerivedOverrides>
@@ -2712,7 +2712,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IUnsealedDerivedOverridesWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.onBeforeDoTheThing()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
     internal typealias IUnsealedDerivedOverloads2Wrapper = UnsealedWinRTClassWrapper<test_component.UnsealedDerived.IUnsealedDerivedOverloads2>
@@ -2751,7 +2751,7 @@ public enum __ABI_test_component {
                 guard let __unwrapped__instance = IUnsealedDerivedOverloads2Wrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance.onAfterDoTheThing()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 }
@@ -2815,7 +2815,7 @@ extension __ABI_test_component {
                 let item: Any? = __ABI_.AnyWrapper.unwrapFrom(abi: ComPtr($1))
                 try __unwrapped__instance(item)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 }
@@ -2850,7 +2850,7 @@ extension __ABI_test_component {
                 guard let __unwrapped__instance = VoidToVoidDelegateWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 }

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -25,7 +25,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanVTable: __x_AB
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanBridge>
@@ -78,7 +78,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1_intVTable: __x_ABI_C_
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_intBridge>
@@ -131,7 +131,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGVTable: __x_AB
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGBridge>
@@ -184,7 +184,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32VTable: __x_ABI
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32Bridge>
@@ -237,7 +237,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HS
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectableBridge>
@@ -290,7 +290,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorVi
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
@@ -343,7 +343,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorVi
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
@@ -396,7 +396,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorVi
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
@@ -449,7 +449,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorVi
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge>
@@ -502,7 +502,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRINGBridge>
@@ -555,7 +555,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesBridge>
@@ -608,7 +608,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesBridge>
@@ -661,7 +661,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesBridge>
@@ -714,7 +714,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesBridge>
@@ -767,7 +767,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailBridge>
@@ -820,7 +820,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesBridge>
@@ -873,7 +873,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
@@ -926,7 +926,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateBridge>
@@ -979,7 +979,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
@@ -1032,7 +1032,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
@@ -1085,7 +1085,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionBridge>
@@ -1138,7 +1138,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBufferBridge>
@@ -1191,7 +1191,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamBridge>
@@ -1244,7 +1244,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamBridge>
@@ -1297,7 +1297,7 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeBridge>
@@ -1350,7 +1350,7 @@ internal var __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleVTable: __x_
             let progressInfo: Double = $2
             try __unwrapped__instance(asyncInfo, progressInfo)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleBridge>
@@ -1403,7 +1403,7 @@ internal var __x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32VTable: _
             let progressInfo: UInt32 = $2
             try __unwrapped__instance(asyncInfo, progressInfo)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32Bridge>
@@ -1456,7 +1456,7 @@ internal var __x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CSto
             let progressInfo: UInt32 = $2
             try __unwrapped__instance(asyncInfo, progressInfo)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Bridge>
@@ -1509,7 +1509,7 @@ internal var __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubl
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleBridge>
@@ -1562,7 +1562,7 @@ internal var __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UI
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32Bridge>
@@ -1615,7 +1615,7 @@ internal var __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_C
             let asyncStatus: test_component.AsyncStatus = $2
             try __unwrapped__instance(asyncInfo, asyncStatus)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Bridge>
@@ -3092,7 +3092,7 @@ internal var __x_ABI_C__FIIterator_1_IInspectableVTable: __x_ABI_C__FIIterator_1
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1_IInspectableBridge>
 internal class IIteratorAny: test_component.IInspectable {
@@ -3220,7 +3220,7 @@ internal var __x_ABI_C__FIIterator_1_GUIDVTable: __x_ABI_C__FIIterator_1_GUIDVtb
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1_GUIDWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1_GUIDBridge>
 internal class IIteratorUUID: test_component.IInspectable {
@@ -3347,7 +3347,7 @@ internal var __x_ABI_C__FIIterator_1_HSTRINGVTable: __x_ABI_C__FIIterator_1_HSTR
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1_HSTRINGBridge>
 internal class IIteratorString: test_component.IInspectable {
@@ -3474,7 +3474,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegmen
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge>
 internal class IIteratorTextSegment: test_component.IInspectable {
@@ -3602,7 +3602,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspec
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge>
 internal class IIteratorIKeyValuePairString_Any: test_component.IInspectable {
@@ -3731,7 +3731,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge>
 internal class IIteratorIKeyValuePairString_String: test_component.IInspectable {
@@ -3860,7 +3860,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge>
 internal class IIteratorIKeyValuePairString_IVectorViewTextSegment: test_component.IInspectable {
@@ -3989,7 +3989,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge>
 internal class IIteratorIKeyValuePairString_Base: test_component.IInspectable {
@@ -4118,7 +4118,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrl
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryBridge>
 internal class IIteratorIWwwFormUrlDecoderEntry: test_component.IInspectable {
@@ -4247,7 +4247,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItemVT
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
 internal class IIteratorIStorageItem: test_component.IInspectable {
@@ -4376,7 +4376,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortE
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryBridge>
 internal class IIteratorSortEntry: test_component.IInspectable {
@@ -4503,7 +4503,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFileVTa
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
 internal class IIteratorStorageFile: test_component.IInspectable {
@@ -4631,7 +4631,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolderV
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
 internal class IIteratorStorageFolder: test_component.IInspectable {
@@ -4759,7 +4759,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibrary
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge>
 internal class IIteratorStorageLibraryChange: test_component.IInspectable {
@@ -4887,7 +4887,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseBridge>
 internal class IIteratorBase: test_component.IInspectable {
@@ -5016,7 +5016,7 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicVTable: _
         return S_OK
     },
 
-    GetMany: { _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicBridge>
 internal class IIteratorIBasic: test_component.IInspectable {
@@ -7941,7 +7941,7 @@ internal var __x_ABI_C__FIVectorView_1_IInspectableVTable: __x_ABI_C__FIVectorVi
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1_IInspectableBridge>
 internal class IVectorViewAny: test_component.IInspectable {
@@ -8103,7 +8103,7 @@ internal var __x_ABI_C__FIVectorView_1_GUIDVTable: __x_ABI_C__FIVectorView_1_GUI
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1_GUIDWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1_GUIDBridge>
 internal class IVectorViewUUID: test_component.IInspectable {
@@ -8262,7 +8262,7 @@ internal var __x_ABI_C__FIVectorView_1_HSTRINGVTable: __x_ABI_C__FIVectorView_1_
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1_HSTRINGBridge>
 internal class IVectorViewString: test_component.IInspectable {
@@ -8422,7 +8422,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegm
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge>
 internal class IVectorViewTextSegment: test_component.IInspectable {
@@ -8582,7 +8582,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormU
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryBridge>
 internal class IVectorViewIWwwFormUrlDecoderEntry: test_component.IInspectable {
@@ -8745,7 +8745,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
 internal class IVectorViewIStorageItem: test_component.IInspectable {
@@ -8908,7 +8908,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSor
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryBridge>
 internal class IVectorViewSortEntry: test_component.IInspectable {
@@ -9068,7 +9068,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileV
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
 internal class IVectorViewStorageFile: test_component.IInspectable {
@@ -9228,7 +9228,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolde
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
 internal class IVectorViewStorageFolder: test_component.IInspectable {
@@ -9388,7 +9388,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibra
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge>
 internal class IVectorViewStorageLibraryChange: test_component.IInspectable {
@@ -9548,7 +9548,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseVTable: _
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseBridge>
 internal class IVectorViewBase: test_component.IInspectable {
@@ -9709,7 +9709,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicVTable:
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) }
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicBridge>
 internal class IVectorViewIBasic: test_component.IInspectable {
@@ -9922,9 +9922,9 @@ internal var __x_ABI_C__FIVector_1_IInspectableVTable: __x_ABI_C__FIVector_1_IIn
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) },
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-    ReplaceAll: { _, _, _ in return failWith(err: E_NOTIMPL) }
+    ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1_IInspectableBridge>
 internal class IVectorAny: test_component.IInspectable {
@@ -10231,9 +10231,9 @@ internal var __x_ABI_C__FIVector_1_GUIDVTable: __x_ABI_C__FIVector_1_GUIDVtbl = 
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) },
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-    ReplaceAll: { _, _, _ in return failWith(err: E_NOTIMPL) }
+    ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1_GUIDWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1_GUIDBridge>
 internal class IVectorUUID: test_component.IInspectable {
@@ -10531,9 +10531,9 @@ internal var __x_ABI_C__FIVector_1_HSTRINGVTable: __x_ABI_C__FIVector_1_HSTRINGV
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) },
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-    ReplaceAll: { _, _, _ in return failWith(err: E_NOTIMPL) }
+    ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1_HSTRINGBridge>
 internal class IVectorString: test_component.IInspectable {
@@ -10836,9 +10836,9 @@ internal var __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEnt
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) },
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-    ReplaceAll: { _, _, _ in return failWith(err: E_NOTIMPL) }
+    ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryBridge>
 internal class IVectorSortEntry: test_component.IInspectable {
@@ -11140,9 +11140,9 @@ internal var __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_A
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) },
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-    ReplaceAll: { _, _, _ in return failWith(err: E_NOTIMPL) }
+    ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseBridge>
 internal class IVectorBase: test_component.IInspectable {
@@ -11442,9 +11442,9 @@ internal var __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicVTable: __x
         return S_OK
     },
 
-    GetMany: { _, _, _, _, _ in return failWith(err: E_NOTIMPL) },
+    GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) },
 
-    ReplaceAll: { _, _, _ in return failWith(err: E_NOTIMPL) }
+    ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicBridge>
 internal class IVectorIBasic: test_component.IInspectable {
@@ -11665,7 +11665,7 @@ internal var __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableVTable: __
             let event: test_component.AnyIMapChangedEventArgs<String>? = test_component.__x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper.unwrapFrom(abi: ComPtr($2))
             try __unwrapped__instance(sender, event)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableBridge>
@@ -11720,7 +11720,7 @@ internal var __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGVTable: __x_ABI
             let event: test_component.AnyIMapChangedEventArgs<String>? = test_component.__x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper.unwrapFrom(abi: ComPtr($2))
             try __unwrapped__instance(sender, event)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGBridge>
@@ -11775,7 +11775,7 @@ internal var __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__
             let event: test_component.AnyIVectorChangedEventArgs? = __ABI_Windows_Foundation_Collections.IVectorChangedEventArgsWrapper.unwrapFrom(abi: ComPtr($2))
             try __unwrapped__instance(sender, event)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseBridge>
@@ -11830,7 +11830,7 @@ internal var __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__
             let event: test_component.AnyIVectorChangedEventArgs? = __ABI_Windows_Foundation_Collections.IVectorChangedEventArgsWrapper.unwrapFrom(abi: ComPtr($2))
             try __unwrapped__instance(sender, event)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicBridge>
@@ -11885,7 +11885,7 @@ internal var __x_ABI_C__FIEventHandler_1_IInspectableVTable: __x_ABI_C__FIEventH
             let args: Any? = __ABI_.AnyWrapper.unwrapFrom(abi: ComPtr($2))
             try __unwrapped__instance(sender, args)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIEventHandler_1_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIEventHandler_1_IInspectableBridge>
@@ -11987,7 +11987,7 @@ internal var __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleVTable: __x_ABI
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: result)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleBridge>
@@ -12178,7 +12178,7 @@ internal var __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32VTable: __x_
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: result)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Bridge>
@@ -12370,7 +12370,7 @@ internal var __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorag
             let resultWrapper = __ABI_Windows_Storage_Streams.IBufferWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Bridge>
@@ -12547,7 +12547,7 @@ internal var __x_ABI_C__FIAsyncOperation_1_booleanVTable: __x_ABI_C__FIAsyncOper
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: .init(from: result))
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1_booleanWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1_booleanBridge>
@@ -12699,7 +12699,7 @@ internal var __x_ABI_C__FIAsyncOperation_1_intVTable: __x_ABI_C__FIAsyncOperatio
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: result)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1_intWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1_intBridge>
@@ -12851,7 +12851,7 @@ internal var __x_ABI_C__FIAsyncOperation_1_HSTRINGVTable: __x_ABI_C__FIAsyncOper
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: try! HString(result).detach())
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1_HSTRINGBridge>
@@ -13003,7 +13003,7 @@ internal var __x_ABI_C__FIAsyncOperation_1_UINT32VTable: __x_ABI_C__FIAsyncOpera
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: result)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1_UINT32Bridge>
@@ -13156,7 +13156,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectab
             let resultWrapper = test_component.__x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectableBridge>
@@ -13310,7 +13310,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWi
             let resultWrapper = test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
@@ -13464,7 +13464,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWi
             let resultWrapper = test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
@@ -13618,7 +13618,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWi
             let resultWrapper = test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
@@ -13772,7 +13772,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWi
             let resultWrapper = test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge>
@@ -13926,7 +13926,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGVTable: 
             let resultWrapper = test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGBridge>
@@ -14079,7 +14079,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
             let result = try __unwrapped__instance.getResults()
             result?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesBridge>
@@ -14232,7 +14232,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
             let result = try __unwrapped__instance.getResults()
             result?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesBridge>
@@ -14385,7 +14385,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
             let result = try __unwrapped__instance.getResults()
             result?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesBridge>
@@ -14538,7 +14538,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
             let result = try __unwrapped__instance.getResults()
             result?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesBridge>
@@ -14691,7 +14691,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
             let result = try __unwrapped__instance.getResults()
             result?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailBridge>
@@ -14844,7 +14844,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
             let result = try __unwrapped__instance.getResults()
             result?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesBridge>
@@ -14998,7 +14998,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorage
             let resultWrapper = __ABI_Windows_Storage.IStorageItemWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
@@ -15151,7 +15151,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__
             let result = try __unwrapped__instance.getResults()
             $1?.initialize(to: result)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateBridge>
@@ -15303,7 +15303,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageF
             let result = try __unwrapped__instance.getResults()
             result?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
@@ -15456,7 +15456,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageF
             let result = try __unwrapped__instance.getResults()
             result?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
@@ -15609,7 +15609,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageS
             let result = try __unwrapped__instance.getResults()
             result?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionBridge>
@@ -15763,7 +15763,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams_
             let resultWrapper = __ABI_Windows_Storage_Streams.IBufferWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferBridge>
@@ -15917,7 +15917,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams_
             let resultWrapper = __ABI_Windows_Storage_Streams.IInputStreamWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamBridge>
@@ -16071,7 +16071,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams_
             let resultWrapper = __ABI_Windows_Storage_Streams.IRandomAccessStreamWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamBridge>
@@ -16225,7 +16225,7 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams_
             let resultWrapper = __ABI_Windows_Storage_Streams.IRandomAccessStreamWithContentTypeWrapper(result)
             resultWrapper?.copyTo($1)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeBridge>
@@ -16578,7 +16578,7 @@ internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__CIM
             let args: Any? = __ABI_.AnyWrapper.unwrapFrom(abi: ComPtr($2))
             try __unwrapped__instance(sender, args)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__CIMemoryBufferReference_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__CIMemoryBufferReference_IInspectableBridge>
@@ -16633,7 +16633,7 @@ internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearc
             let args: Any? = __ABI_.AnyWrapper.unwrapFrom(abi: ComPtr($2))
             try __unwrapped__instance(sender, args)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearch__CIStorageQueryResultBase_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearch__CIStorageQueryResultBase_IInspectableBridge>
@@ -16688,7 +16688,7 @@ internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass_
             let args: test_component.DeferrableEventArgs? = .from(abi: ComPtr($2))
             try __unwrapped__instance(sender, args)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsBridge>
@@ -16739,7 +16739,7 @@ internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple
             let args: test_component.SimpleEventArgs = .from(abi: $2)
             try __unwrapped__instance(sender, args)
             return S_OK
-        } catch { return failWith(err: E_FAIL) } 
+        } catch { return failWith(error: error) } 
     }
 )
 typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsBridge>

--- a/tests/test_component/Sources/test_component/test_component.Delegates+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+ABI.swift
@@ -47,7 +47,7 @@ extension __ABI_test_component_Delegates {
                 let value: String = .init(from: $1)
                 try __unwrapped__instance(value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 }
@@ -85,7 +85,7 @@ extension __ABI_test_component_Delegates {
                 let value: Any? = __ABI_.AnyWrapper.unwrapFrom(abi: ComPtr($1))
                 try __unwrapped__instance(value)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 }
@@ -123,7 +123,7 @@ extension __ABI_test_component_Delegates {
                 let result = try __unwrapped__instance()
                 $1?.initialize(to: result)
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 }
@@ -158,7 +158,7 @@ extension __ABI_test_component_Delegates {
                 guard let __unwrapped__instance = SignalDelegateWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
                 try __unwrapped__instance()
                 return S_OK
-            } catch { return failWith(err: E_FAIL) } 
+            } catch { return failWith(error: error) } 
         }
     )
 }


### PR DESCRIPTION
When an `Error` is caught by the projection, it needs to call `RoOriginateLanguageException` to capture the callstack and provide a message for the exception.

There is a lot more we should do to create a more complete experience, for example translating `HRESULT` -> `Error` at the API and caching the `Error` thrown so that we can resurface it in the `Application.unhandledException` callback. 

Right now, this is a first step which will hopefully help Arc get better error information in our traces.

Defaulting to returning `E_FAIL` for generic swift errors, since there are no "well-defined" exceptions in swift, i don't see an elegant way to translate an error to an `HRESULT`