### PR TITLE
make internals public but behind spi

### DIFF
--- a/swiftwinrt/file_writers.h
+++ b/swiftwinrt/file_writers.h
@@ -29,6 +29,10 @@ namespace swiftwinrt
         }
         else if (force)
         {
+            if (ns.starts_with("__"))
+            {
+                w.write("@_spi(WinRTInternal)\n");
+            }
             w.write("%public enum % {\n", i, ns);
             guard.push("}\n");
             i.additional_indentation++;

--- a/tests/test_app/DoubleDelegate+QueryInterface.swift
+++ b/tests/test_app/DoubleDelegate+QueryInterface.swift
@@ -1,5 +1,5 @@
 import Ctest_component
-@_spi(WinRTImplements) import test_component
+@_spi(WinRTImplements) @_spi(WinRTInternal) import test_component
 import Foundation
 
 extension DoubleDelegate {

--- a/tests/test_component/Sources/test_component/Windows.Data.Text+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Data.Text+ABI.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Ctest_component
 
+@_spi(WinRTInternal)
 public enum __ABI_Windows_Data_Text {
 }
 extension __x_ABI_CWindows_CData_CText_CTextSegment {

--- a/tests/test_component/Sources/test_component/Windows.Data.Text+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Data.Text+Impl.swift
@@ -3,5 +3,6 @@
 import Foundation
 import Ctest_component
 
+@_spi(WinRTInternal)
 public enum __IMPL_Windows_Data_Text {
 }

--- a/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
@@ -111,6 +111,7 @@ private var IID___x_ABI_C__FITypedEventHandler_2_TSender_TResult: test_component
     .init(Data1: 0x9DE1C534, Data2: 0x6AE1, Data3: 0x11E0, Data4: ( 0x84,0xE1,0x18,0xA9,0x05,0xBC,0xC5,0x3F ))// 9DE1C534-6AE1-11E0-84E1-18A905BCC53F
 }
 
+@_spi(WinRTInternal)
 public enum __ABI_Windows_Foundation {
     public class IAsyncAction: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIAsyncAction }
@@ -354,7 +355,7 @@ public enum __ABI_Windows_Foundation {
     public class IDeferral: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIDeferral }
 
-        internal func CompleteImpl() throws {
+        public func CompleteImpl() throws {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIDeferral.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Complete(pThis))
             }
@@ -365,7 +366,7 @@ public enum __ABI_Windows_Foundation {
     public class IDeferralFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIDeferralFactory }
 
-        internal func CreateImpl(_ handler: test_component.DeferralCompletedHandler?) throws -> IDeferral {
+        public func CreateImpl(_ handler: test_component.DeferralCompletedHandler?) throws -> IDeferral {
             let (result) = try ComPtrs.initialize { resultAbi in
                 let handlerWrapper = __ABI_Windows_Foundation.DeferralCompletedHandlerWrapper(handler)
                 let _handler = try! handlerWrapper?.toABI { $0 }
@@ -436,7 +437,7 @@ public enum __ABI_Windows_Foundation {
     public class IMemoryBufferFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIMemoryBufferFactory }
 
-        internal func CreateImpl(_ capacity: UInt32) throws -> IMemoryBuffer {
+        public func CreateImpl(_ capacity: UInt32) throws -> IMemoryBuffer {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIMemoryBufferFactory.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Create(pThis, capacity, &valueAbi))
@@ -994,7 +995,7 @@ public enum __ABI_Windows_Foundation {
     public class IUriEscapeStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIUriEscapeStatics }
 
-        internal func UnescapeComponentImpl(_ toUnescape: String) throws -> String {
+        public func UnescapeComponentImpl(_ toUnescape: String) throws -> String {
             var value: HSTRING?
             let _toUnescape = try! HString(toUnescape)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriEscapeStatics.self) { pThis in
@@ -1003,7 +1004,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func EscapeComponentImpl(_ toEscape: String) throws -> String {
+        public func EscapeComponentImpl(_ toEscape: String) throws -> String {
             var value: HSTRING?
             let _toEscape = try! HString(toEscape)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriEscapeStatics.self) { pThis in
@@ -1017,7 +1018,7 @@ public enum __ABI_Windows_Foundation {
     public class IUriRuntimeClass: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIUriRuntimeClass }
 
-        internal func get_AbsoluteUriImpl() throws -> String {
+        public func get_AbsoluteUriImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AbsoluteUri(pThis, &value))
@@ -1025,7 +1026,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_DisplayUriImpl() throws -> String {
+        public func get_DisplayUriImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayUri(pThis, &value))
@@ -1033,7 +1034,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_DomainImpl() throws -> String {
+        public func get_DomainImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Domain(pThis, &value))
@@ -1041,7 +1042,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_ExtensionImpl() throws -> String {
+        public func get_ExtensionImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Extension(pThis, &value))
@@ -1049,7 +1050,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_FragmentImpl() throws -> String {
+        public func get_FragmentImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Fragment(pThis, &value))
@@ -1057,7 +1058,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_HostImpl() throws -> String {
+        public func get_HostImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Host(pThis, &value))
@@ -1065,7 +1066,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_PasswordImpl() throws -> String {
+        public func get_PasswordImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Password(pThis, &value))
@@ -1073,7 +1074,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_PathImpl() throws -> String {
+        public func get_PathImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Path(pThis, &value))
@@ -1081,7 +1082,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_QueryImpl() throws -> String {
+        public func get_QueryImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Query(pThis, &value))
@@ -1089,7 +1090,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_QueryParsedImpl() throws -> test_component.WwwFormUrlDecoder? {
+        public func get_QueryParsedImpl() throws -> test_component.WwwFormUrlDecoder? {
             let (ppWwwFormUrlDecoder) = try ComPtrs.initialize { ppWwwFormUrlDecoderAbi in
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_QueryParsed(pThis, &ppWwwFormUrlDecoderAbi))
@@ -1098,7 +1099,7 @@ public enum __ABI_Windows_Foundation {
             return .from(abi: ppWwwFormUrlDecoder)
         }
 
-        internal func get_RawUriImpl() throws -> String {
+        public func get_RawUriImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_RawUri(pThis, &value))
@@ -1106,7 +1107,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_SchemeNameImpl() throws -> String {
+        public func get_SchemeNameImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_SchemeName(pThis, &value))
@@ -1114,7 +1115,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_UserNameImpl() throws -> String {
+        public func get_UserNameImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_UserName(pThis, &value))
@@ -1122,7 +1123,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_PortImpl() throws -> Int32 {
+        public func get_PortImpl() throws -> Int32 {
             var value: INT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Port(pThis, &value))
@@ -1130,7 +1131,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        internal func get_SuspiciousImpl() throws -> Bool {
+        public func get_SuspiciousImpl() throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Suspicious(pThis, &value))
@@ -1138,7 +1139,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func EqualsImpl(_ pUri: test_component.Uri?) throws -> Bool {
+        public func EqualsImpl(_ pUri: test_component.Uri?) throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Equals(pThis, RawPointer(pUri), &value))
@@ -1146,7 +1147,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func CombineUriImpl(_ relativeUri: String) throws -> test_component.Uri? {
+        public func CombineUriImpl(_ relativeUri: String) throws -> test_component.Uri? {
             let (instance) = try ComPtrs.initialize { instanceAbi in
                 let _relativeUri = try! HString(relativeUri)
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
@@ -1161,7 +1162,7 @@ public enum __ABI_Windows_Foundation {
     public class IUriRuntimeClassFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIUriRuntimeClassFactory }
 
-        internal func CreateUriImpl(_ uri: String) throws -> IUriRuntimeClass {
+        public func CreateUriImpl(_ uri: String) throws -> IUriRuntimeClass {
             let (instance) = try ComPtrs.initialize { instanceAbi in
                 let _uri = try! HString(uri)
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClassFactory.self) { pThis in
@@ -1171,7 +1172,7 @@ public enum __ABI_Windows_Foundation {
             return IUriRuntimeClass(instance!)
         }
 
-        internal func CreateWithRelativeUriImpl(_ baseUri: String, _ relativeUri: String) throws -> IUriRuntimeClass {
+        public func CreateWithRelativeUriImpl(_ baseUri: String, _ relativeUri: String) throws -> IUriRuntimeClass {
             let (instance) = try ComPtrs.initialize { instanceAbi in
                 let _baseUri = try! HString(baseUri)
                 let _relativeUri = try! HString(relativeUri)
@@ -1187,7 +1188,7 @@ public enum __ABI_Windows_Foundation {
     public class IUriRuntimeClassWithAbsoluteCanonicalUri: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIUriRuntimeClassWithAbsoluteCanonicalUri }
 
-        internal func get_AbsoluteCanonicalUriImpl() throws -> String {
+        public func get_AbsoluteCanonicalUriImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClassWithAbsoluteCanonicalUri.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AbsoluteCanonicalUri(pThis, &value))
@@ -1195,7 +1196,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        internal func get_DisplayIriImpl() throws -> String {
+        public func get_DisplayIriImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClassWithAbsoluteCanonicalUri.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayIri(pThis, &value))
@@ -1273,7 +1274,7 @@ public enum __ABI_Windows_Foundation {
     public class IWwwFormUrlDecoderRuntimeClass: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass }
 
-        internal func GetFirstValueByNameImpl(_ name: String) throws -> String {
+        public func GetFirstValueByNameImpl(_ name: String) throws -> String {
             var phstrValue: HSTRING?
             let _name = try! HString(name)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass.self) { pThis in
@@ -1287,7 +1288,7 @@ public enum __ABI_Windows_Foundation {
     public class IWwwFormUrlDecoderRuntimeClassFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClassFactory }
 
-        internal func CreateWwwFormUrlDecoderImpl(_ query: String) throws -> IWwwFormUrlDecoderRuntimeClass {
+        public func CreateWwwFormUrlDecoderImpl(_ query: String) throws -> IWwwFormUrlDecoderRuntimeClass {
             let (instance) = try ComPtrs.initialize { instanceAbi in
                 let _query = try! HString(query)
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClassFactory.self) { pThis in

--- a/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Ctest_component
 
+@_spi(WinRTInternal)
 public enum __IMPL_Windows_Foundation {
     public enum IAsyncActionBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIAsyncAction

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections+ABI.swift
@@ -59,6 +59,7 @@ private var IID___x_ABI_C__FVectorChangedEventHandler_1_T: test_component.IID {
     .init(Data1: 0x0C051752, Data2: 0x9FBF, Data3: 0x4C70, Data4: ( 0xAA,0x0C,0x0E,0x4C,0x82,0xD9,0xA7,0x61 ))// 0C051752-9FBF-4C70-AA0C-0E4C82D9A761
 }
 
+@_spi(WinRTInternal)
 public enum __ABI_Windows_Foundation_Collections {
     public class IPropertySet: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CCollections_CIPropertySet }

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Ctest_component
 
+@_spi(WinRTInternal)
 public enum __IMPL_Windows_Foundation_Collections {
     public enum IPropertySetBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CCollections_CIPropertySet

--- a/tests/test_component/Sources/test_component/Windows.Storage+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage+ABI.swift
@@ -91,11 +91,12 @@ private var IID___x_ABI_CWindows_CStorage_CIStreamedFileDataRequestedHandler: te
     .init(Data1: 0xFEF6A824, Data2: 0x2FE1, Data3: 0x4D07, Data4: ( 0xA3,0x5B,0xB7,0x7C,0x50,0xB5,0xF4,0xCC ))// FEF6A824-2FE1-4D07-A35B-B77C50B5F4CC
 }
 
+@_spi(WinRTInternal)
 public enum __ABI_Windows_Storage {
     public class IPathIOStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIPathIOStatics }
 
-        internal func ReadTextAsyncImpl(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<String>? {
+        public func ReadTextAsyncImpl(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<String>? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIPathIOStatics.self) { pThis in
@@ -105,7 +106,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1_HSTRINGWrapper.unwrapFrom(abi: textOperation)
         }
 
-        internal func ReadTextWithEncodingAsyncImpl(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncOperation<String>? {
+        public func ReadTextWithEncodingAsyncImpl(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncOperation<String>? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIPathIOStatics.self) { pThis in
@@ -115,7 +116,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1_HSTRINGWrapper.unwrapFrom(abi: textOperation)
         }
 
-        internal func WriteTextAsyncImpl(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction? {
+        public func WriteTextAsyncImpl(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let _contents = try! HString(contents)
@@ -126,7 +127,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: textOperation)
         }
 
-        internal func WriteTextWithEncodingAsyncImpl(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
+        public func WriteTextWithEncodingAsyncImpl(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let _contents = try! HString(contents)
@@ -137,7 +138,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: textOperation)
         }
 
-        internal func AppendTextAsyncImpl(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction? {
+        public func AppendTextAsyncImpl(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let _contents = try! HString(contents)
@@ -148,7 +149,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: textOperation)
         }
 
-        internal func AppendTextWithEncodingAsyncImpl(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
+        public func AppendTextWithEncodingAsyncImpl(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let _contents = try! HString(contents)
@@ -159,7 +160,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: textOperation)
         }
 
-        internal func ReadLinesAsyncImpl(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>? {
+        public func ReadLinesAsyncImpl(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>? {
             let (linesOperation) = try ComPtrs.initialize { linesOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIPathIOStatics.self) { pThis in
@@ -169,7 +170,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: linesOperation)
         }
 
-        internal func ReadLinesWithEncodingAsyncImpl(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>? {
+        public func ReadLinesWithEncodingAsyncImpl(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>? {
             let (linesOperation) = try ComPtrs.initialize { linesOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIPathIOStatics.self) { pThis in
@@ -179,7 +180,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: linesOperation)
         }
 
-        internal func WriteLinesAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?) throws -> test_component.AnyIAsyncAction? {
+        public func WriteLinesAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let linesWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(lines)
@@ -191,7 +192,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func WriteLinesWithEncodingAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
+        public func WriteLinesWithEncodingAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let linesWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(lines)
@@ -203,7 +204,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func AppendLinesAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?) throws -> test_component.AnyIAsyncAction? {
+        public func AppendLinesAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let linesWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(lines)
@@ -215,7 +216,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func AppendLinesWithEncodingAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
+        public func AppendLinesWithEncodingAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let linesWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(lines)
@@ -227,7 +228,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func ReadBufferAsyncImpl(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIBuffer?>? {
+        public func ReadBufferAsyncImpl(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIBuffer?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIPathIOStatics.self) { pThis in
@@ -237,7 +238,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func WriteBufferAsyncImpl(_ absolutePath: String, _ buffer: test_component.AnyIBuffer?) throws -> test_component.AnyIAsyncAction? {
+        public func WriteBufferAsyncImpl(_ absolutePath: String, _ buffer: test_component.AnyIBuffer?) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let bufferWrapper = __ABI_Windows_Storage_Streams.IBufferWrapper(buffer)
@@ -673,7 +674,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageFileStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFileStatics }
 
-        internal func GetFileFromPathAsyncImpl(_ path: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func GetFileFromPathAsyncImpl(_ path: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _path = try! HString(path)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFileStatics.self) { pThis in
@@ -683,7 +684,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func GetFileFromApplicationUriAsyncImpl(_ uri: test_component.Uri?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func GetFileFromApplicationUriAsyncImpl(_ uri: test_component.Uri?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFileStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFileFromApplicationUriAsync(pThis, RawPointer(uri), &operationAbi))
@@ -692,7 +693,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func CreateStreamedFileAsyncImpl(_ displayNameWithExtension: String, _ dataRequested: test_component.StreamedFileDataRequestedHandler?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func CreateStreamedFileAsyncImpl(_ displayNameWithExtension: String, _ dataRequested: test_component.StreamedFileDataRequestedHandler?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _displayNameWithExtension = try! HString(displayNameWithExtension)
                 let dataRequestedWrapper = __ABI_Windows_Storage.StreamedFileDataRequestedHandlerWrapper(dataRequested)
@@ -706,7 +707,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func ReplaceWithStreamedFileAsyncImpl(_ fileToReplace: test_component.AnyIStorageFile?, _ dataRequested: test_component.StreamedFileDataRequestedHandler?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func ReplaceWithStreamedFileAsyncImpl(_ fileToReplace: test_component.AnyIStorageFile?, _ dataRequested: test_component.StreamedFileDataRequestedHandler?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let fileToReplaceWrapper = __ABI_Windows_Storage.IStorageFileWrapper(fileToReplace)
                 let _fileToReplace = try! fileToReplaceWrapper?.toABI { $0 }
@@ -721,7 +722,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func CreateStreamedFileFromUriAsyncImpl(_ displayNameWithExtension: String, _ uri: test_component.Uri?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func CreateStreamedFileFromUriAsyncImpl(_ displayNameWithExtension: String, _ uri: test_component.Uri?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _displayNameWithExtension = try! HString(displayNameWithExtension)
                 let thumbnailWrapper = __ABI_Windows_Storage_Streams.IRandomAccessStreamReferenceWrapper(thumbnail)
@@ -733,7 +734,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func ReplaceWithStreamedFileFromUriAsyncImpl(_ fileToReplace: test_component.AnyIStorageFile?, _ uri: test_component.Uri?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func ReplaceWithStreamedFileFromUriAsyncImpl(_ fileToReplace: test_component.AnyIStorageFile?, _ uri: test_component.Uri?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let fileToReplaceWrapper = __ABI_Windows_Storage.IStorageFileWrapper(fileToReplace)
                 let _fileToReplace = try! fileToReplaceWrapper?.toABI { $0 }
@@ -1049,7 +1050,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageFolder3: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFolder3 }
 
-        internal func TryGetChangeTrackerImpl() throws -> test_component.StorageLibraryChangeTracker? {
+        public func TryGetChangeTrackerImpl() throws -> test_component.StorageLibraryChangeTracker? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder3.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.TryGetChangeTracker(pThis, &resultAbi))
@@ -1063,7 +1064,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageFolderStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFolderStatics }
 
-        internal func GetFolderFromPathAsyncImpl(_ path: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
+        public func GetFolderFromPathAsyncImpl(_ path: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _path = try! HString(path)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolderStatics.self) { pThis in
@@ -1677,7 +1678,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageLibraryChange: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageLibraryChange }
 
-        internal func get_ChangeTypeImpl() throws -> test_component.StorageLibraryChangeType {
+        public func get_ChangeTypeImpl() throws -> test_component.StorageLibraryChangeType {
             var value: __x_ABI_CWindows_CStorage_CStorageLibraryChangeType = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ChangeType(pThis, &value))
@@ -1685,7 +1686,7 @@ public enum __ABI_Windows_Storage {
             return value
         }
 
-        internal func get_PathImpl() throws -> String {
+        public func get_PathImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Path(pThis, &value))
@@ -1693,7 +1694,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        internal func get_PreviousPathImpl() throws -> String {
+        public func get_PreviousPathImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_PreviousPath(pThis, &value))
@@ -1701,7 +1702,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        internal func IsOfTypeImpl(_ type: test_component.StorageItemTypes) throws -> Bool {
+        public func IsOfTypeImpl(_ type: test_component.StorageItemTypes) throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.IsOfType(pThis, type, &value))
@@ -1709,7 +1710,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        internal func GetStorageItemAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>? {
+        public func GetStorageItemAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetStorageItemAsync(pThis, &operationAbi))
@@ -1723,7 +1724,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageLibraryChangeReader: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader }
 
-        internal func ReadBatchAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>? {
+        public func ReadBatchAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.ReadBatchAsync(pThis, &operationAbi))
@@ -1732,7 +1733,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func AcceptChangesAsyncImpl() throws -> test_component.AnyIAsyncAction? {
+        public func AcceptChangesAsyncImpl() throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.AcceptChangesAsync(pThis, &operationAbi))
@@ -1746,7 +1747,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageLibraryChangeTracker: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker }
 
-        internal func GetChangeReaderImpl() throws -> test_component.StorageLibraryChangeReader? {
+        public func GetChangeReaderImpl() throws -> test_component.StorageLibraryChangeReader? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetChangeReader(pThis, &valueAbi))
@@ -1755,13 +1756,13 @@ public enum __ABI_Windows_Storage {
             return .from(abi: value)
         }
 
-        internal func EnableImpl() throws {
+        public func EnableImpl() throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Enable(pThis))
             }
         }
 
-        internal func ResetImpl() throws {
+        public func ResetImpl() throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Reset(pThis))
             }
@@ -1772,7 +1773,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageProvider: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageProvider }
 
-        internal func get_IdImpl() throws -> String {
+        public func get_IdImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageProvider.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Id(pThis, &value))
@@ -1780,7 +1781,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        internal func get_DisplayNameImpl() throws -> String {
+        public func get_DisplayNameImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageProvider.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayName(pThis, &value))
@@ -1793,7 +1794,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageProvider2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageProvider2 }
 
-        internal func IsPropertySupportedForPartialFileAsyncImpl(_ propertyCanonicalName: String) throws -> test_component.AnyIAsyncOperation<Bool>? {
+        public func IsPropertySupportedForPartialFileAsyncImpl(_ propertyCanonicalName: String) throws -> test_component.AnyIAsyncOperation<Bool>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _propertyCanonicalName = try! HString(propertyCanonicalName)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageProvider2.self) { pThis in
@@ -1808,7 +1809,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageStreamTransaction: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageStreamTransaction }
 
-        internal func get_StreamImpl() throws -> test_component.AnyIRandomAccessStream? {
+        public func get_StreamImpl() throws -> test_component.AnyIRandomAccessStream? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageStreamTransaction.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Stream(pThis, &valueAbi))
@@ -1817,7 +1818,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Storage_Streams.IRandomAccessStreamWrapper.unwrapFrom(abi: value)
         }
 
-        internal func CommitAsyncImpl() throws -> test_component.AnyIAsyncAction? {
+        public func CommitAsyncImpl() throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageStreamTransaction.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CommitAsync(pThis, &operationAbi))

--- a/tests/test_component/Sources/test_component/Windows.Storage+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage+Impl.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Ctest_component
 
+@_spi(WinRTInternal)
 public enum __IMPL_Windows_Storage {
     public enum IStorageFileBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFile

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+ABI.swift
@@ -35,11 +35,12 @@ private var IID___x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties: tes
     .init(Data1: 0x719AE507, Data2: 0x68DE, Data3: 0x4DB8, Data4: ( 0x97,0xDE,0x49,0x99,0x8C,0x05,0x9F,0x2F ))// 719AE507-68DE-4DB8-97DE-49998C059F2F
 }
 
+@_spi(WinRTInternal)
 public enum __ABI_Windows_Storage_FileProperties {
     public class IBasicProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties }
 
-        internal func get_SizeImpl() throws -> UInt64 {
+        public func get_SizeImpl() throws -> UInt64 {
             var value: UINT64 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &value))
@@ -47,7 +48,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func get_DateModifiedImpl() throws -> test_component.DateTime {
+        public func get_DateModifiedImpl() throws -> test_component.DateTime {
             var value: __x_ABI_CWindows_CFoundation_CDateTime = .init()
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DateModified(pThis, &value))
@@ -55,7 +56,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .from(abi: value)
         }
 
-        internal func get_ItemDateImpl() throws -> test_component.DateTime {
+        public func get_ItemDateImpl() throws -> test_component.DateTime {
             var value: __x_ABI_CWindows_CFoundation_CDateTime = .init()
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ItemDate(pThis, &value))
@@ -68,7 +69,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IDocumentProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties }
 
-        internal func get_AuthorImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_AuthorImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Author(pThis, &valueAbi))
@@ -77,7 +78,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_TitleImpl() throws -> String {
+        public func get_TitleImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
@@ -85,14 +86,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_TitleImpl(_ value: String) throws {
+        public func put_TitleImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Title(pThis, _value.get()))
             }
         }
 
-        internal func get_KeywordsImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_KeywordsImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Keywords(pThis, &valueAbi))
@@ -101,7 +102,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_CommentImpl() throws -> String {
+        public func get_CommentImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Comment(pThis, &value))
@@ -109,7 +110,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_CommentImpl(_ value: String) throws {
+        public func put_CommentImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Comment(pThis, _value.get()))
@@ -121,7 +122,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IImageProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties }
 
-        internal func get_RatingImpl() throws -> UInt32 {
+        public func get_RatingImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Rating(pThis, &value))
@@ -129,13 +130,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func put_RatingImpl(_ value: UInt32) throws {
+        public func put_RatingImpl(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Rating(pThis, value))
             }
         }
 
-        internal func get_KeywordsImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_KeywordsImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Keywords(pThis, &valueAbi))
@@ -144,7 +145,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_DateTakenImpl() throws -> test_component.DateTime {
+        public func get_DateTakenImpl() throws -> test_component.DateTime {
             var value: __x_ABI_CWindows_CFoundation_CDateTime = .init()
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DateTaken(pThis, &value))
@@ -152,13 +153,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .from(abi: value)
         }
 
-        internal func put_DateTakenImpl(_ value: test_component.DateTime) throws {
+        public func put_DateTakenImpl(_ value: test_component.DateTime) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_DateTaken(pThis, .from(swift: value)))
             }
         }
 
-        internal func get_WidthImpl() throws -> UInt32 {
+        public func get_WidthImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Width(pThis, &value))
@@ -166,7 +167,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func get_HeightImpl() throws -> UInt32 {
+        public func get_HeightImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Height(pThis, &value))
@@ -174,7 +175,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func get_TitleImpl() throws -> String {
+        public func get_TitleImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
@@ -182,14 +183,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_TitleImpl(_ value: String) throws {
+        public func put_TitleImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Title(pThis, _value.get()))
             }
         }
 
-        internal func get_LatitudeImpl() throws -> Double? {
+        public func get_LatitudeImpl() throws -> Double? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Latitude(pThis, &valueAbi))
@@ -198,7 +199,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIReference_1_doubleWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_LongitudeImpl() throws -> Double? {
+        public func get_LongitudeImpl() throws -> Double? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Longitude(pThis, &valueAbi))
@@ -207,7 +208,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIReference_1_doubleWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_CameraManufacturerImpl() throws -> String {
+        public func get_CameraManufacturerImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_CameraManufacturer(pThis, &value))
@@ -215,14 +216,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_CameraManufacturerImpl(_ value: String) throws {
+        public func put_CameraManufacturerImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_CameraManufacturer(pThis, _value.get()))
             }
         }
 
-        internal func get_CameraModelImpl() throws -> String {
+        public func get_CameraModelImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_CameraModel(pThis, &value))
@@ -230,14 +231,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_CameraModelImpl(_ value: String) throws {
+        public func put_CameraModelImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_CameraModel(pThis, _value.get()))
             }
         }
 
-        internal func get_OrientationImpl() throws -> test_component.PhotoOrientation {
+        public func get_OrientationImpl() throws -> test_component.PhotoOrientation {
             var value: __x_ABI_CWindows_CStorage_CFileProperties_CPhotoOrientation = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Orientation(pThis, &value))
@@ -245,7 +246,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func get_PeopleNamesImpl() throws -> test_component.AnyIVectorView<String>? {
+        public func get_PeopleNamesImpl() throws -> test_component.AnyIVectorView<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_PeopleNames(pThis, &valueAbi))
@@ -259,7 +260,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IMusicProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties }
 
-        internal func get_AlbumImpl() throws -> String {
+        public func get_AlbumImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Album(pThis, &value))
@@ -267,14 +268,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_AlbumImpl(_ value: String) throws {
+        public func put_AlbumImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Album(pThis, _value.get()))
             }
         }
 
-        internal func get_ArtistImpl() throws -> String {
+        public func get_ArtistImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Artist(pThis, &value))
@@ -282,14 +283,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_ArtistImpl(_ value: String) throws {
+        public func put_ArtistImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Artist(pThis, _value.get()))
             }
         }
 
-        internal func get_GenreImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_GenreImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Genre(pThis, &valueAbi))
@@ -298,7 +299,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_TrackNumberImpl() throws -> UInt32 {
+        public func get_TrackNumberImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_TrackNumber(pThis, &value))
@@ -306,13 +307,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func put_TrackNumberImpl(_ value: UInt32) throws {
+        public func put_TrackNumberImpl(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_TrackNumber(pThis, value))
             }
         }
 
-        internal func get_TitleImpl() throws -> String {
+        public func get_TitleImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
@@ -320,14 +321,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_TitleImpl(_ value: String) throws {
+        public func put_TitleImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Title(pThis, _value.get()))
             }
         }
 
-        internal func get_RatingImpl() throws -> UInt32 {
+        public func get_RatingImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Rating(pThis, &value))
@@ -335,13 +336,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func put_RatingImpl(_ value: UInt32) throws {
+        public func put_RatingImpl(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Rating(pThis, value))
             }
         }
 
-        internal func get_DurationImpl() throws -> test_component.TimeSpan {
+        public func get_DurationImpl() throws -> test_component.TimeSpan {
             var value: __x_ABI_CWindows_CFoundation_CTimeSpan = .init()
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Duration(pThis, &value))
@@ -349,7 +350,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .from(abi: value)
         }
 
-        internal func get_BitrateImpl() throws -> UInt32 {
+        public func get_BitrateImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Bitrate(pThis, &value))
@@ -357,7 +358,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func get_AlbumArtistImpl() throws -> String {
+        public func get_AlbumArtistImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AlbumArtist(pThis, &value))
@@ -365,14 +366,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_AlbumArtistImpl(_ value: String) throws {
+        public func put_AlbumArtistImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_AlbumArtist(pThis, _value.get()))
             }
         }
 
-        internal func get_ComposersImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_ComposersImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Composers(pThis, &valueAbi))
@@ -381,7 +382,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_ConductorsImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_ConductorsImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Conductors(pThis, &valueAbi))
@@ -390,7 +391,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_SubtitleImpl() throws -> String {
+        public func get_SubtitleImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Subtitle(pThis, &value))
@@ -398,14 +399,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_SubtitleImpl(_ value: String) throws {
+        public func put_SubtitleImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Subtitle(pThis, _value.get()))
             }
         }
 
-        internal func get_ProducersImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_ProducersImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Producers(pThis, &valueAbi))
@@ -414,7 +415,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_PublisherImpl() throws -> String {
+        public func get_PublisherImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Publisher(pThis, &value))
@@ -422,14 +423,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_PublisherImpl(_ value: String) throws {
+        public func put_PublisherImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Publisher(pThis, _value.get()))
             }
         }
 
-        internal func get_WritersImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_WritersImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Writers(pThis, &valueAbi))
@@ -438,7 +439,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_YearImpl() throws -> UInt32 {
+        public func get_YearImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Year(pThis, &value))
@@ -446,7 +447,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func put_YearImpl(_ value: UInt32) throws {
+        public func put_YearImpl(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Year(pThis, value))
             }
@@ -457,7 +458,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IStorageItemContentProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties }
 
-        internal func GetMusicPropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.MusicProperties?>? {
+        public func GetMusicPropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.MusicProperties?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetMusicPropertiesAsync(pThis, &operationAbi))
@@ -466,7 +467,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func GetVideoPropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.VideoProperties?>? {
+        public func GetVideoPropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.VideoProperties?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetVideoPropertiesAsync(pThis, &operationAbi))
@@ -475,7 +476,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func GetImagePropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.ImageProperties?>? {
+        public func GetImagePropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.ImageProperties?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetImagePropertiesAsync(pThis, &operationAbi))
@@ -484,7 +485,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func GetDocumentPropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.DocumentProperties?>? {
+        public func GetDocumentPropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.DocumentProperties?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetDocumentPropertiesAsync(pThis, &operationAbi))
@@ -596,7 +597,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IThumbnailProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIThumbnailProperties }
 
-        internal func get_OriginalWidthImpl() throws -> UInt32 {
+        public func get_OriginalWidthImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIThumbnailProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_OriginalWidth(pThis, &value))
@@ -604,7 +605,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func get_OriginalHeightImpl() throws -> UInt32 {
+        public func get_OriginalHeightImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIThumbnailProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_OriginalHeight(pThis, &value))
@@ -612,7 +613,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func get_ReturnedSmallerCachedSizeImpl() throws -> Bool {
+        public func get_ReturnedSmallerCachedSizeImpl() throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIThumbnailProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ReturnedSmallerCachedSize(pThis, &value))
@@ -620,7 +621,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func get_TypeImpl() throws -> test_component.ThumbnailType {
+        public func get_TypeImpl() throws -> test_component.ThumbnailType {
             var value: __x_ABI_CWindows_CStorage_CFileProperties_CThumbnailType = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIThumbnailProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Type(pThis, &value))
@@ -633,7 +634,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IVideoProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties }
 
-        internal func get_RatingImpl() throws -> UInt32 {
+        public func get_RatingImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Rating(pThis, &value))
@@ -641,13 +642,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func put_RatingImpl(_ value: UInt32) throws {
+        public func put_RatingImpl(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Rating(pThis, value))
             }
         }
 
-        internal func get_KeywordsImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_KeywordsImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Keywords(pThis, &valueAbi))
@@ -656,7 +657,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_WidthImpl() throws -> UInt32 {
+        public func get_WidthImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Width(pThis, &value))
@@ -664,7 +665,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func get_HeightImpl() throws -> UInt32 {
+        public func get_HeightImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Height(pThis, &value))
@@ -672,7 +673,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func get_DurationImpl() throws -> test_component.TimeSpan {
+        public func get_DurationImpl() throws -> test_component.TimeSpan {
             var value: __x_ABI_CWindows_CFoundation_CTimeSpan = .init()
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Duration(pThis, &value))
@@ -680,7 +681,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .from(abi: value)
         }
 
-        internal func get_LatitudeImpl() throws -> Double? {
+        public func get_LatitudeImpl() throws -> Double? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Latitude(pThis, &valueAbi))
@@ -689,7 +690,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIReference_1_doubleWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_LongitudeImpl() throws -> Double? {
+        public func get_LongitudeImpl() throws -> Double? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Longitude(pThis, &valueAbi))
@@ -698,7 +699,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIReference_1_doubleWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_TitleImpl() throws -> String {
+        public func get_TitleImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
@@ -706,14 +707,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_TitleImpl(_ value: String) throws {
+        public func put_TitleImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Title(pThis, _value.get()))
             }
         }
 
-        internal func get_SubtitleImpl() throws -> String {
+        public func get_SubtitleImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Subtitle(pThis, &value))
@@ -721,14 +722,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_SubtitleImpl(_ value: String) throws {
+        public func put_SubtitleImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Subtitle(pThis, _value.get()))
             }
         }
 
-        internal func get_ProducersImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_ProducersImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Producers(pThis, &valueAbi))
@@ -737,7 +738,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_PublisherImpl() throws -> String {
+        public func get_PublisherImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Publisher(pThis, &value))
@@ -745,14 +746,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        internal func put_PublisherImpl(_ value: String) throws {
+        public func put_PublisherImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Publisher(pThis, _value.get()))
             }
         }
 
-        internal func get_WritersImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_WritersImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Writers(pThis, &valueAbi))
@@ -761,7 +762,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_YearImpl() throws -> UInt32 {
+        public func get_YearImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Year(pThis, &value))
@@ -769,13 +770,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func put_YearImpl(_ value: UInt32) throws {
+        public func put_YearImpl(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Year(pThis, value))
             }
         }
 
-        internal func get_BitrateImpl() throws -> UInt32 {
+        public func get_BitrateImpl() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Bitrate(pThis, &value))
@@ -783,7 +784,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        internal func get_DirectorsImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_DirectorsImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Directors(pThis, &valueAbi))
@@ -792,7 +793,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_OrientationImpl() throws -> test_component.VideoOrientation {
+        public func get_OrientationImpl() throws -> test_component.VideoOrientation {
             var value: __x_ABI_CWindows_CStorage_CFileProperties_CVideoOrientation = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Orientation(pThis, &value))

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+Impl.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Ctest_component
 
+@_spi(WinRTInternal)
 public enum __IMPL_Windows_Storage_FileProperties {
     public enum IStorageItemExtraPropertiesBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemExtraProperties

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search+ABI.swift
@@ -39,11 +39,12 @@ private var IID___x_ABI_CWindows_CStorage_CSearch_CIStorageQueryResultBase: test
     .init(Data1: 0xC297D70D, Data2: 0x7353, Data3: 0x47AB, Data4: ( 0xBA,0x58,0x8C,0x61,0x42,0x5D,0xC5,0x4B ))// C297D70D-7353-47AB-BA58-8C61425DC54B
 }
 
+@_spi(WinRTInternal)
 public enum __ABI_Windows_Storage_Search {
     public class IQueryOptions: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIQueryOptions }
 
-        internal func get_FileTypeFilterImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_FileTypeFilterImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_FileTypeFilter(pThis, &valueAbi))
@@ -52,7 +53,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_FolderDepthImpl() throws -> test_component.FolderDepth {
+        public func get_FolderDepthImpl() throws -> test_component.FolderDepth {
             var value: __x_ABI_CWindows_CStorage_CSearch_CFolderDepth = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_FolderDepth(pThis, &value))
@@ -60,13 +61,13 @@ public enum __ABI_Windows_Storage_Search {
             return value
         }
 
-        internal func put_FolderDepthImpl(_ value: test_component.FolderDepth) throws {
+        public func put_FolderDepthImpl(_ value: test_component.FolderDepth) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_FolderDepth(pThis, value))
             }
         }
 
-        internal func get_ApplicationSearchFilterImpl() throws -> String {
+        public func get_ApplicationSearchFilterImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ApplicationSearchFilter(pThis, &value))
@@ -74,14 +75,14 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        internal func put_ApplicationSearchFilterImpl(_ value: String) throws {
+        public func put_ApplicationSearchFilterImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_ApplicationSearchFilter(pThis, _value.get()))
             }
         }
 
-        internal func get_UserSearchFilterImpl() throws -> String {
+        public func get_UserSearchFilterImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_UserSearchFilter(pThis, &value))
@@ -89,14 +90,14 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        internal func put_UserSearchFilterImpl(_ value: String) throws {
+        public func put_UserSearchFilterImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_UserSearchFilter(pThis, _value.get()))
             }
         }
 
-        internal func get_LanguageImpl() throws -> String {
+        public func get_LanguageImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Language(pThis, &value))
@@ -104,14 +105,14 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        internal func put_LanguageImpl(_ value: String) throws {
+        public func put_LanguageImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Language(pThis, _value.get()))
             }
         }
 
-        internal func get_IndexerOptionImpl() throws -> test_component.IndexerOption {
+        public func get_IndexerOptionImpl() throws -> test_component.IndexerOption {
             var value: __x_ABI_CWindows_CStorage_CSearch_CIndexerOption = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_IndexerOption(pThis, &value))
@@ -119,13 +120,13 @@ public enum __ABI_Windows_Storage_Search {
             return value
         }
 
-        internal func put_IndexerOptionImpl(_ value: test_component.IndexerOption) throws {
+        public func put_IndexerOptionImpl(_ value: test_component.IndexerOption) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_IndexerOption(pThis, value))
             }
         }
 
-        internal func get_SortOrderImpl() throws -> test_component.AnyIVector<test_component.SortEntry>? {
+        public func get_SortOrderImpl() throws -> test_component.AnyIVector<test_component.SortEntry>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_SortOrder(pThis, &valueAbi))
@@ -134,7 +135,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryWrapper.unwrapFrom(abi: value)
         }
 
-        internal func get_GroupPropertyNameImpl() throws -> String {
+        public func get_GroupPropertyNameImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_GroupPropertyName(pThis, &value))
@@ -142,7 +143,7 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        internal func get_DateStackOptionImpl() throws -> test_component.DateStackOption {
+        public func get_DateStackOptionImpl() throws -> test_component.DateStackOption {
             var value: __x_ABI_CWindows_CStorage_CSearch_CDateStackOption = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DateStackOption(pThis, &value))
@@ -150,7 +151,7 @@ public enum __ABI_Windows_Storage_Search {
             return value
         }
 
-        internal func SaveToStringImpl() throws -> String {
+        public func SaveToStringImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.SaveToString(pThis, &value))
@@ -158,20 +159,20 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        internal func LoadFromStringImpl(_ value: String) throws {
+        public func LoadFromStringImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.LoadFromString(pThis, _value.get()))
             }
         }
 
-        internal func SetThumbnailPrefetchImpl(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws {
+        public func SetThumbnailPrefetchImpl(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.SetThumbnailPrefetch(pThis, mode, requestedSize, options))
             }
         }
 
-        internal func SetPropertyPrefetchImpl(_ options: test_component.PropertyPrefetchOptions, _ propertiesToRetrieve: test_component.AnyIIterable<String>?) throws {
+        public func SetPropertyPrefetchImpl(_ options: test_component.PropertyPrefetchOptions, _ propertiesToRetrieve: test_component.AnyIIterable<String>?) throws {
             let propertiesToRetrieveWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(propertiesToRetrieve)
             let _propertiesToRetrieve = try! propertiesToRetrieveWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
@@ -184,7 +185,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IQueryOptionsFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIQueryOptionsFactory }
 
-        internal func CreateCommonFileQueryImpl(_ query: test_component.CommonFileQuery, _ fileTypeFilter: test_component.AnyIIterable<String>?) throws -> IQueryOptions {
+        public func CreateCommonFileQueryImpl(_ query: test_component.CommonFileQuery, _ fileTypeFilter: test_component.AnyIIterable<String>?) throws -> IQueryOptions {
             let (queryOptions) = try ComPtrs.initialize { queryOptionsAbi in
                 let fileTypeFilterWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(fileTypeFilter)
                 let _fileTypeFilter = try! fileTypeFilterWrapper?.toABI { $0 }
@@ -195,7 +196,7 @@ public enum __ABI_Windows_Storage_Search {
             return IQueryOptions(queryOptions!)
         }
 
-        internal func CreateCommonFolderQueryImpl(_ query: test_component.CommonFolderQuery) throws -> IQueryOptions {
+        public func CreateCommonFolderQueryImpl(_ query: test_component.CommonFolderQuery) throws -> IQueryOptions {
             let (queryOptions) = try ComPtrs.initialize { queryOptionsAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptionsFactory.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateCommonFolderQuery(pThis, query, &queryOptionsAbi))
@@ -209,7 +210,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IQueryOptionsWithProviderFilter: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIQueryOptionsWithProviderFilter }
 
-        internal func get_StorageProviderIdFilterImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_StorageProviderIdFilterImpl() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptionsWithProviderFilter.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_StorageProviderIdFilter(pThis, &valueAbi))
@@ -223,7 +224,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IStorageFileQueryResult: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult }
 
-        internal func GetFilesAsyncImpl(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
+        public func GetFilesAsyncImpl(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFilesAsync(pThis, startIndex, maxNumberOfItems, &operationAbi))
@@ -232,7 +233,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func GetFilesAsyncDefaultStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
+        public func GetFilesAsyncDefaultStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFilesAsyncDefaultStartAndCount(pThis, &operationAbi))
@@ -246,7 +247,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IStorageFileQueryResult2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult2 }
 
-        internal func GetMatchingPropertiesWithRangesImpl(_ file: test_component.StorageFile?) throws -> test_component.AnyIMap<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
+        public func GetMatchingPropertiesWithRangesImpl(_ file: test_component.StorageFile?) throws -> test_component.AnyIMap<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult2.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetMatchingPropertiesWithRanges(pThis, RawPointer(file), &resultAbi))
@@ -622,7 +623,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IStorageFolderQueryResult: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult }
 
-        internal func GetFoldersAsyncImpl(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
+        public func GetFoldersAsyncImpl(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFoldersAsync(pThis, startIndex, maxNumberOfItems, &operationAbi))
@@ -631,7 +632,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func GetFoldersAsyncDefaultStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
+        public func GetFoldersAsyncDefaultStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFoldersAsyncDefaultStartAndCount(pThis, &operationAbi))
@@ -645,7 +646,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IStorageItemQueryResult: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult }
 
-        internal func GetItemsAsyncImpl(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
+        public func GetItemsAsyncImpl(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetItemsAsync(pThis, startIndex, maxNumberOfItems, &operationAbi))
@@ -654,7 +655,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func GetItemsAsyncDefaultStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
+        public func GetItemsAsyncDefaultStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetItemsAsyncDefaultStartAndCount(pThis, &operationAbi))

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Ctest_component
 
+@_spi(WinRTInternal)
 public enum __IMPL_Windows_Storage_Search {
     public enum IStorageFolderQueryOperationsBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams+ABI.swift
@@ -43,6 +43,7 @@ private var IID___x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamWithConte
     .init(Data1: 0xCC254827, Data2: 0x4B3D, Data3: 0x438F, Data4: ( 0x92,0x32,0x10,0xC7,0x6B,0xC7,0xE0,0x38 ))// CC254827-4B3D-438F-9232-10C76BC7E038
 }
 
+@_spi(WinRTInternal)
 public enum __ABI_Windows_Storage_Streams {
     public class IBuffer: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIBuffer }
@@ -126,7 +127,7 @@ public enum __ABI_Windows_Storage_Streams {
     public class IBufferFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIBufferFactory }
 
-        internal func CreateImpl(_ capacity: UInt32) throws -> IBuffer {
+        public func CreateImpl(_ capacity: UInt32) throws -> IBuffer {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIBufferFactory.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Create(pThis, capacity, &valueAbi))
@@ -140,7 +141,7 @@ public enum __ABI_Windows_Storage_Streams {
     public class IBufferStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIBufferStatics }
 
-        internal func CreateCopyFromMemoryBufferImpl(_ input: test_component.AnyIMemoryBuffer?) throws -> test_component.Buffer? {
+        public func CreateCopyFromMemoryBufferImpl(_ input: test_component.AnyIMemoryBuffer?) throws -> test_component.Buffer? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let inputWrapper = __ABI_Windows_Foundation.IMemoryBufferWrapper(input)
                 let _input = try! inputWrapper?.toABI { $0 }
@@ -151,7 +152,7 @@ public enum __ABI_Windows_Storage_Streams {
             return .from(abi: value)
         }
 
-        internal func CreateMemoryBufferOverIBufferImpl(_ input: test_component.AnyIBuffer?) throws -> test_component.MemoryBuffer? {
+        public func CreateMemoryBufferOverIBufferImpl(_ input: test_component.AnyIBuffer?) throws -> test_component.MemoryBuffer? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let inputWrapper = __ABI_Windows_Storage_Streams.IBufferWrapper(input)
                 let _input = try! inputWrapper?.toABI { $0 }

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams+Impl.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Ctest_component
 
+@_spi(WinRTInternal)
 public enum __IMPL_Windows_Storage_Streams {
     public enum IBufferBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIBuffer

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -223,11 +223,12 @@ private var IID___x_ABI_Ctest__component_CIVoidToVoidDelegate: test_component.II
     .init(Data1: 0x5ED7E415, Data2: 0x84E7, Data3: 0x5E4C, Data4: ( 0x8F,0x68,0xD4,0x65,0x3C,0x39,0xEE,0x46 ))// 5ED7E415-84E7-5E4C-8F68-D4653C39EE46
 }
 
+@_spi(WinRTInternal)
 public enum __ABI_test_component {
     public class IAsyncMethodsStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIAsyncMethodsStatics }
 
-        internal func GetCompletedAsyncImpl(_ result: Int32) throws -> test_component.AnyIAsyncOperation<Int32>? {
+        public func GetCompletedAsyncImpl(_ result: Int32) throws -> test_component.AnyIAsyncOperation<Int32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethodsStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetCompletedAsync(pThis, result, &operationAbi))
@@ -236,7 +237,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func GetCompletedWithErrorAsyncImpl(_ errorCode: HRESULT) throws -> test_component.AnyIAsyncOperation<Int32>? {
+        public func GetCompletedWithErrorAsyncImpl(_ errorCode: HRESULT) throws -> test_component.AnyIAsyncOperation<Int32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethodsStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetCompletedWithErrorAsync(pThis, errorCode, &operationAbi))
@@ -245,7 +246,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func GetPendingAsyncImpl() throws -> test_component.AsyncOperationInt? {
+        public func GetPendingAsyncImpl() throws -> test_component.AsyncOperationInt? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethodsStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetPendingAsync(pThis, &resultAbi))
@@ -379,7 +380,7 @@ public enum __ABI_test_component {
     public class IBase: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBase }
 
-        internal func DoTheThingImpl() throws {
+        public func DoTheThingImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.DoTheThing(pThis))
             }
@@ -390,7 +391,7 @@ public enum __ABI_test_component {
     public class IBaseCollectionProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseCollectionProtectedFactory }
 
-        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.BaseCollection.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IVectorBase {
+        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.BaseCollection.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IVectorBase {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -413,7 +414,7 @@ public enum __ABI_test_component {
     public class IBaseNoOverridesProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseNoOverridesProtectedFactory }
 
-        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.BaseNoOverrides.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBaseNoOverrides {
+        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.BaseNoOverrides.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBaseNoOverrides {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -431,7 +432,7 @@ public enum __ABI_test_component {
     public class IBaseNoOverridesStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseNoOverridesStatics }
 
-        internal func CreateFromStringImpl(_ value: String) throws -> test_component.BaseNoOverrides? {
+        public func CreateFromStringImpl(_ value: String) throws -> test_component.BaseNoOverrides? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 let _value = try! HString(value)
                 _ = try perform(as: __x_ABI_Ctest__component_CIBaseNoOverridesStatics.self) { pThis in
@@ -446,7 +447,7 @@ public enum __ABI_test_component {
     public class IBaseOverrides: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseOverrides }
 
-        internal func OnDoTheThingImpl() throws {
+        public func OnDoTheThingImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIBaseOverrides.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OnDoTheThing(pThis))
             }
@@ -457,7 +458,7 @@ public enum __ABI_test_component {
     public class IBaseProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseProtectedFactory }
 
-        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.Base.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBase {
+        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.Base.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBase {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -475,7 +476,7 @@ public enum __ABI_test_component {
     public class IBaseStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseStatics }
 
-        internal func CreateFromStringImpl(_ value: String) throws -> test_component.Base? {
+        public func CreateFromStringImpl(_ value: String) throws -> test_component.Base? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 let _value = try! HString(value)
                 _ = try perform(as: __x_ABI_Ctest__component_CIBaseStatics.self) { pThis in
@@ -539,7 +540,7 @@ public enum __ABI_test_component {
     public class IBufferTesterStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBufferTesterStatics }
 
-        internal func GetDataFromImpl(_ buffer: test_component.AnyIBuffer?, _ index: UInt32) throws -> UInt8 {
+        public func GetDataFromImpl(_ buffer: test_component.AnyIBuffer?, _ index: UInt32) throws -> UInt8 {
             var result: UINT8 = 0
             let bufferWrapper = __ABI_Windows_Storage_Streams.IBufferWrapper(buffer)
             let _buffer = try! bufferWrapper?.toABI { $0 }
@@ -554,7 +555,7 @@ public enum __ABI_test_component {
     public class IClass: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIClass }
 
-        internal func get_ImplementationImpl() throws -> test_component.AnyIBasic? {
+        public func get_ImplementationImpl() throws -> test_component.AnyIBasic? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Implementation(pThis, &valueAbi))
@@ -563,7 +564,7 @@ public enum __ABI_test_component {
             return __ABI_test_component.IBasicWrapper.unwrapFrom(abi: value)
         }
 
-        internal func put_ImplementationImpl(_ value: test_component.AnyIBasic?) throws {
+        public func put_ImplementationImpl(_ value: test_component.AnyIBasic?) throws {
             let valueWrapper = __ABI_test_component.IBasicWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
@@ -571,7 +572,7 @@ public enum __ABI_test_component {
             }
         }
 
-        internal func SetDelegateImpl(_ value: test_component.AnyISimpleDelegate?) throws {
+        public func SetDelegateImpl(_ value: test_component.AnyISimpleDelegate?) throws {
             let valueWrapper = __ABI_test_component.ISimpleDelegateWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
@@ -579,7 +580,7 @@ public enum __ABI_test_component {
             }
         }
 
-        internal func GetDelegateImpl() throws -> test_component.AnyISimpleDelegate? {
+        public func GetDelegateImpl() throws -> test_component.AnyISimpleDelegate? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetDelegate(pThis, &resultAbi))
@@ -588,14 +589,14 @@ public enum __ABI_test_component {
             return __ABI_test_component.ISimpleDelegateWrapper.unwrapFrom(abi: result)
         }
 
-        internal func FailImpl(_ message: String) throws {
+        public func FailImpl(_ message: String) throws {
             let _message = try! HString(message)
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Fail(pThis, _message.get()))
             }
         }
 
-        internal func InInt32Impl(_ value: Int32) throws -> String {
+        public func InInt32Impl(_ value: Int32) throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InInt32(pThis, value, &result))
@@ -603,7 +604,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func InStringImpl(_ value: String) throws -> String {
+        public func InStringImpl(_ value: String) throws -> String {
             var result: HSTRING?
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
@@ -612,7 +613,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func InObjectImpl(_ value: Any?) throws -> String {
+        public func InObjectImpl(_ value: Any?) throws -> String {
             var result: HSTRING?
             let valueWrapper = __ABI_.AnyWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -622,7 +623,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func InEnumImpl(_ value: test_component.Signed) throws -> String {
+        public func InEnumImpl(_ value: test_component.Signed) throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InEnum(pThis, value, &result))
@@ -630,13 +631,13 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func OutInt32Impl(_ value: inout Int32) throws {
+        public func OutInt32Impl(_ value: inout Int32) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutInt32(pThis, &value))
             }
         }
 
-        internal func OutStringImpl(_ value: inout String) throws {
+        public func OutStringImpl(_ value: inout String) throws {
             var _value: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutString(pThis, &_value))
@@ -645,7 +646,7 @@ public enum __ABI_test_component {
             WindowsDeleteString(_value)
         }
 
-        internal func OutObjectImpl(_ value: inout Any?) throws {
+        public func OutObjectImpl(_ value: inout Any?) throws {
             let (_value) = try ComPtrs.initialize { (_valueAbi) in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OutObject(pThis, &_valueAbi))
@@ -654,7 +655,7 @@ public enum __ABI_test_component {
             value = __ABI_.AnyWrapper.unwrapFrom(abi: _value)
         }
 
-        internal func OutStringableImpl(_ value: inout test_component.AnyIStringable?) throws {
+        public func OutStringableImpl(_ value: inout test_component.AnyIStringable?) throws {
             let (_value) = try ComPtrs.initialize { (_valueAbi) in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OutStringable(pThis, &_valueAbi))
@@ -663,7 +664,7 @@ public enum __ABI_test_component {
             value = __ABI_Windows_Foundation.IStringableWrapper.unwrapFrom(abi: _value)
         }
 
-        internal func OutBlittableStructImpl(_ value: inout test_component.BlittableStruct) throws {
+        public func OutBlittableStructImpl(_ value: inout test_component.BlittableStruct) throws {
             var _value: __x_ABI_Ctest__component_CBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutBlittableStruct(pThis, &_value))
@@ -671,7 +672,7 @@ public enum __ABI_test_component {
             value = .from(abi: _value)
         }
 
-        internal func OutNonBlittableStructImpl(_ value: inout test_component.NonBlittableStruct) throws {
+        public func OutNonBlittableStructImpl(_ value: inout test_component.NonBlittableStruct) throws {
             let _value: __ABI_test_component._ABI_NonBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutNonBlittableStruct(pThis, &_value.val))
@@ -679,13 +680,13 @@ public enum __ABI_test_component {
             value = .from(abi: _value.val)
         }
 
-        internal func OutEnumImpl(_ value: inout test_component.Signed) throws {
+        public func OutEnumImpl(_ value: inout test_component.Signed) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutEnum(pThis, &value))
             }
         }
 
-        internal func ReturnObjectImpl() throws -> Any? {
+        public func ReturnObjectImpl() throws -> Any? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnObject(pThis, &resultAbi))
@@ -694,7 +695,7 @@ public enum __ABI_test_component {
             return __ABI_.AnyWrapper.unwrapFrom(abi: result)
         }
 
-        internal func ReturnEnumImpl() throws -> test_component.Signed {
+        public func ReturnEnumImpl() throws -> test_component.Signed {
             var result: __x_ABI_Ctest__component_CSigned = .init(0)
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnEnum(pThis, &result))
@@ -702,7 +703,7 @@ public enum __ABI_test_component {
             return result
         }
 
-        internal func ReturnReferenceEnumImpl() throws -> test_component.Signed? {
+        public func ReturnReferenceEnumImpl() throws -> test_component.Signed? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnReferenceEnum(pThis, &resultAbi))
@@ -711,7 +712,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedWrapper.unwrapFrom(abi: result)
         }
 
-        internal func get_EnumPropertyImpl() throws -> test_component.Fruit {
+        public func get_EnumPropertyImpl() throws -> test_component.Fruit {
             var value: __x_ABI_Ctest__component_CFruit = .init(0)
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_EnumProperty(pThis, &value))
@@ -719,19 +720,19 @@ public enum __ABI_test_component {
             return value
         }
 
-        internal func put_EnumPropertyImpl(_ value: test_component.Fruit) throws {
+        public func put_EnumPropertyImpl(_ value: test_component.Fruit) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_EnumProperty(pThis, value))
             }
         }
 
-        internal func NoexceptVoidImpl() throws {
+        public func NoexceptVoidImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.NoexceptVoid(pThis))
             }
         }
 
-        internal func NoexceptInt32Impl() throws -> Int32 {
+        public func NoexceptInt32Impl() throws -> Int32 {
             var result: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.NoexceptInt32(pThis, &result))
@@ -739,7 +740,7 @@ public enum __ABI_test_component {
             return result
         }
 
-        internal func NoexceptStringImpl() throws -> String {
+        public func NoexceptStringImpl() throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.NoexceptString(pThis, &result))
@@ -747,7 +748,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func add_DeferrableEventImpl(_ handler: TypedEventHandler<test_component.Class?, test_component.DeferrableEventArgs?>?) throws -> EventRegistrationToken {
+        public func add_DeferrableEventImpl(_ handler: TypedEventHandler<test_component.Class?, test_component.DeferrableEventArgs?>?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -757,13 +758,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        internal func remove_DeferrableEventImpl(_ token: EventRegistrationToken) throws {
+        public func remove_DeferrableEventImpl(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_DeferrableEvent(pThis, token))
             }
         }
 
-        internal func RaiseDeferrableEventAsyncImpl() throws -> test_component.AnyIAsyncOperation<Int32>? {
+        public func RaiseDeferrableEventAsyncImpl() throws -> test_component.AnyIAsyncOperation<Int32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.RaiseDeferrableEventAsync(pThis, &operationAbi))
@@ -772,7 +773,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func ReturnCharImpl() throws -> Character {
+        public func ReturnCharImpl() throws -> Character {
             var result: WCHAR = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnChar(pThis, &result))
@@ -780,7 +781,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func InCharImpl(_ value: Character) throws -> String {
+        public func InCharImpl(_ value: Character) throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InChar(pThis, .init(from: value), &result))
@@ -788,7 +789,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func OutCharImpl(_ value: inout Character) throws {
+        public func OutCharImpl(_ value: inout Character) throws {
             var _value: WCHAR = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutChar(pThis, &_value))
@@ -796,7 +797,7 @@ public enum __ABI_test_component {
             value = .init(from: _value)
         }
 
-        internal func get_StartValueImpl() throws -> Int32? {
+        public func get_StartValueImpl() throws -> Int32? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_StartValue(pThis, &valueAbi))
@@ -805,7 +806,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIReference_1_intWrapper.unwrapFrom(abi: value)
         }
 
-        internal func put_StartValueImpl(_ value: Int32?) throws {
+        public func put_StartValueImpl(_ value: Int32?) throws {
             let valueWrapper = test_component.__x_ABI_C__FIReference_1_intWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
@@ -813,7 +814,7 @@ public enum __ABI_test_component {
             }
         }
 
-        internal func get_IdImpl() throws -> Foundation.UUID? {
+        public func get_IdImpl() throws -> Foundation.UUID? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Id(pThis, &valueAbi))
@@ -822,7 +823,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIReference_1_GUIDWrapper.unwrapFrom(abi: value)
         }
 
-        internal func put_IdImpl(_ value: Foundation.UUID?) throws {
+        public func put_IdImpl(_ value: Foundation.UUID?) throws {
             let valueWrapper = test_component.__x_ABI_C__FIReference_1_GUIDWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
@@ -830,7 +831,7 @@ public enum __ABI_test_component {
             }
         }
 
-        internal func get_BasePropertyImpl() throws -> test_component.Base? {
+        public func get_BasePropertyImpl() throws -> test_component.Base? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_BaseProperty(pThis, &valueAbi))
@@ -839,13 +840,13 @@ public enum __ABI_test_component {
             return .from(abi: value)
         }
 
-        internal func put_BasePropertyImpl(_ value: test_component.Base?) throws {
+        public func put_BasePropertyImpl(_ value: test_component.Base?) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_BaseProperty(pThis, RawPointer(value)))
             }
         }
 
-        internal func get_BaseNoOverridesPropertyImpl() throws -> test_component.BaseNoOverrides? {
+        public func get_BaseNoOverridesPropertyImpl() throws -> test_component.BaseNoOverrides? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_BaseNoOverridesProperty(pThis, &valueAbi))
@@ -854,7 +855,7 @@ public enum __ABI_test_component {
             return .from(abi: value)
         }
 
-        internal func put_BaseNoOverridesPropertyImpl(_ value: test_component.BaseNoOverrides?) throws {
+        public func put_BaseNoOverridesPropertyImpl(_ value: test_component.BaseNoOverrides?) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_BaseNoOverridesProperty(pThis, RawPointer(value)))
             }
@@ -865,7 +866,7 @@ public enum __ABI_test_component {
     public class IClassFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIClassFactory }
 
-        internal func CreateInstanceImpl(_ name: String) throws -> IClass {
+        public func CreateInstanceImpl(_ name: String) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _name = try! HString(name)
                 _ = try perform(as: __x_ABI_Ctest__component_CIClassFactory.self) { pThis in
@@ -875,7 +876,7 @@ public enum __ABI_test_component {
             return IClass(value!)
         }
 
-        internal func CreateInstance2Impl(_ name: String, _ fruit: test_component.Fruit) throws -> IClass {
+        public func CreateInstance2Impl(_ name: String, _ fruit: test_component.Fruit) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _name = try! HString(name)
                 _ = try perform(as: __x_ABI_Ctest__component_CIClassFactory.self) { pThis in
@@ -885,7 +886,7 @@ public enum __ABI_test_component {
             return IClass(value!)
         }
 
-        internal func CreateInstance3Impl(_ arg: test_component.AnyIMap<String, String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32) throws -> IClass {
+        public func CreateInstance3Impl(_ arg: test_component.AnyIMap<String, String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let argWrapper = test_component.__x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper(arg)
                 let _arg = try! argWrapper?.toABI { $0 }
@@ -896,7 +897,7 @@ public enum __ABI_test_component {
             return IClass(value!)
         }
 
-        internal func CreateInstance4Impl(_ arg: test_component.AnyIMapView<String, String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32) throws -> IClass {
+        public func CreateInstance4Impl(_ arg: test_component.AnyIMapView<String, String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let argWrapper = test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper(arg)
                 let _arg = try! argWrapper?.toABI { $0 }
@@ -907,7 +908,7 @@ public enum __ABI_test_component {
             return IClass(value!)
         }
 
-        internal func CreateInstance5Impl(_ arg: test_component.AnyIVector<String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32, _ dummy5: Int32) throws -> IClass {
+        public func CreateInstance5Impl(_ arg: test_component.AnyIVector<String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32, _ dummy5: Int32) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let argWrapper = test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper(arg)
                 let _arg = try! argWrapper?.toABI { $0 }
@@ -918,7 +919,7 @@ public enum __ABI_test_component {
             return IClass(value!)
         }
 
-        internal func CreateInstance6Impl(_ arg: test_component.AnyIVectorView<String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32, _ dummy5: Int32, _ dummy6: Int32) throws -> IClass {
+        public func CreateInstance6Impl(_ arg: test_component.AnyIVectorView<String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32, _ dummy5: Int32, _ dummy6: Int32) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let argWrapper = test_component.__x_ABI_C__FIVectorView_1_HSTRINGWrapper(arg)
                 let _arg = try! argWrapper?.toABI { $0 }
@@ -934,7 +935,7 @@ public enum __ABI_test_component {
     public class IClassFactory2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIClassFactory2 }
 
-        internal func CreateInstanceImpl(_ name: String, _ fruit: test_component.Fruit, _ implementation: test_component.AnyIIAmImplementable?) throws -> IClass {
+        public func CreateInstanceImpl(_ name: String, _ fruit: test_component.Fruit, _ implementation: test_component.AnyIIAmImplementable?) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _name = try! HString(name)
                 let implementationWrapper = __ABI_test_component.IIAmImplementableWrapper(implementation)
@@ -951,13 +952,13 @@ public enum __ABI_test_component {
     public class IClassStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIClassStatics }
 
-        internal func StaticTestImpl() throws {
+        public func StaticTestImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.StaticTest(pThis))
             }
         }
 
-        internal func StaticTestReturnImpl() throws -> Int32 {
+        public func StaticTestReturnImpl() throws -> Int32 {
             var result: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.StaticTestReturn(pThis, &result))
@@ -965,7 +966,7 @@ public enum __ABI_test_component {
             return result
         }
 
-        internal func get_StaticPropertyImpl() throws -> Int32 {
+        public func get_StaticPropertyImpl() throws -> Int32 {
             var value: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StaticProperty(pThis, &value))
@@ -973,7 +974,7 @@ public enum __ABI_test_component {
             return value
         }
 
-        internal func TakeBaseAndGiveToCallbackAsObjectImpl(_ base: test_component.Base?, _ callback: test_component.InObjectDelegate?) throws {
+        public func TakeBaseAndGiveToCallbackAsObjectImpl(_ base: test_component.Base?, _ callback: test_component.InObjectDelegate?) throws {
             let callbackWrapper = __ABI_test_component_Delegates.InObjectDelegateWrapper(callback)
             let _callback = try! callbackWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics.self) { pThis in
@@ -986,7 +987,7 @@ public enum __ABI_test_component {
     public class IClassStatics2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIClassStatics2 }
 
-        internal func StaticTestReturnFloatImpl() throws -> Float {
+        public func StaticTestReturnFloatImpl() throws -> Float {
             var result: FLOAT = 0.0
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics2.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.StaticTestReturnFloat(pThis, &result))
@@ -994,7 +995,7 @@ public enum __ABI_test_component {
             return result
         }
 
-        internal func get_StaticPropertyFloatImpl() throws -> Float {
+        public func get_StaticPropertyFloatImpl() throws -> Float {
             var value: FLOAT = 0.0
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics2.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StaticPropertyFloat(pThis, &value))
@@ -1002,7 +1003,7 @@ public enum __ABI_test_component {
             return value
         }
 
-        internal func put_StaticPropertyFloatImpl(_ value: Float) throws {
+        public func put_StaticPropertyFloatImpl(_ value: Float) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics2.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_StaticPropertyFloat(pThis, value))
             }
@@ -1013,7 +1014,7 @@ public enum __ABI_test_component {
     public class ICollectionTester: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CICollectionTester }
 
-        internal func ReturnStoredStringVectorImpl() throws -> test_component.AnyIVector<String>? {
+        public func ReturnStoredStringVectorImpl() throws -> test_component.AnyIVector<String>? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CICollectionTester.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnStoredStringVector(pThis, &resultAbi))
@@ -1022,7 +1023,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: result)
         }
 
-        internal func ReturnMapFromStringToStringImpl() throws -> test_component.AnyIMap<String, String>? {
+        public func ReturnMapFromStringToStringImpl() throws -> test_component.AnyIMap<String, String>? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CICollectionTester.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnMapFromStringToString(pThis, &resultAbi))
@@ -1036,7 +1037,7 @@ public enum __ABI_test_component {
     public class ICollectionTesterStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CICollectionTesterStatics }
 
-        internal func InMapImpl(_ value: test_component.AnyIMap<String, String>?) throws -> String {
+        public func InMapImpl(_ value: test_component.AnyIMap<String, String>?) throws -> String {
             var result: HSTRING?
             let valueWrapper = test_component.__x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1046,7 +1047,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func InMapViewImpl(_ value: test_component.AnyIMapView<String, String>?) throws -> String {
+        public func InMapViewImpl(_ value: test_component.AnyIMapView<String, String>?) throws -> String {
             var result: HSTRING?
             let valueWrapper = test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1056,7 +1057,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func InVectorImpl(_ value: test_component.AnyIVector<String>?) throws -> String {
+        public func InVectorImpl(_ value: test_component.AnyIVector<String>?) throws -> String {
             var result: HSTRING?
             let valueWrapper = test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1066,7 +1067,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func InVectorViewImpl(_ value: test_component.AnyIVectorView<String>?) throws -> String {
+        public func InVectorViewImpl(_ value: test_component.AnyIVectorView<String>?) throws -> String {
             var result: HSTRING?
             let valueWrapper = test_component.__x_ABI_C__FIVectorView_1_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1076,7 +1077,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func GetObjectAtImpl(_ value: test_component.AnyIVector<Any?>?, _ index: UInt32, _ callback: test_component.ObjectHandler?) throws {
+        public func GetObjectAtImpl(_ value: test_component.AnyIVector<Any?>?, _ index: UInt32, _ callback: test_component.ObjectHandler?) throws {
             let valueWrapper = test_component.__x_ABI_C__FIVector_1_IInspectableWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             let callbackWrapper = __ABI_test_component.ObjectHandlerWrapper(callback)
@@ -1086,7 +1087,7 @@ public enum __ABI_test_component {
             }
         }
 
-        internal func VectorAsIterableImpl(_ value: test_component.AnyIVector<String>?) throws -> test_component.AnyIIterable<String>? {
+        public func VectorAsIterableImpl(_ value: test_component.AnyIVector<String>?) throws -> test_component.AnyIIterable<String>? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 let valueWrapper = test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper(value)
                 let _value = try! valueWrapper?.toABI { $0 }
@@ -1102,7 +1103,7 @@ public enum __ABI_test_component {
     public class IDeferrableEventArgs: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIDeferrableEventArgs }
 
-        internal func GetDeferralImpl() throws -> test_component.Deferral? {
+        public func GetDeferralImpl() throws -> test_component.Deferral? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIDeferrableEventArgs.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetDeferral(pThis, &resultAbi))
@@ -1111,7 +1112,7 @@ public enum __ABI_test_component {
             return .from(abi: result)
         }
 
-        internal func IncrementCounterImpl() throws {
+        public func IncrementCounterImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIDeferrableEventArgs.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.IncrementCounter(pThis))
             }
@@ -1122,7 +1123,7 @@ public enum __ABI_test_component {
     public class IDerived: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIDerived }
 
-        internal func get_PropImpl() throws -> Int32 {
+        public func get_PropImpl() throws -> Int32 {
             var value: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIDerived.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Prop(pThis, &value))
@@ -1130,7 +1131,7 @@ public enum __ABI_test_component {
             return value
         }
 
-        internal func put_PropImpl(_ value: Int32) throws {
+        public func put_PropImpl(_ value: Int32) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIDerived.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Prop(pThis, value))
             }
@@ -1141,7 +1142,7 @@ public enum __ABI_test_component {
     public class IDerivedFromNoConstructor: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIDerivedFromNoConstructor }
 
-        internal func MethodImpl() throws {
+        public func MethodImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIDerivedFromNoConstructor.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Method(pThis))
             }
@@ -1152,7 +1153,7 @@ public enum __ABI_test_component {
     public class IDerivedStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIDerivedStatics }
 
-        internal func CreateFromStringImpl(_ value: String) throws -> test_component.Derived? {
+        public func CreateFromStringImpl(_ value: String) throws -> test_component.Derived? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 let _value = try! HString(value)
                 _ = try perform(as: __x_ABI_Ctest__component_CIDerivedStatics.self) { pThis in
@@ -1167,19 +1168,19 @@ public enum __ABI_test_component {
     public class IEventTester: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIEventTester }
 
-        internal func SubscribeImpl() throws {
+        public func SubscribeImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIEventTester.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Subscribe(pThis))
             }
         }
 
-        internal func UnsubscribeImpl() throws {
+        public func UnsubscribeImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIEventTester.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Unsubscribe(pThis))
             }
         }
 
-        internal func GetResultImpl() throws -> String {
+        public func GetResultImpl() throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIEventTester.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResult(pThis, &result))
@@ -1187,7 +1188,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func get_CountImpl() throws -> Int32 {
+        public func get_CountImpl() throws -> Int32 {
             var value: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIEventTester.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Count(pThis, &value))
@@ -1200,7 +1201,7 @@ public enum __ABI_test_component {
     public class IEventTesterFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIEventTesterFactory }
 
-        internal func CreateInstanceImpl(_ impl: test_component.AnyIIAmImplementable?) throws -> IEventTester {
+        public func CreateInstanceImpl(_ impl: test_component.AnyIIAmImplementable?) throws -> IEventTester {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let implWrapper = __ABI_test_component.IIAmImplementableWrapper(impl)
                 let _impl = try! implWrapper?.toABI { $0 }
@@ -1629,7 +1630,7 @@ public enum __ABI_test_component {
     public class INullValuesStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CINullValuesStatics }
 
-        internal func IsObjectNullImpl(_ value: Any?) throws -> Bool {
+        public func IsObjectNullImpl(_ value: Any?) throws -> Bool {
             var result: boolean = 0
             let valueWrapper = __ABI_.AnyWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1639,7 +1640,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func IsInterfaceNullImpl(_ value: test_component.AnyIClosable?) throws -> Bool {
+        public func IsInterfaceNullImpl(_ value: test_component.AnyIClosable?) throws -> Bool {
             var result: boolean = 0
             let valueWrapper = __ABI_Windows_Foundation.IClosableWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1649,7 +1650,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func IsGenericInterfaceNullImpl(_ value: test_component.AnyIVector<String>?) throws -> Bool {
+        public func IsGenericInterfaceNullImpl(_ value: test_component.AnyIVector<String>?) throws -> Bool {
             var result: boolean = 0
             let valueWrapper = test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1659,7 +1660,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func IsClassNullImpl(_ value: test_component.NoopClosable?) throws -> Bool {
+        public func IsClassNullImpl(_ value: test_component.NoopClosable?) throws -> Bool {
             var result: boolean = 0
             _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.IsClassNull(pThis, RawPointer(value), &result))
@@ -1667,7 +1668,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func IsDelegateNullImpl(_ value: test_component.VoidToVoidDelegate?) throws -> Bool {
+        public func IsDelegateNullImpl(_ value: test_component.VoidToVoidDelegate?) throws -> Bool {
             var result: boolean = 0
             let valueWrapper = __ABI_test_component.VoidToVoidDelegateWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1677,7 +1678,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func GetNullObjectImpl() throws -> Any? {
+        public func GetNullObjectImpl() throws -> Any? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetNullObject(pThis, &resultAbi))
@@ -1686,7 +1687,7 @@ public enum __ABI_test_component {
             return __ABI_.AnyWrapper.unwrapFrom(abi: result)
         }
 
-        internal func GetNullInterfaceImpl() throws -> test_component.AnyIClosable? {
+        public func GetNullInterfaceImpl() throws -> test_component.AnyIClosable? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetNullInterface(pThis, &resultAbi))
@@ -1695,7 +1696,7 @@ public enum __ABI_test_component {
             return __ABI_Windows_Foundation.IClosableWrapper.unwrapFrom(abi: result)
         }
 
-        internal func GetNullGenericInterfaceImpl() throws -> test_component.AnyIVector<String>? {
+        public func GetNullGenericInterfaceImpl() throws -> test_component.AnyIVector<String>? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetNullGenericInterface(pThis, &resultAbi))
@@ -1704,7 +1705,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: result)
         }
 
-        internal func GetNullClassImpl() throws -> test_component.NoopClosable? {
+        public func GetNullClassImpl() throws -> test_component.NoopClosable? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetNullClass(pThis, &resultAbi))
@@ -1713,7 +1714,7 @@ public enum __ABI_test_component {
             return .from(abi: result)
         }
 
-        internal func GetNullDelegateImpl() throws -> test_component.VoidToVoidDelegate? {
+        public func GetNullDelegateImpl() throws -> test_component.VoidToVoidDelegate? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetNullDelegate(pThis, &resultAbi))
@@ -1776,13 +1777,13 @@ public enum __ABI_test_component {
     public class ISimple: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CISimple }
 
-        internal func MethodImpl() throws {
+        public func MethodImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Method(pThis))
             }
         }
 
-        internal func OperationImpl(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncOperation<Int32>? {
+        public func OperationImpl(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncOperation<Int32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Operation(pThis, .from(swift: value), &operationAbi))
@@ -1791,7 +1792,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func ActionImpl(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncAction? {
+        public func ActionImpl(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Action(pThis, .from(swift: value), &operationAbi))
@@ -1800,7 +1801,7 @@ public enum __ABI_test_component {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        internal func ObjectImpl(_ value: test_component.DateTime) throws -> Any? {
+        public func ObjectImpl(_ value: test_component.DateTime) throws -> Any? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Object(pThis, .from(swift: value), &resultAbi))
@@ -1809,7 +1810,7 @@ public enum __ABI_test_component {
             return __ABI_.AnyWrapper.unwrapFrom(abi: result)
         }
 
-        internal func ReturnBlittableStructImpl() throws -> test_component.BlittableStruct {
+        public func ReturnBlittableStructImpl() throws -> test_component.BlittableStruct {
             var result: __x_ABI_Ctest__component_CBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnBlittableStruct(pThis, &result))
@@ -1817,13 +1818,13 @@ public enum __ABI_test_component {
             return .from(abi: result)
         }
 
-        internal func TakeBlittableStructImpl(_ value: test_component.BlittableStruct) throws {
+        public func TakeBlittableStructImpl(_ value: test_component.BlittableStruct) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.TakeBlittableStruct(pThis, .from(swift: value)))
             }
         }
 
-        internal func get_BlittableStructPropertyImpl() throws -> test_component.BlittableStruct {
+        public func get_BlittableStructPropertyImpl() throws -> test_component.BlittableStruct {
             var value: __x_ABI_Ctest__component_CBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_BlittableStructProperty(pThis, &value))
@@ -1831,13 +1832,13 @@ public enum __ABI_test_component {
             return .from(abi: value)
         }
 
-        internal func put_BlittableStructPropertyImpl(_ value: test_component.BlittableStruct) throws {
+        public func put_BlittableStructPropertyImpl(_ value: test_component.BlittableStruct) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_BlittableStructProperty(pThis, .from(swift: value)))
             }
         }
 
-        internal func ReturnStructWithReferenceImpl() throws -> test_component.StructWithIReference {
+        public func ReturnStructWithReferenceImpl() throws -> test_component.StructWithIReference {
             var result: __x_ABI_Ctest__component_CStructWithIReference = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnStructWithReference(pThis, &result))
@@ -1845,14 +1846,14 @@ public enum __ABI_test_component {
             return .from(abi: result)
         }
 
-        internal func TakeStructWithReferenceImpl(_ value: test_component.StructWithIReference) throws {
+        public func TakeStructWithReferenceImpl(_ value: test_component.StructWithIReference) throws {
             let _value = __ABI_test_component._ABI_StructWithIReference(from: value)
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.TakeStructWithReference(pThis, _value.val))
             }
         }
 
-        internal func get_StructWithReferencePropertyImpl() throws -> test_component.StructWithIReference {
+        public func get_StructWithReferencePropertyImpl() throws -> test_component.StructWithIReference {
             var value: __x_ABI_Ctest__component_CStructWithIReference = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StructWithReferenceProperty(pThis, &value))
@@ -1860,14 +1861,14 @@ public enum __ABI_test_component {
             return .from(abi: value)
         }
 
-        internal func put_StructWithReferencePropertyImpl(_ value: test_component.StructWithIReference) throws {
+        public func put_StructWithReferencePropertyImpl(_ value: test_component.StructWithIReference) throws {
             let _value = __ABI_test_component._ABI_StructWithIReference(from: value)
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_StructWithReferenceProperty(pThis, _value.val))
             }
         }
 
-        internal func ReturnNonBlittableStructImpl() throws -> test_component.NonBlittableStruct {
+        public func ReturnNonBlittableStructImpl() throws -> test_component.NonBlittableStruct {
             var result: __x_ABI_Ctest__component_CNonBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnNonBlittableStruct(pThis, &result))
@@ -1875,14 +1876,14 @@ public enum __ABI_test_component {
             return .from(abi: result)
         }
 
-        internal func TakeNonBlittableStructImpl(_ value: test_component.NonBlittableStruct) throws {
+        public func TakeNonBlittableStructImpl(_ value: test_component.NonBlittableStruct) throws {
             let _value = __ABI_test_component._ABI_NonBlittableStruct(from: value)
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.TakeNonBlittableStruct(pThis, _value.val))
             }
         }
 
-        internal func get_NonBlittableStructPropertyImpl() throws -> test_component.NonBlittableStruct {
+        public func get_NonBlittableStructPropertyImpl() throws -> test_component.NonBlittableStruct {
             var value: __x_ABI_Ctest__component_CNonBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_NonBlittableStructProperty(pThis, &value))
@@ -1890,14 +1891,14 @@ public enum __ABI_test_component {
             return .from(abi: value)
         }
 
-        internal func put_NonBlittableStructPropertyImpl(_ value: test_component.NonBlittableStruct) throws {
+        public func put_NonBlittableStructPropertyImpl(_ value: test_component.NonBlittableStruct) throws {
             let _value = __ABI_test_component._ABI_NonBlittableStruct(from: value)
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_NonBlittableStructProperty(pThis, _value.val))
             }
         }
 
-        internal func get_StringPropertyImpl() throws -> String {
+        public func get_StringPropertyImpl() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StringProperty(pThis, &value))
@@ -1905,14 +1906,14 @@ public enum __ABI_test_component {
             return .init(from: value)
         }
 
-        internal func put_StringPropertyImpl(_ value: String) throws {
+        public func put_StringPropertyImpl(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_StringProperty(pThis, _value.get()))
             }
         }
 
-        internal func add_SignalEventImpl(_ handler: test_component.SignalDelegate?) throws -> EventRegistrationToken {
+        public func add_SignalEventImpl(_ handler: test_component.SignalDelegate?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = __ABI_test_component_Delegates.SignalDelegateWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -1922,13 +1923,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        internal func remove_SignalEventImpl(_ token: EventRegistrationToken) throws {
+        public func remove_SignalEventImpl(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_SignalEvent(pThis, token))
             }
         }
 
-        internal func add_InEventImpl(_ handler: test_component.InDelegate?) throws -> EventRegistrationToken {
+        public func add_InEventImpl(_ handler: test_component.InDelegate?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = __ABI_test_component_Delegates.InDelegateWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -1938,13 +1939,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        internal func remove_InEventImpl(_ token: EventRegistrationToken) throws {
+        public func remove_InEventImpl(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_InEvent(pThis, token))
             }
         }
 
-        internal func add_SimpleEventImpl(_ handler: TypedEventHandler<test_component.Simple?, test_component.SimpleEventArgs>?) throws -> EventRegistrationToken {
+        public func add_SimpleEventImpl(_ handler: TypedEventHandler<test_component.Simple?, test_component.SimpleEventArgs>?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -1954,13 +1955,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        internal func remove_SimpleEventImpl(_ token: EventRegistrationToken) throws {
+        public func remove_SimpleEventImpl(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_SimpleEvent(pThis, token))
             }
         }
 
-        internal func FireEventImpl() throws {
+        public func FireEventImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.FireEvent(pThis))
             }
@@ -2035,7 +2036,7 @@ public enum __ABI_test_component {
     public class ISimpleOverrides: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CISimpleOverrides }
 
-        internal func CantActuallyOverrideBecauseNotComposableImpl() throws {
+        public func CantActuallyOverrideBecauseNotComposableImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimpleOverrides.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.CantActuallyOverrideBecauseNotComposable(pThis))
             }
@@ -2046,7 +2047,7 @@ public enum __ABI_test_component {
     public class ISimpleStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CISimpleStatics }
 
-        internal func add_StaticEventImpl(_ handler: EventHandler<Any?>?) throws -> EventRegistrationToken {
+        public func add_StaticEventImpl(_ handler: EventHandler<Any?>?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = test_component.__x_ABI_C__FIEventHandler_1_IInspectableWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -2056,13 +2057,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        internal func remove_StaticEventImpl(_ token: EventRegistrationToken) throws {
+        public func remove_StaticEventImpl(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimpleStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_StaticEvent(pThis, token))
             }
         }
 
-        internal func FireStaticEventImpl() throws {
+        public func FireStaticEventImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimpleStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.FireStaticEvent(pThis))
             }
@@ -2073,7 +2074,7 @@ public enum __ABI_test_component {
     public class IStaticClassStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIStaticClassStatics }
 
-        internal func get_EnumPropertyImpl() throws -> test_component.Fruit {
+        public func get_EnumPropertyImpl() throws -> test_component.Fruit {
             var value: __x_ABI_Ctest__component_CFruit = .init(0)
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_EnumProperty(pThis, &value))
@@ -2081,13 +2082,13 @@ public enum __ABI_test_component {
             return value
         }
 
-        internal func put_EnumPropertyImpl(_ value: test_component.Fruit) throws {
+        public func put_EnumPropertyImpl(_ value: test_component.Fruit) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_EnumProperty(pThis, value))
             }
         }
 
-        internal func InEnumImpl(_ value: test_component.Signed) throws -> String {
+        public func InEnumImpl(_ value: test_component.Signed) throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InEnum(pThis, value, &result))
@@ -2095,7 +2096,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func InNonBlittableStructImpl(_ value: test_component.NonBlittableStruct) throws -> String {
+        public func InNonBlittableStructImpl(_ value: test_component.NonBlittableStruct) throws -> String {
             var result: HSTRING?
             let _value = __ABI_test_component._ABI_NonBlittableStruct(from: value)
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
@@ -2104,7 +2105,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        internal func TakeBaseImpl(_ base: test_component.Base?) throws {
+        public func TakeBaseImpl(_ base: test_component.Base?) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.TakeBase(pThis, RawPointer(base)))
             }
@@ -2115,7 +2116,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerived: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerived }
 
-        internal func get_PropImpl() throws -> Int32 {
+        public func get_PropImpl() throws -> Int32 {
             var value: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIUnsealedDerived.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Prop(pThis, &value))
@@ -2123,7 +2124,7 @@ public enum __ABI_test_component {
             return value
         }
 
-        internal func put_PropImpl(_ value: Int32) throws {
+        public func put_PropImpl(_ value: Int32) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIUnsealedDerived.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Prop(pThis, value))
             }
@@ -2134,7 +2135,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerived2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerived2 }
 
-        internal func MethodImpl() throws {
+        public func MethodImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIUnsealedDerived2.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Method(pThis))
             }
@@ -2145,7 +2146,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerived2Factory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerived2Factory }
 
-        internal func CreateInstanceImpl(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived2.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
+        public func CreateInstanceImpl(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived2.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2163,7 +2164,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerived2ProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerived2ProtectedFactory }
 
-        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived2.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
+        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived2.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2181,7 +2182,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedFactory }
 
-        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
+        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2194,7 +2195,7 @@ public enum __ABI_test_component {
             return IUnsealedDerived(value!)
         }
 
-        internal func CreateInstance2Impl(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
+        public func CreateInstance2Impl(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2207,7 +2208,7 @@ public enum __ABI_test_component {
             return IUnsealedDerived(value!)
         }
 
-        internal func CreateInstance3Impl(_ prop1: String, _ prop2: test_component.Base?, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
+        public func CreateInstance3Impl(_ prop1: String, _ prop2: test_component.Base?, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _prop1 = try! HString(prop1)
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
@@ -2231,7 +2232,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedFromNoConstructorFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructorFactory }
 
-        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerivedFromNoConstructor.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedFromNoConstructor {
+        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerivedFromNoConstructor.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedFromNoConstructor {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2264,7 +2265,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedNoOverridesProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedNoOverridesProtectedFactory }
 
-        internal func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerivedNoOverrides.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedNoOverrides {
+        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerivedNoOverrides.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedNoOverrides {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2282,7 +2283,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedOverloads2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedOverloads2 }
 
-        internal func OnAfterDoTheThingImpl() throws {
+        public func OnAfterDoTheThingImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OnAfterDoTheThing(pThis))
             }
@@ -2293,7 +2294,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedOverrides: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedOverrides }
 
-        internal func OnBeforeDoTheThingImpl() throws {
+        public func OnBeforeDoTheThingImpl() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIUnsealedDerivedOverrides.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OnBeforeDoTheThing(pThis))
             }
@@ -2304,7 +2305,7 @@ public enum __ABI_test_component {
     public class IWeakReferencer: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIWeakReferencer }
 
-        internal func ResolveImpl() throws -> test_component.AnyIReferenceTarget? {
+        public func ResolveImpl() throws -> test_component.AnyIReferenceTarget? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIWeakReferencer.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Resolve(pThis, &resultAbi))
@@ -2318,7 +2319,7 @@ public enum __ABI_test_component {
     public class IWeakReferencerFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIWeakReferencerFactory }
 
-        internal func CreateInstanceImpl(_ object: test_component.AnyIReferenceTarget?) throws -> IWeakReferencer {
+        public func CreateInstanceImpl(_ object: test_component.AnyIReferenceTarget?) throws -> IWeakReferencer {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let objectWrapper = __ABI_test_component.IReferenceTargetWrapper(object)
                 let _object = try! objectWrapper?.toABI { $0 }

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -29,10 +29,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanVTable: __x_AB
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanBridge>
-internal class AsyncOperationCompletedHandlerBool: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerBool: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1_boolean }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<Bool>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<Bool>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1_booleanWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1_boolean.self) { pThis in
@@ -82,10 +82,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1_intVTable: __x_ABI_C_
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_intBridge>
-internal class AsyncOperationCompletedHandlerInt32: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1_int }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<Int32>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<Int32>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1_int.self) { pThis in
@@ -135,10 +135,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGVTable: __x_AB
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGBridge>
-internal class AsyncOperationCompletedHandlerString: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerString: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRING }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<String>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<String>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1_HSTRINGWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRING.self) { pThis in
@@ -188,10 +188,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32VTable: __x_ABI
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32Bridge>
-internal class AsyncOperationCompletedHandlerUInt32: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerUInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32 }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1_UINT32Wrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32.self) { pThis in
@@ -241,10 +241,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HS
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectableBridge>
-internal class AsyncOperationCompletedHandlerIMapString_Any: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIMapString_Any: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectable }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIMap<String, Any?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIMap<String, Any?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
@@ -294,10 +294,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorVi
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
-internal class AsyncOperationCompletedHandlerIVectorViewIStorageItem: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIVectorViewIStorageItem: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
@@ -347,10 +347,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorVi
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
-internal class AsyncOperationCompletedHandlerIVectorViewStorageFile: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIVectorViewStorageFile: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
@@ -400,10 +400,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorVi
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
-internal class AsyncOperationCompletedHandlerIVectorViewStorageFolder: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIVectorViewStorageFolder: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
@@ -453,10 +453,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorVi
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge>
-internal class AsyncOperationCompletedHandlerIVectorViewStorageLibraryChange: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIVectorViewStorageLibraryChange: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
@@ -506,10 +506,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRINGBridge>
-internal class AsyncOperationCompletedHandlerIVectorString: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIVectorString: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRING }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRING.self) { pThis in
@@ -559,10 +559,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesBridge>
-internal class AsyncOperationCompletedHandlerBasicProperties: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerBasicProperties: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.BasicProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.BasicProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties.self) { pThis in
@@ -612,10 +612,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesBridge>
-internal class AsyncOperationCompletedHandlerDocumentProperties: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerDocumentProperties: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.DocumentProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.DocumentProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties.self) { pThis in
@@ -665,10 +665,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesBridge>
-internal class AsyncOperationCompletedHandlerImageProperties: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerImageProperties: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.ImageProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.ImageProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties.self) { pThis in
@@ -718,10 +718,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesBridge>
-internal class AsyncOperationCompletedHandlerMusicProperties: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerMusicProperties: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.MusicProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.MusicProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties.self) { pThis in
@@ -771,10 +771,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailBridge>
-internal class AsyncOperationCompletedHandlerStorageItemThumbnail: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerStorageItemThumbnail: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail.self) { pThis in
@@ -824,10 +824,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesBridge>
-internal class AsyncOperationCompletedHandlerVideoProperties: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerVideoProperties: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.VideoProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.VideoProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties.self) { pThis in
@@ -877,10 +877,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
-internal class AsyncOperationCompletedHandlerIStorageItem: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIStorageItem: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
@@ -930,10 +930,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateBridge>
-internal class AsyncOperationCompletedHandlerIndexedState: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIndexedState: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.IndexedState>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.IndexedState>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState.self) { pThis in
@@ -983,10 +983,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
-internal class AsyncOperationCompletedHandlerStorageFile: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerStorageFile: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageFile?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageFile?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
@@ -1036,10 +1036,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
-internal class AsyncOperationCompletedHandlerStorageFolder: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerStorageFolder: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageFolder?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageFolder?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
@@ -1089,10 +1089,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionBridge>
-internal class AsyncOperationCompletedHandlerStorageStreamTransaction: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerStorageStreamTransaction: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageStreamTransaction?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageStreamTransaction?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction.self) { pThis in
@@ -1142,10 +1142,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBufferBridge>
-internal class AsyncOperationCompletedHandlerIBuffer: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIBuffer: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIBuffer?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIBuffer?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer.self) { pThis in
@@ -1195,10 +1195,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamBridge>
-internal class AsyncOperationCompletedHandlerIInputStream: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIInputStream: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIInputStream?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIInputStream?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream.self) { pThis in
@@ -1248,10 +1248,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamBridge>
-internal class AsyncOperationCompletedHandlerIRandomAccessStream: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIRandomAccessStream: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream.self) { pThis in
@@ -1301,10 +1301,10 @@ internal var __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSt
     }
 )
 typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeBridge>
-internal class AsyncOperationCompletedHandlerIRandomAccessStreamWithContentType: test_component.IUnknown {
+public class AsyncOperationCompletedHandlerIRandomAccessStreamWithContentType: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStreamWithContentType?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStreamWithContentType?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType.self) { pThis in
@@ -1354,10 +1354,10 @@ internal var __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleVTable: __x_
     }
 )
 typealias __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleBridge>
-internal class AsyncOperationProgressHandlerInt32_Double: test_component.IUnknown {
+public class AsyncOperationProgressHandlerInt32_Double: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationProgressHandler_2_int_double }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<Int32, Double>?, _ progressInfo: Double) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<Int32, Double>?, _ progressInfo: Double) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationProgressHandler_2_int_double.self) { pThis in
@@ -1407,10 +1407,10 @@ internal var __x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32VTable: _
     }
 )
 typealias __x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32Bridge>
-internal class AsyncOperationProgressHandlerUInt32_UInt32: test_component.IUnknown {
+public class AsyncOperationProgressHandlerUInt32_UInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32 }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<UInt32, UInt32>?, _ progressInfo: UInt32) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<UInt32, UInt32>?, _ progressInfo: UInt32) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Wrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32.self) { pThis in
@@ -1460,10 +1460,10 @@ internal var __x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CSto
     }
 )
 typealias __x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Bridge>
-internal class AsyncOperationProgressHandlerIBuffer_UInt32: test_component.IUnknown {
+public class AsyncOperationProgressHandlerIBuffer_UInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32 }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<test_component.AnyIBuffer?, UInt32>?, _ progressInfo: UInt32) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<test_component.AnyIBuffer?, UInt32>?, _ progressInfo: UInt32) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
@@ -1513,10 +1513,10 @@ internal var __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubl
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleBridge>
-internal class AsyncOperationWithProgressCompletedHandlerInt32_Double: test_component.IUnknown {
+public class AsyncOperationWithProgressCompletedHandlerInt32_Double: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_double }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<Int32, Double>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<Int32, Double>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_double.self) { pThis in
@@ -1566,10 +1566,10 @@ internal var __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UI
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32Bridge>
-internal class AsyncOperationWithProgressCompletedHandlerUInt32_UInt32: test_component.IUnknown {
+public class AsyncOperationWithProgressCompletedHandlerUInt32_UInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32 }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<UInt32, UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<UInt32, UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Wrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32.self) { pThis in
@@ -1619,10 +1619,10 @@ internal var __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_C
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Bridge>
-internal class AsyncOperationWithProgressCompletedHandlerIBuffer_UInt32: test_component.IUnknown {
+public class AsyncOperationWithProgressCompletedHandlerIBuffer_UInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32 }
 
-    internal func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<test_component.AnyIBuffer?, UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<test_component.AnyIBuffer?, UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
@@ -1687,10 +1687,10 @@ internal var __x_ABI_C__FIIterable_1_IInspectableVTable: __x_ABI_C__FIIterable_1
     }
 )
 typealias __x_ABI_C__FIIterable_1_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1_IInspectableBridge>
-internal class IIterableAny: test_component.IInspectable {
+public class IIterableAny: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1_IInspectable }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<Any?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<Any?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -1774,10 +1774,10 @@ internal var __x_ABI_C__FIIterable_1_GUIDVTable: __x_ABI_C__FIIterable_1_GUIDVtb
     }
 )
 typealias __x_ABI_C__FIIterable_1_GUIDWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1_GUIDBridge>
-internal class IIterableUUID: test_component.IInspectable {
+public class IIterableUUID: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1_GUID }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<Foundation.UUID>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<Foundation.UUID>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1_GUID.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -1861,10 +1861,10 @@ internal var __x_ABI_C__FIIterable_1_HSTRINGVTable: __x_ABI_C__FIIterable_1_HSTR
     }
 )
 typealias __x_ABI_C__FIIterable_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1_HSTRINGBridge>
-internal class IIterableString: test_component.IInspectable {
+public class IIterableString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1_HSTRING }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<String>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -1948,10 +1948,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegmen
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge>
-internal class IIterableTextSegment: test_component.IInspectable {
+public class IIterableTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.TextSegment>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.TextSegment>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2035,10 +2035,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspec
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge>
-internal class IIterableIKeyValuePairString_Any: test_component.IInspectable {
+public class IIterableIKeyValuePairString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, Any?>?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, Any?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2122,10 +2122,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge>
-internal class IIterableIKeyValuePairString_String: test_component.IInspectable {
+public class IIterableIKeyValuePairString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, String>?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, String>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2209,10 +2209,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge>
-internal class IIterableIKeyValuePairString_IVectorViewTextSegment: test_component.IInspectable {
+public class IIterableIKeyValuePairString_IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, test_component.AnyIVectorView<test_component.TextSegment>?>?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, test_component.AnyIVectorView<test_component.TextSegment>?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2296,10 +2296,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge>
-internal class IIterableIKeyValuePairString_Base: test_component.IInspectable {
+public class IIterableIKeyValuePairString_Base: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, test_component.Base?>?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, test_component.Base?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2383,10 +2383,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUrl
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryBridge>
-internal class IIterableIWwwFormUrlDecoderEntry: test_component.IInspectable {
+public class IIterableIWwwFormUrlDecoderEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIWwwFormUrlDecoderEntry?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIWwwFormUrlDecoderEntry?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2470,10 +2470,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItemVT
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
-internal class IIterableIStorageItem: test_component.IInspectable {
+public class IIterableIStorageItem: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIStorageItem?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIStorageItem?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2557,10 +2557,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSortE
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryBridge>
-internal class IIterableSortEntry: test_component.IInspectable {
+public class IIterableSortEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.SortEntry>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.SortEntry>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2644,10 +2644,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFileVTa
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
-internal class IIterableStorageFile: test_component.IInspectable {
+public class IIterableStorageFile: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.StorageFile?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.StorageFile?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2731,10 +2731,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolderV
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
-internal class IIterableStorageFolder: test_component.IInspectable {
+public class IIterableStorageFolder: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.StorageFolder?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.StorageFolder?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2818,10 +2818,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibrary
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge>
-internal class IIterableStorageLibraryChange: test_component.IInspectable {
+public class IIterableStorageLibraryChange: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibraryChange }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.StorageLibraryChange?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.StorageLibraryChange?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2905,10 +2905,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseBridge>
-internal class IIterableBase: test_component.IInspectable {
+public class IIterableBase: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBase }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.Base?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.Base?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2992,10 +2992,10 @@ internal var __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicVTable: _
     }
 )
 typealias __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicBridge>
-internal class IIterableIBasic: test_component.IInspectable {
+public class IIterableIBasic: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    internal func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIBasic?>? {
+    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIBasic?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -3095,10 +3095,10 @@ internal var __x_ABI_C__FIIterator_1_IInspectableVTable: __x_ABI_C__FIIterator_1
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1_IInspectableBridge>
-internal class IIteratorAny: test_component.IInspectable {
+public class IIteratorAny: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1_IInspectable }
 
-    internal func get_CurrentImpl() throws -> Any? {
+    open func get_CurrentImpl() throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -3107,7 +3107,7 @@ internal class IIteratorAny: test_component.IInspectable {
         return __ABI_.AnyWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3115,7 +3115,7 @@ internal class IIteratorAny: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3223,10 +3223,10 @@ internal var __x_ABI_C__FIIterator_1_GUIDVTable: __x_ABI_C__FIIterator_1_GUIDVtb
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1_GUIDWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1_GUIDBridge>
-internal class IIteratorUUID: test_component.IInspectable {
+public class IIteratorUUID: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1_GUID }
 
-    internal func get_CurrentImpl() throws -> Foundation.UUID {
+    open func get_CurrentImpl() throws -> Foundation.UUID {
         var result: test_component.GUID = .init()
         _ = try perform(as: __x_ABI_C__FIIterator_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
@@ -3234,7 +3234,7 @@ internal class IIteratorUUID: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3242,7 +3242,7 @@ internal class IIteratorUUID: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3350,10 +3350,10 @@ internal var __x_ABI_C__FIIterator_1_HSTRINGVTable: __x_ABI_C__FIIterator_1_HSTR
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1_HSTRINGBridge>
-internal class IIteratorString: test_component.IInspectable {
+public class IIteratorString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1_HSTRING }
 
-    internal func get_CurrentImpl() throws -> String {
+    open func get_CurrentImpl() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIIterator_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
@@ -3361,7 +3361,7 @@ internal class IIteratorString: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3369,7 +3369,7 @@ internal class IIteratorString: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3477,10 +3477,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegmen
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge>
-internal class IIteratorTextSegment: test_component.IInspectable {
+public class IIteratorTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    internal func get_CurrentImpl() throws -> test_component.TextSegment {
+    open func get_CurrentImpl() throws -> test_component.TextSegment {
         var result: __x_ABI_CWindows_CData_CText_CTextSegment = .init()
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
@@ -3488,7 +3488,7 @@ internal class IIteratorTextSegment: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3496,7 +3496,7 @@ internal class IIteratorTextSegment: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3605,10 +3605,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspec
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge>
-internal class IIteratorIKeyValuePairString_Any: test_component.IInspectable {
+public class IIteratorIKeyValuePairString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable }
 
-    internal func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, Any?>? {
+    open func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, Any?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -3617,7 +3617,7 @@ internal class IIteratorIKeyValuePairString_Any: test_component.IInspectable {
         return test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3625,7 +3625,7 @@ internal class IIteratorIKeyValuePairString_Any: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3734,10 +3734,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge>
-internal class IIteratorIKeyValuePairString_String: test_component.IInspectable {
+public class IIteratorIKeyValuePairString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING }
 
-    internal func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, String>? {
+    open func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -3746,7 +3746,7 @@ internal class IIteratorIKeyValuePairString_String: test_component.IInspectable 
         return test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3754,7 +3754,7 @@ internal class IIteratorIKeyValuePairString_String: test_component.IInspectable 
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3863,10 +3863,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge>
-internal class IIteratorIKeyValuePairString_IVectorViewTextSegment: test_component.IInspectable {
+public class IIteratorIKeyValuePairString_IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    internal func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
+    open func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -3875,7 +3875,7 @@ internal class IIteratorIKeyValuePairString_IVectorViewTextSegment: test_compone
         return test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3883,7 +3883,7 @@ internal class IIteratorIKeyValuePairString_IVectorViewTextSegment: test_compone
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3992,10 +3992,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge>
-internal class IIteratorIKeyValuePairString_Base: test_component.IInspectable {
+public class IIteratorIKeyValuePairString_Base: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase }
 
-    internal func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, test_component.Base?>? {
+    open func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, test_component.Base?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4004,7 +4004,7 @@ internal class IIteratorIKeyValuePairString_Base: test_component.IInspectable {
         return test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4012,7 +4012,7 @@ internal class IIteratorIKeyValuePairString_Base: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4121,10 +4121,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrl
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryBridge>
-internal class IIteratorIWwwFormUrlDecoderEntry: test_component.IInspectable {
+public class IIteratorIWwwFormUrlDecoderEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry }
 
-    internal func get_CurrentImpl() throws -> test_component.AnyIWwwFormUrlDecoderEntry? {
+    open func get_CurrentImpl() throws -> test_component.AnyIWwwFormUrlDecoderEntry? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4133,7 +4133,7 @@ internal class IIteratorIWwwFormUrlDecoderEntry: test_component.IInspectable {
         return __ABI_Windows_Foundation.IWwwFormUrlDecoderEntryWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4141,7 +4141,7 @@ internal class IIteratorIWwwFormUrlDecoderEntry: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4250,10 +4250,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItemVT
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
-internal class IIteratorIStorageItem: test_component.IInspectable {
+public class IIteratorIStorageItem: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    internal func get_CurrentImpl() throws -> test_component.AnyIStorageItem? {
+    open func get_CurrentImpl() throws -> test_component.AnyIStorageItem? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4262,7 +4262,7 @@ internal class IIteratorIStorageItem: test_component.IInspectable {
         return __ABI_Windows_Storage.IStorageItemWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4270,7 +4270,7 @@ internal class IIteratorIStorageItem: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4379,10 +4379,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortE
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryBridge>
-internal class IIteratorSortEntry: test_component.IInspectable {
+public class IIteratorSortEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry }
 
-    internal func get_CurrentImpl() throws -> test_component.SortEntry {
+    open func get_CurrentImpl() throws -> test_component.SortEntry {
         var result: __x_ABI_CWindows_CStorage_CSearch_CSortEntry = .init()
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
@@ -4390,7 +4390,7 @@ internal class IIteratorSortEntry: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4398,7 +4398,7 @@ internal class IIteratorSortEntry: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4506,10 +4506,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFileVTa
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
-internal class IIteratorStorageFile: test_component.IInspectable {
+public class IIteratorStorageFile: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    internal func get_CurrentImpl() throws -> test_component.StorageFile? {
+    open func get_CurrentImpl() throws -> test_component.StorageFile? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4518,7 +4518,7 @@ internal class IIteratorStorageFile: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4526,7 +4526,7 @@ internal class IIteratorStorageFile: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4634,10 +4634,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolderV
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
-internal class IIteratorStorageFolder: test_component.IInspectable {
+public class IIteratorStorageFolder: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    internal func get_CurrentImpl() throws -> test_component.StorageFolder? {
+    open func get_CurrentImpl() throws -> test_component.StorageFolder? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4646,7 +4646,7 @@ internal class IIteratorStorageFolder: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4654,7 +4654,7 @@ internal class IIteratorStorageFolder: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4762,10 +4762,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibrary
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge>
-internal class IIteratorStorageLibraryChange: test_component.IInspectable {
+public class IIteratorStorageLibraryChange: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChange }
 
-    internal func get_CurrentImpl() throws -> test_component.StorageLibraryChange? {
+    open func get_CurrentImpl() throws -> test_component.StorageLibraryChange? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4774,7 +4774,7 @@ internal class IIteratorStorageLibraryChange: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4782,7 +4782,7 @@ internal class IIteratorStorageLibraryChange: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4890,10 +4890,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseBridge>
-internal class IIteratorBase: test_component.IInspectable {
+public class IIteratorBase: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBase }
 
-    internal func get_CurrentImpl() throws -> test_component.Base? {
+    open func get_CurrentImpl() throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4902,7 +4902,7 @@ internal class IIteratorBase: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4910,7 +4910,7 @@ internal class IIteratorBase: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -5019,10 +5019,10 @@ internal var __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicVTable: _
     GetMany: { _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicBridge>
-internal class IIteratorIBasic: test_component.IInspectable {
+public class IIteratorIBasic: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    internal func get_CurrentImpl() throws -> test_component.AnyIBasic? {
+    open func get_CurrentImpl() throws -> test_component.AnyIBasic? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -5031,7 +5031,7 @@ internal class IIteratorIBasic: test_component.IInspectable {
         return __ABI_test_component.IBasicWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrentImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -5039,7 +5039,7 @@ internal class IIteratorIBasic: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func MoveNextImpl() throws -> Bool {
+    open func MoveNextImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -5139,10 +5139,10 @@ internal var __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableVTable: __x_ABI_C__
     }
 )
 typealias __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge>
-internal class IKeyValuePairString_Any: test_component.IInspectable {
+public class IKeyValuePairString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable }
 
-    internal func get_KeyImpl() throws -> String {
+    open func get_KeyImpl() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
@@ -5150,7 +5150,7 @@ internal class IKeyValuePairString_Any: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func get_ValueImpl() throws -> Any? {
+    open func get_ValueImpl() throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &resultAbi))
@@ -5246,10 +5246,10 @@ internal var __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGVTable: __x_ABI_C__FIKey
     }
 )
 typealias __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge>
-internal class IKeyValuePairString_String: test_component.IInspectable {
+public class IKeyValuePairString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING }
 
-    internal func get_KeyImpl() throws -> String {
+    open func get_KeyImpl() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
@@ -5257,7 +5257,7 @@ internal class IKeyValuePairString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func get_ValueImpl() throws -> String {
+    open func get_ValueImpl() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &result))
@@ -5353,10 +5353,10 @@ internal var __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_A
     }
 )
 typealias __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge>
-internal class IKeyValuePairString_IVectorViewTextSegment: test_component.IInspectable {
+public class IKeyValuePairString_IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    internal func get_KeyImpl() throws -> String {
+    open func get_KeyImpl() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
@@ -5364,7 +5364,7 @@ internal class IKeyValuePairString_IVectorViewTextSegment: test_component.IInspe
         return .init(from: result)
     }
 
-    internal func get_ValueImpl() throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
+    open func get_ValueImpl() throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &resultAbi))
@@ -5460,10 +5460,10 @@ internal var __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBas
     }
 )
 typealias __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge>
-internal class IKeyValuePairString_Base: test_component.IInspectable {
+public class IKeyValuePairString_Base: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase }
 
-    internal func get_KeyImpl() throws -> String {
+    open func get_KeyImpl() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
@@ -5471,7 +5471,7 @@ internal class IKeyValuePairString_Base: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func get_ValueImpl() throws -> test_component.Base? {
+    open func get_ValueImpl() throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &resultAbi))
@@ -5567,10 +5567,10 @@ internal var __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGVTable: __x_ABI_C__FIMapC
     }
 )
 typealias __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIMapChangedEventArgs_1_HSTRINGBridge>
-internal class IMapChangedEventArgsString: test_component.IInspectable {
+public class IMapChangedEventArgsString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMapChangedEventArgs_1_HSTRING }
 
-    internal func get_CollectionChangeImpl() throws -> test_component.CollectionChange {
+    open func get_CollectionChangeImpl() throws -> test_component.CollectionChange {
         var result: __x_ABI_CWindows_CFoundation_CCollections_CCollectionChange = .init(0)
         _ = try perform(as: __x_ABI_C__FIMapChangedEventArgs_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_CollectionChange(pThis, &result))
@@ -5578,7 +5578,7 @@ internal class IMapChangedEventArgsString: test_component.IInspectable {
         return result
     }
 
-    internal func get_KeyImpl() throws -> String {
+    open func get_KeyImpl() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIMapChangedEventArgs_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
@@ -5695,10 +5695,10 @@ internal var __x_ABI_C__FIMapView_2_HSTRING_IInspectableVTable: __x_ABI_C__FIMap
     }
 )
 typealias __x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIMapView_2_HSTRING_IInspectableBridge>
-internal class IMapViewString_Any: test_component.IInspectable {
+public class IMapViewString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMapView_2_HSTRING_IInspectable }
 
-    internal func LookupImpl(_ key: String) throws -> Any? {
+    open func LookupImpl(_ key: String) throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
@@ -5708,7 +5708,7 @@ internal class IMapViewString_Any: test_component.IInspectable {
         return __ABI_.AnyWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -5716,7 +5716,7 @@ internal class IMapViewString_Any: test_component.IInspectable {
         return result
     }
 
-    internal func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKeyImpl(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
@@ -5725,7 +5725,7 @@ internal class IMapViewString_Any: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func SplitImpl(_ first: inout test_component.AnyIMapView<String, Any?>?, _ second: inout test_component.AnyIMapView<String, Any?>?) throws {
+    open func SplitImpl(_ first: inout test_component.AnyIMapView<String, Any?>?, _ second: inout test_component.AnyIMapView<String, Any?>?) throws {
         let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
@@ -5861,10 +5861,10 @@ internal var __x_ABI_C__FIMapView_2_HSTRING_HSTRINGVTable: __x_ABI_C__FIMapView_
     }
 )
 typealias __x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGBridge>
-internal class IMapViewString_String: test_component.IInspectable {
+public class IMapViewString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMapView_2_HSTRING_HSTRING }
 
-    internal func LookupImpl(_ key: String) throws -> String {
+    open func LookupImpl(_ key: String) throws -> String {
         var result: HSTRING?
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
@@ -5873,7 +5873,7 @@ internal class IMapViewString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -5881,7 +5881,7 @@ internal class IMapViewString_String: test_component.IInspectable {
         return result
     }
 
-    internal func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKeyImpl(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
@@ -5890,7 +5890,7 @@ internal class IMapViewString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func SplitImpl(_ first: inout test_component.AnyIMapView<String, String>?, _ second: inout test_component.AnyIMapView<String, String>?) throws {
+    open func SplitImpl(_ first: inout test_component.AnyIMapView<String, String>?, _ second: inout test_component.AnyIMapView<String, String>?) throws {
         let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
@@ -6027,10 +6027,10 @@ internal var __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CW
     }
 )
 typealias __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge>
-internal class IMapViewString_IVectorViewTextSegment: test_component.IInspectable {
+public class IMapViewString_IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    internal func LookupImpl(_ key: String) throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
+    open func LookupImpl(_ key: String) throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
@@ -6040,7 +6040,7 @@ internal class IMapViewString_IVectorViewTextSegment: test_component.IInspectabl
         return test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -6048,7 +6048,7 @@ internal class IMapViewString_IVectorViewTextSegment: test_component.IInspectabl
         return result
     }
 
-    internal func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKeyImpl(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
@@ -6057,7 +6057,7 @@ internal class IMapViewString_IVectorViewTextSegment: test_component.IInspectabl
         return .init(from: result)
     }
 
-    internal func SplitImpl(_ first: inout test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>?, _ second: inout test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>?) throws {
+    open func SplitImpl(_ first: inout test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>?, _ second: inout test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>?) throws {
         let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
@@ -6193,10 +6193,10 @@ internal var __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVTab
     }
 )
 typealias __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge>
-internal class IMapViewString_Base: test_component.IInspectable {
+public class IMapViewString_Base: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase }
 
-    internal func LookupImpl(_ key: String) throws -> test_component.Base? {
+    open func LookupImpl(_ key: String) throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
@@ -6206,7 +6206,7 @@ internal class IMapViewString_Base: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -6214,7 +6214,7 @@ internal class IMapViewString_Base: test_component.IInspectable {
         return result
     }
 
-    internal func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKeyImpl(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
@@ -6223,7 +6223,7 @@ internal class IMapViewString_Base: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func SplitImpl(_ first: inout test_component.AnyIMapView<String, test_component.Base?>?, _ second: inout test_component.AnyIMapView<String, test_component.Base?>?) throws {
+    open func SplitImpl(_ first: inout test_component.AnyIMapView<String, test_component.Base?>?, _ second: inout test_component.AnyIMapView<String, test_component.Base?>?) throws {
         let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
@@ -6378,10 +6378,10 @@ internal var __x_ABI_C__FIMap_2_HSTRING_IInspectableVTable: __x_ABI_C__FIMap_2_H
     }
 )
 typealias __x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIMap_2_HSTRING_IInspectableBridge>
-internal class IMapString_Any: test_component.IInspectable {
+public class IMapString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMap_2_HSTRING_IInspectable }
 
-    internal func LookupImpl(_ key: String) throws -> Any? {
+    open func LookupImpl(_ key: String) throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
@@ -6391,7 +6391,7 @@ internal class IMapString_Any: test_component.IInspectable {
         return __ABI_.AnyWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -6399,7 +6399,7 @@ internal class IMapString_Any: test_component.IInspectable {
         return result
     }
 
-    internal func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKeyImpl(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
@@ -6408,7 +6408,7 @@ internal class IMapString_Any: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func GetViewImpl() throws -> test_component.AnyIMapView<String, Any?>? {
+    open func GetViewImpl() throws -> test_component.AnyIMapView<String, Any?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -6417,7 +6417,7 @@ internal class IMapString_Any: test_component.IInspectable {
         return test_component.__x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: result)
     }
 
-    internal func InsertImpl(_ key: String, _ value: Any?) throws -> Bool {
+    open func InsertImpl(_ key: String, _ value: Any?) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         let valueWrapper = __ABI_.AnyWrapper(value)
@@ -6428,14 +6428,14 @@ internal class IMapString_Any: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func RemoveImpl(_ key: String) throws {
+    open func RemoveImpl(_ key: String) throws {
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Remove(pThis, _key.get()))
         }
     }
 
-    internal func ClearImpl() throws {
+    open func ClearImpl() throws {
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -6600,10 +6600,10 @@ internal var __x_ABI_C__FIMap_2_HSTRING_HSTRINGVTable: __x_ABI_C__FIMap_2_HSTRIN
     }
 )
 typealias __x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIMap_2_HSTRING_HSTRINGBridge>
-internal class IMapString_String: test_component.IInspectable {
+public class IMapString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMap_2_HSTRING_HSTRING }
 
-    internal func LookupImpl(_ key: String) throws -> String {
+    open func LookupImpl(_ key: String) throws -> String {
         var result: HSTRING?
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
@@ -6612,7 +6612,7 @@ internal class IMapString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -6620,7 +6620,7 @@ internal class IMapString_String: test_component.IInspectable {
         return result
     }
 
-    internal func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKeyImpl(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
@@ -6629,7 +6629,7 @@ internal class IMapString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func GetViewImpl() throws -> test_component.AnyIMapView<String, String>? {
+    open func GetViewImpl() throws -> test_component.AnyIMapView<String, String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -6638,7 +6638,7 @@ internal class IMapString_String: test_component.IInspectable {
         return test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: result)
     }
 
-    internal func InsertImpl(_ key: String, _ value: String) throws -> Bool {
+    open func InsertImpl(_ key: String, _ value: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         let _value = try! HString(value)
@@ -6648,14 +6648,14 @@ internal class IMapString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func RemoveImpl(_ key: String) throws {
+    open func RemoveImpl(_ key: String) throws {
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Remove(pThis, _key.get()))
         }
     }
 
-    internal func ClearImpl() throws {
+    open func ClearImpl() throws {
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -6821,10 +6821,10 @@ internal var __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindo
     }
 )
 typealias __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge>
-internal class IMapString_IVectorViewTextSegment: test_component.IInspectable {
+public class IMapString_IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    internal func LookupImpl(_ key: String) throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
+    open func LookupImpl(_ key: String) throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
@@ -6834,7 +6834,7 @@ internal class IMapString_IVectorViewTextSegment: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -6842,7 +6842,7 @@ internal class IMapString_IVectorViewTextSegment: test_component.IInspectable {
         return result
     }
 
-    internal func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKeyImpl(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
@@ -6851,7 +6851,7 @@ internal class IMapString_IVectorViewTextSegment: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func GetViewImpl() throws -> test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
+    open func GetViewImpl() throws -> test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -6860,7 +6860,7 @@ internal class IMapString_IVectorViewTextSegment: test_component.IInspectable {
         return test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: result)
     }
 
-    internal func InsertImpl(_ key: String, _ value: test_component.AnyIVectorView<test_component.TextSegment>?) throws -> Bool {
+    open func InsertImpl(_ key: String, _ value: test_component.AnyIVectorView<test_component.TextSegment>?) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         let valueWrapper = test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper(value)
@@ -6871,14 +6871,14 @@ internal class IMapString_IVectorViewTextSegment: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func RemoveImpl(_ key: String) throws {
+    open func RemoveImpl(_ key: String) throws {
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Remove(pThis, _key.get()))
         }
     }
 
-    internal func ClearImpl() throws {
+    open func ClearImpl() throws {
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -7043,10 +7043,10 @@ internal var __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVTable: 
     }
 )
 typealias __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge>
-internal class IMapString_Base: test_component.IInspectable {
+public class IMapString_Base: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase }
 
-    internal func LookupImpl(_ key: String) throws -> test_component.Base? {
+    open func LookupImpl(_ key: String) throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
@@ -7056,7 +7056,7 @@ internal class IMapString_Base: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -7064,7 +7064,7 @@ internal class IMapString_Base: test_component.IInspectable {
         return result
     }
 
-    internal func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKeyImpl(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
@@ -7073,7 +7073,7 @@ internal class IMapString_Base: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func GetViewImpl() throws -> test_component.AnyIMapView<String, test_component.Base?>? {
+    open func GetViewImpl() throws -> test_component.AnyIMapView<String, test_component.Base?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -7082,7 +7082,7 @@ internal class IMapString_Base: test_component.IInspectable {
         return test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.unwrapFrom(abi: result)
     }
 
-    internal func InsertImpl(_ key: String, _ value: test_component.Base?) throws -> Bool {
+    open func InsertImpl(_ key: String, _ value: test_component.Base?) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
@@ -7091,14 +7091,14 @@ internal class IMapString_Base: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func RemoveImpl(_ key: String) throws {
+    open func RemoveImpl(_ key: String) throws {
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Remove(pThis, _key.get()))
         }
     }
 
-    internal func ClearImpl() throws {
+    open func ClearImpl() throws {
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -7226,10 +7226,10 @@ internal var __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableVTable: __x_ABI_C_
     }
 )
 typealias __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIObservableMap_2_HSTRING_IInspectableBridge>
-internal class IObservableMapString_Any: test_component.IInspectable {
+public class IObservableMapString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIObservableMap_2_HSTRING_IInspectable }
 
-    internal func add_MapChangedImpl(_ vhnd: MapChangedEventHandler<String, Any?>?) throws -> EventRegistrationToken {
+    open func add_MapChangedImpl(_ vhnd: MapChangedEventHandler<String, Any?>?) throws -> EventRegistrationToken {
         var result: EventRegistrationToken = .init()
         let vhndWrapper = test_component.__x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableWrapper(vhnd)
         let _vhnd = try! vhndWrapper?.toABI { $0 }
@@ -7239,7 +7239,7 @@ internal class IObservableMapString_Any: test_component.IInspectable {
         return result
     }
 
-    internal func remove_MapChangedImpl(_ token: EventRegistrationToken) throws {
+    open func remove_MapChangedImpl(_ token: EventRegistrationToken) throws {
         _ = try perform(as: __x_ABI_C__FIObservableMap_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.remove_MapChanged(pThis, token))
         }
@@ -7381,10 +7381,10 @@ internal var __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGVTable: __x_ABI_C__FIOb
     }
 )
 typealias __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGBridge>
-internal class IObservableMapString_String: test_component.IInspectable {
+public class IObservableMapString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIObservableMap_2_HSTRING_HSTRING }
 
-    internal func add_MapChangedImpl(_ vhnd: MapChangedEventHandler<String, String>?) throws -> EventRegistrationToken {
+    open func add_MapChangedImpl(_ vhnd: MapChangedEventHandler<String, String>?) throws -> EventRegistrationToken {
         var result: EventRegistrationToken = .init()
         let vhndWrapper = test_component.__x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGWrapper(vhnd)
         let _vhnd = try! vhndWrapper?.toABI { $0 }
@@ -7394,7 +7394,7 @@ internal class IObservableMapString_String: test_component.IInspectable {
         return result
     }
 
-    internal func remove_MapChangedImpl(_ token: EventRegistrationToken) throws {
+    open func remove_MapChangedImpl(_ token: EventRegistrationToken) throws {
         _ = try perform(as: __x_ABI_C__FIObservableMap_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.remove_MapChanged(pThis, token))
         }
@@ -7536,10 +7536,10 @@ internal var __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseVTa
     }
 )
 typealias __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseBridge>
-internal class IObservableVectorBase: test_component.IInspectable {
+public class IObservableVectorBase: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase }
 
-    internal func add_VectorChangedImpl(_ vhnd: VectorChangedEventHandler<test_component.Base?>?) throws -> EventRegistrationToken {
+    open func add_VectorChangedImpl(_ vhnd: VectorChangedEventHandler<test_component.Base?>?) throws -> EventRegistrationToken {
         var result: EventRegistrationToken = .init()
         let vhndWrapper = test_component.__x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseWrapper(vhnd)
         let _vhnd = try! vhndWrapper?.toABI { $0 }
@@ -7549,7 +7549,7 @@ internal class IObservableVectorBase: test_component.IInspectable {
         return result
     }
 
-    internal func remove_VectorChangedImpl(_ token: EventRegistrationToken) throws {
+    open func remove_VectorChangedImpl(_ token: EventRegistrationToken) throws {
         _ = try perform(as: __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.remove_VectorChanged(pThis, token))
         }
@@ -7734,10 +7734,10 @@ internal var __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicV
     }
 )
 typealias __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicBridge>
-internal class IObservableVectorIBasic: test_component.IInspectable {
+public class IObservableVectorIBasic: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    internal func add_VectorChangedImpl(_ vhnd: VectorChangedEventHandler<test_component.AnyIBasic?>?) throws -> EventRegistrationToken {
+    open func add_VectorChangedImpl(_ vhnd: VectorChangedEventHandler<test_component.AnyIBasic?>?) throws -> EventRegistrationToken {
         var result: EventRegistrationToken = .init()
         let vhndWrapper = test_component.__x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicWrapper(vhnd)
         let _vhnd = try! vhndWrapper?.toABI { $0 }
@@ -7747,7 +7747,7 @@ internal class IObservableVectorIBasic: test_component.IInspectable {
         return result
     }
 
-    internal func remove_VectorChangedImpl(_ token: EventRegistrationToken) throws {
+    open func remove_VectorChangedImpl(_ token: EventRegistrationToken) throws {
         _ = try perform(as: __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.remove_VectorChanged(pThis, token))
         }
@@ -7944,10 +7944,10 @@ internal var __x_ABI_C__FIVectorView_1_IInspectableVTable: __x_ABI_C__FIVectorVi
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1_IInspectableBridge>
-internal class IVectorViewAny: test_component.IInspectable {
+public class IVectorViewAny: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1_IInspectable }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> Any? {
+    open func GetAtImpl(_ index: UInt32) throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -7956,7 +7956,7 @@ internal class IVectorViewAny: test_component.IInspectable {
         return __ABI_.AnyWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -7964,7 +7964,7 @@ internal class IVectorViewAny: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: Any?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: Any?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_.AnyWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -8106,10 +8106,10 @@ internal var __x_ABI_C__FIVectorView_1_GUIDVTable: __x_ABI_C__FIVectorView_1_GUI
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1_GUIDWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1_GUIDBridge>
-internal class IVectorViewUUID: test_component.IInspectable {
+public class IVectorViewUUID: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1_GUID }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> Foundation.UUID {
+    open func GetAtImpl(_ index: UInt32) throws -> Foundation.UUID {
         var result: test_component.GUID = .init()
         _ = try perform(as: __x_ABI_C__FIVectorView_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -8117,7 +8117,7 @@ internal class IVectorViewUUID: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8125,7 +8125,7 @@ internal class IVectorViewUUID: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: Foundation.UUID, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: Foundation.UUID, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, .init(from: value), &index, &result))
@@ -8265,10 +8265,10 @@ internal var __x_ABI_C__FIVectorView_1_HSTRINGVTable: __x_ABI_C__FIVectorView_1_
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1_HSTRINGBridge>
-internal class IVectorViewString: test_component.IInspectable {
+public class IVectorViewString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1_HSTRING }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> String {
+    open func GetAtImpl(_ index: UInt32) throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIVectorView_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -8276,7 +8276,7 @@ internal class IVectorViewString: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8284,7 +8284,7 @@ internal class IVectorViewString: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: String, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: String, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let _value = try! HString(value)
         _ = try perform(as: __x_ABI_C__FIVectorView_1_HSTRING.self) { pThis in
@@ -8425,10 +8425,10 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegm
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge>
-internal class IVectorViewTextSegment: test_component.IInspectable {
+public class IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.TextSegment {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.TextSegment {
         var result: __x_ABI_CWindows_CData_CText_CTextSegment = .init()
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -8436,7 +8436,7 @@ internal class IVectorViewTextSegment: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8444,7 +8444,7 @@ internal class IVectorViewTextSegment: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: test_component.TextSegment, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.TextSegment, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, .from(swift: value), &index, &result))
@@ -8585,10 +8585,10 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormU
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryBridge>
-internal class IVectorViewIWwwFormUrlDecoderEntry: test_component.IInspectable {
+public class IVectorViewIWwwFormUrlDecoderEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIWwwFormUrlDecoderEntry? {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIWwwFormUrlDecoderEntry? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -8597,7 +8597,7 @@ internal class IVectorViewIWwwFormUrlDecoderEntry: test_component.IInspectable {
         return __ABI_Windows_Foundation.IWwwFormUrlDecoderEntryWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8605,7 +8605,7 @@ internal class IVectorViewIWwwFormUrlDecoderEntry: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: test_component.AnyIWwwFormUrlDecoderEntry?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.AnyIWwwFormUrlDecoderEntry?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_Windows_Foundation.IWwwFormUrlDecoderEntryWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -8748,10 +8748,10 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
-internal class IVectorViewIStorageItem: test_component.IInspectable {
+public class IVectorViewIStorageItem: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIStorageItem? {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIStorageItem? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -8760,7 +8760,7 @@ internal class IVectorViewIStorageItem: test_component.IInspectable {
         return __ABI_Windows_Storage.IStorageItemWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8768,7 +8768,7 @@ internal class IVectorViewIStorageItem: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: test_component.AnyIStorageItem?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.AnyIStorageItem?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_Windows_Storage.IStorageItemWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -8911,10 +8911,10 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSor
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryBridge>
-internal class IVectorViewSortEntry: test_component.IInspectable {
+public class IVectorViewSortEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.SortEntry {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.SortEntry {
         var result: __x_ABI_CWindows_CStorage_CSearch_CSortEntry = .init()
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -8922,7 +8922,7 @@ internal class IVectorViewSortEntry: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8930,7 +8930,7 @@ internal class IVectorViewSortEntry: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: test_component.SortEntry, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.SortEntry, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let _value = __ABI_Windows_Storage_Search._ABI_SortEntry(from: value)
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
@@ -9071,10 +9071,10 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileV
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
-internal class IVectorViewStorageFile: test_component.IInspectable {
+public class IVectorViewStorageFile: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.StorageFile? {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.StorageFile? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9083,7 +9083,7 @@ internal class IVectorViewStorageFile: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9091,7 +9091,7 @@ internal class IVectorViewStorageFile: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: test_component.StorageFile?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.StorageFile?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, RawPointer(value), &index, &result))
@@ -9231,10 +9231,10 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolde
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
-internal class IVectorViewStorageFolder: test_component.IInspectable {
+public class IVectorViewStorageFolder: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.StorageFolder? {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.StorageFolder? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9243,7 +9243,7 @@ internal class IVectorViewStorageFolder: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9251,7 +9251,7 @@ internal class IVectorViewStorageFolder: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: test_component.StorageFolder?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.StorageFolder?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, RawPointer(value), &index, &result))
@@ -9391,10 +9391,10 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibra
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge>
-internal class IVectorViewStorageLibraryChange: test_component.IInspectable {
+public class IVectorViewStorageLibraryChange: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.StorageLibraryChange? {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.StorageLibraryChange? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9403,7 +9403,7 @@ internal class IVectorViewStorageLibraryChange: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9411,7 +9411,7 @@ internal class IVectorViewStorageLibraryChange: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: test_component.StorageLibraryChange?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.StorageLibraryChange?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, RawPointer(value), &index, &result))
@@ -9551,10 +9551,10 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseVTable: _
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseBridge>
-internal class IVectorViewBase: test_component.IInspectable {
+public class IVectorViewBase: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBase }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.Base? {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9563,7 +9563,7 @@ internal class IVectorViewBase: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9571,7 +9571,7 @@ internal class IVectorViewBase: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: test_component.Base?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.Base?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, RawPointer(value), &index, &result))
@@ -9712,10 +9712,10 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicVTable:
     GetMany: { _, _, _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicBridge>
-internal class IVectorViewIBasic: test_component.IInspectable {
+public class IVectorViewIBasic: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIBasic? {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIBasic? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9724,7 +9724,7 @@ internal class IVectorViewIBasic: test_component.IInspectable {
         return __ABI_test_component.IBasicWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9732,7 +9732,7 @@ internal class IVectorViewIBasic: test_component.IInspectable {
         return result
     }
 
-    internal func IndexOfImpl(_ value: test_component.AnyIBasic?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.AnyIBasic?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_test_component.IBasicWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -9927,10 +9927,10 @@ internal var __x_ABI_C__FIVector_1_IInspectableVTable: __x_ABI_C__FIVector_1_IIn
     ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1_IInspectableBridge>
-internal class IVectorAny: test_component.IInspectable {
+public class IVectorAny: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1_IInspectable }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> Any? {
+    open func GetAtImpl(_ index: UInt32) throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9939,7 +9939,7 @@ internal class IVectorAny: test_component.IInspectable {
         return __ABI_.AnyWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9947,7 +9947,7 @@ internal class IVectorAny: test_component.IInspectable {
         return result
     }
 
-    internal func GetViewImpl() throws -> test_component.AnyIVectorView<Any?>? {
+    open func GetViewImpl() throws -> test_component.AnyIVectorView<Any?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -9956,7 +9956,7 @@ internal class IVectorAny: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1_IInspectableWrapper.unwrapFrom(abi: result)
     }
 
-    internal func IndexOfImpl(_ value: Any?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: Any?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_.AnyWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -9966,7 +9966,7 @@ internal class IVectorAny: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func SetAtImpl(_ index: UInt32, _ value: Any?) throws {
+    open func SetAtImpl(_ index: UInt32, _ value: Any?) throws {
         let valueWrapper = __ABI_.AnyWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
@@ -9974,7 +9974,7 @@ internal class IVectorAny: test_component.IInspectable {
         }
     }
 
-    internal func InsertAtImpl(_ index: UInt32, _ value: Any?) throws {
+    open func InsertAtImpl(_ index: UInt32, _ value: Any?) throws {
         let valueWrapper = __ABI_.AnyWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
@@ -9982,13 +9982,13 @@ internal class IVectorAny: test_component.IInspectable {
         }
     }
 
-    internal func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAtImpl(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    internal func AppendImpl(_ value: Any?) throws {
+    open func AppendImpl(_ value: Any?) throws {
         let valueWrapper = __ABI_.AnyWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
@@ -9996,13 +9996,13 @@ internal class IVectorAny: test_component.IInspectable {
         }
     }
 
-    internal func RemoveAtEndImpl() throws {
+    open func RemoveAtEndImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    internal func ClearImpl() throws {
+    open func ClearImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -10236,10 +10236,10 @@ internal var __x_ABI_C__FIVector_1_GUIDVTable: __x_ABI_C__FIVector_1_GUIDVtbl = 
     ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1_GUIDWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1_GUIDBridge>
-internal class IVectorUUID: test_component.IInspectable {
+public class IVectorUUID: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1_GUID }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> Foundation.UUID {
+    open func GetAtImpl(_ index: UInt32) throws -> Foundation.UUID {
         var result: test_component.GUID = .init()
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -10247,7 +10247,7 @@ internal class IVectorUUID: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -10255,7 +10255,7 @@ internal class IVectorUUID: test_component.IInspectable {
         return result
     }
 
-    internal func GetViewImpl() throws -> test_component.AnyIVectorView<Foundation.UUID>? {
+    open func GetViewImpl() throws -> test_component.AnyIVectorView<Foundation.UUID>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -10264,7 +10264,7 @@ internal class IVectorUUID: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1_GUIDWrapper.unwrapFrom(abi: result)
     }
 
-    internal func IndexOfImpl(_ value: Foundation.UUID, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: Foundation.UUID, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, .init(from: value), &index, &result))
@@ -10272,37 +10272,37 @@ internal class IVectorUUID: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func SetAtImpl(_ index: UInt32, _ value: Foundation.UUID) throws {
+    open func SetAtImpl(_ index: UInt32, _ value: Foundation.UUID) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.SetAt(pThis, index, .init(from: value)))
         }
     }
 
-    internal func InsertAtImpl(_ index: UInt32, _ value: Foundation.UUID) throws {
+    open func InsertAtImpl(_ index: UInt32, _ value: Foundation.UUID) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.InsertAt(pThis, index, .init(from: value)))
         }
     }
 
-    internal func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAtImpl(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    internal func AppendImpl(_ value: Foundation.UUID) throws {
+    open func AppendImpl(_ value: Foundation.UUID) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Append(pThis, .init(from: value)))
         }
     }
 
-    internal func RemoveAtEndImpl() throws {
+    open func RemoveAtEndImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    internal func ClearImpl() throws {
+    open func ClearImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -10536,10 +10536,10 @@ internal var __x_ABI_C__FIVector_1_HSTRINGVTable: __x_ABI_C__FIVector_1_HSTRINGV
     ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1_HSTRINGBridge>
-internal class IVectorString: test_component.IInspectable {
+public class IVectorString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1_HSTRING }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> String {
+    open func GetAtImpl(_ index: UInt32) throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -10547,7 +10547,7 @@ internal class IVectorString: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -10555,7 +10555,7 @@ internal class IVectorString: test_component.IInspectable {
         return result
     }
 
-    internal func GetViewImpl() throws -> test_component.AnyIVectorView<String>? {
+    open func GetViewImpl() throws -> test_component.AnyIVectorView<String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -10564,7 +10564,7 @@ internal class IVectorString: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1_HSTRINGWrapper.unwrapFrom(abi: result)
     }
 
-    internal func IndexOfImpl(_ value: String, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: String, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let _value = try! HString(value)
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
@@ -10573,40 +10573,40 @@ internal class IVectorString: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func SetAtImpl(_ index: UInt32, _ value: String) throws {
+    open func SetAtImpl(_ index: UInt32, _ value: String) throws {
         let _value = try! HString(value)
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.SetAt(pThis, index, _value.get()))
         }
     }
 
-    internal func InsertAtImpl(_ index: UInt32, _ value: String) throws {
+    open func InsertAtImpl(_ index: UInt32, _ value: String) throws {
         let _value = try! HString(value)
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.InsertAt(pThis, index, _value.get()))
         }
     }
 
-    internal func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAtImpl(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    internal func AppendImpl(_ value: String) throws {
+    open func AppendImpl(_ value: String) throws {
         let _value = try! HString(value)
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Append(pThis, _value.get()))
         }
     }
 
-    internal func RemoveAtEndImpl() throws {
+    open func RemoveAtEndImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    internal func ClearImpl() throws {
+    open func ClearImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -10841,10 +10841,10 @@ internal var __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEnt
     ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryBridge>
-internal class IVectorSortEntry: test_component.IInspectable {
+public class IVectorSortEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.SortEntry {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.SortEntry {
         var result: __x_ABI_CWindows_CStorage_CSearch_CSortEntry = .init()
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -10852,7 +10852,7 @@ internal class IVectorSortEntry: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -10860,7 +10860,7 @@ internal class IVectorSortEntry: test_component.IInspectable {
         return result
     }
 
-    internal func GetViewImpl() throws -> test_component.AnyIVectorView<test_component.SortEntry>? {
+    open func GetViewImpl() throws -> test_component.AnyIVectorView<test_component.SortEntry>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -10869,7 +10869,7 @@ internal class IVectorSortEntry: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryWrapper.unwrapFrom(abi: result)
     }
 
-    internal func IndexOfImpl(_ value: test_component.SortEntry, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.SortEntry, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let _value = __ABI_Windows_Storage_Search._ABI_SortEntry(from: value)
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
@@ -10878,40 +10878,40 @@ internal class IVectorSortEntry: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func SetAtImpl(_ index: UInt32, _ value: test_component.SortEntry) throws {
+    open func SetAtImpl(_ index: UInt32, _ value: test_component.SortEntry) throws {
         let _value = __ABI_Windows_Storage_Search._ABI_SortEntry(from: value)
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.SetAt(pThis, index, _value.val))
         }
     }
 
-    internal func InsertAtImpl(_ index: UInt32, _ value: test_component.SortEntry) throws {
+    open func InsertAtImpl(_ index: UInt32, _ value: test_component.SortEntry) throws {
         let _value = __ABI_Windows_Storage_Search._ABI_SortEntry(from: value)
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.InsertAt(pThis, index, _value.val))
         }
     }
 
-    internal func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAtImpl(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    internal func AppendImpl(_ value: test_component.SortEntry) throws {
+    open func AppendImpl(_ value: test_component.SortEntry) throws {
         let _value = __ABI_Windows_Storage_Search._ABI_SortEntry(from: value)
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Append(pThis, _value.val))
         }
     }
 
-    internal func RemoveAtEndImpl() throws {
+    open func RemoveAtEndImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    internal func ClearImpl() throws {
+    open func ClearImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -11145,10 +11145,10 @@ internal var __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_A
     ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseBridge>
-internal class IVectorBase: test_component.IInspectable {
+public class IVectorBase: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.Base? {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -11157,7 +11157,7 @@ internal class IVectorBase: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -11165,7 +11165,7 @@ internal class IVectorBase: test_component.IInspectable {
         return result
     }
 
-    internal func GetViewImpl() throws -> test_component.AnyIVectorView<test_component.Base?>? {
+    open func GetViewImpl() throws -> test_component.AnyIVectorView<test_component.Base?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -11174,7 +11174,7 @@ internal class IVectorBase: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseWrapper.unwrapFrom(abi: result)
     }
 
-    internal func IndexOfImpl(_ value: test_component.Base?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.Base?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, RawPointer(value), &index, &result))
@@ -11182,37 +11182,37 @@ internal class IVectorBase: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func SetAtImpl(_ index: UInt32, _ value: test_component.Base?) throws {
+    open func SetAtImpl(_ index: UInt32, _ value: test_component.Base?) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.SetAt(pThis, index, RawPointer(value)))
         }
     }
 
-    internal func InsertAtImpl(_ index: UInt32, _ value: test_component.Base?) throws {
+    open func InsertAtImpl(_ index: UInt32, _ value: test_component.Base?) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.InsertAt(pThis, index, RawPointer(value)))
         }
     }
 
-    internal func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAtImpl(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    internal func AppendImpl(_ value: test_component.Base?) throws {
+    open func AppendImpl(_ value: test_component.Base?) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Append(pThis, RawPointer(value)))
         }
     }
 
-    internal func RemoveAtEndImpl() throws {
+    open func RemoveAtEndImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    internal func ClearImpl() throws {
+    open func ClearImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -11447,10 +11447,10 @@ internal var __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicVTable: __x
     ReplaceAll: { _, _, _ in return failWith(hr: E_NOTIMPL) }
 )
 typealias __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicBridge>
-internal class IVectorIBasic: test_component.IInspectable {
+public class IVectorIBasic: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    internal func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIBasic? {
+    open func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIBasic? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -11459,7 +11459,7 @@ internal class IVectorIBasic: test_component.IInspectable {
         return __ABI_test_component.IBasicWrapper.unwrapFrom(abi: result)
     }
 
-    internal func get_SizeImpl() throws -> UInt32 {
+    open func get_SizeImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -11467,7 +11467,7 @@ internal class IVectorIBasic: test_component.IInspectable {
         return result
     }
 
-    internal func GetViewImpl() throws -> test_component.AnyIVectorView<test_component.AnyIBasic?>? {
+    open func GetViewImpl() throws -> test_component.AnyIVectorView<test_component.AnyIBasic?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -11476,7 +11476,7 @@ internal class IVectorIBasic: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.unwrapFrom(abi: result)
     }
 
-    internal func IndexOfImpl(_ value: test_component.AnyIBasic?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOfImpl(_ value: test_component.AnyIBasic?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_test_component.IBasicWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -11486,7 +11486,7 @@ internal class IVectorIBasic: test_component.IInspectable {
         return .init(from: result)
     }
 
-    internal func SetAtImpl(_ index: UInt32, _ value: test_component.AnyIBasic?) throws {
+    open func SetAtImpl(_ index: UInt32, _ value: test_component.AnyIBasic?) throws {
         let valueWrapper = __ABI_test_component.IBasicWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
@@ -11494,7 +11494,7 @@ internal class IVectorIBasic: test_component.IInspectable {
         }
     }
 
-    internal func InsertAtImpl(_ index: UInt32, _ value: test_component.AnyIBasic?) throws {
+    open func InsertAtImpl(_ index: UInt32, _ value: test_component.AnyIBasic?) throws {
         let valueWrapper = __ABI_test_component.IBasicWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
@@ -11502,13 +11502,13 @@ internal class IVectorIBasic: test_component.IInspectable {
         }
     }
 
-    internal func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAtImpl(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    internal func AppendImpl(_ value: test_component.AnyIBasic?) throws {
+    open func AppendImpl(_ value: test_component.AnyIBasic?) throws {
         let valueWrapper = __ABI_test_component.IBasicWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
@@ -11516,13 +11516,13 @@ internal class IVectorIBasic: test_component.IInspectable {
         }
     }
 
-    internal func RemoveAtEndImpl() throws {
+    open func RemoveAtEndImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    internal func ClearImpl() throws {
+    open func ClearImpl() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -11669,10 +11669,10 @@ internal var __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableVTable: __
     }
 )
 typealias __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableBridge>
-internal class MapChangedEventHandlerString_Any: test_component.IUnknown {
+public class MapChangedEventHandlerString_Any: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectable }
 
-    internal func InvokeImpl(_ sender: test_component.AnyIObservableMap<String, Any?>?, _ event: test_component.AnyIMapChangedEventArgs<String>?) throws {
+    open func InvokeImpl(_ sender: test_component.AnyIObservableMap<String, Any?>?, _ event: test_component.AnyIMapChangedEventArgs<String>?) throws {
         let senderWrapper = test_component.__x_ABI_C__FIObservableMap_2_HSTRING_IInspectableWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let eventWrapper = test_component.__x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper(event)
@@ -11724,10 +11724,10 @@ internal var __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGVTable: __x_ABI
     }
 )
 typealias __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGBridge>
-internal class MapChangedEventHandlerString_String: test_component.IUnknown {
+public class MapChangedEventHandlerString_String: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRING }
 
-    internal func InvokeImpl(_ sender: test_component.AnyIObservableMap<String, String>?, _ event: test_component.AnyIMapChangedEventArgs<String>?) throws {
+    open func InvokeImpl(_ sender: test_component.AnyIObservableMap<String, String>?, _ event: test_component.AnyIMapChangedEventArgs<String>?) throws {
         let senderWrapper = test_component.__x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let eventWrapper = test_component.__x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper(event)
@@ -11779,10 +11779,10 @@ internal var __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__
     }
 )
 typealias __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseBridge>
-internal class VectorChangedEventHandlerBase: test_component.IUnknown {
+public class VectorChangedEventHandlerBase: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBase }
 
-    internal func InvokeImpl(_ sender: test_component.AnyIObservableVector<test_component.Base?>?, _ event: test_component.AnyIVectorChangedEventArgs?) throws {
+    open func InvokeImpl(_ sender: test_component.AnyIObservableVector<test_component.Base?>?, _ event: test_component.AnyIVectorChangedEventArgs?) throws {
         let senderWrapper = test_component.__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let eventWrapper = __ABI_Windows_Foundation_Collections.IVectorChangedEventArgsWrapper(event)
@@ -11834,10 +11834,10 @@ internal var __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__
     }
 )
 typealias __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicBridge>
-internal class VectorChangedEventHandlerIBasic: test_component.IUnknown {
+public class VectorChangedEventHandlerIBasic: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    internal func InvokeImpl(_ sender: test_component.AnyIObservableVector<test_component.AnyIBasic?>?, _ event: test_component.AnyIVectorChangedEventArgs?) throws {
+    open func InvokeImpl(_ sender: test_component.AnyIObservableVector<test_component.AnyIBasic?>?, _ event: test_component.AnyIVectorChangedEventArgs?) throws {
         let senderWrapper = test_component.__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let eventWrapper = __ABI_Windows_Foundation_Collections.IVectorChangedEventArgsWrapper(event)
@@ -11889,10 +11889,10 @@ internal var __x_ABI_C__FIEventHandler_1_IInspectableVTable: __x_ABI_C__FIEventH
     }
 )
 typealias __x_ABI_C__FIEventHandler_1_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIEventHandler_1_IInspectableBridge>
-internal class EventHandlerAny: test_component.IUnknown {
+public class EventHandlerAny: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIEventHandler_1_IInspectable }
 
-    internal func InvokeImpl(_ sender: Any?, _ args: Any?) throws {
+    open func InvokeImpl(_ sender: Any?, _ args: Any?) throws {
         let senderWrapper = __ABI_.AnyWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let argsWrapper = __ABI_.AnyWrapper(args)
@@ -11991,10 +11991,10 @@ internal var __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleVTable: __x_ABI
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleBridge>
-internal class IAsyncOperationWithProgressInt32_Double: test_component.IInspectable {
+public class IAsyncOperationWithProgressInt32_Double: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgress_2_int_double }
 
-    internal func put_ProgressImpl(_ handler: AsyncOperationProgressHandler<Int32, Double>?) throws {
+    open func put_ProgressImpl(_ handler: AsyncOperationProgressHandler<Int32, Double>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_int_double.self) { pThis in
@@ -12002,7 +12002,7 @@ internal class IAsyncOperationWithProgressInt32_Double: test_component.IInspecta
         }
     }
 
-    internal func get_ProgressImpl() throws -> AsyncOperationProgressHandler<Int32, Double>? {
+    open func get_ProgressImpl() throws -> AsyncOperationProgressHandler<Int32, Double>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_int_double.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Progress(pThis, &resultAbi))
@@ -12011,7 +12011,7 @@ internal class IAsyncOperationWithProgressInt32_Double: test_component.IInspecta
         return test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleWrapper.unwrapFrom(abi: result)
     }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationWithProgressCompletedHandler<Int32, Double>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationWithProgressCompletedHandler<Int32, Double>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_int_double.self) { pThis in
@@ -12019,7 +12019,7 @@ internal class IAsyncOperationWithProgressInt32_Double: test_component.IInspecta
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationWithProgressCompletedHandler<Int32, Double>? {
+    open func get_CompletedImpl() throws -> AsyncOperationWithProgressCompletedHandler<Int32, Double>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_int_double.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12028,7 +12028,7 @@ internal class IAsyncOperationWithProgressInt32_Double: test_component.IInspecta
         return test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> Int32 {
+    open func GetResultsImpl() throws -> Int32 {
         var result: INT32 = 0
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_int_double.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -12182,10 +12182,10 @@ internal var __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32VTable: __x_
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Bridge>
-internal class IAsyncOperationWithProgressUInt32_UInt32: test_component.IInspectable {
+public class IAsyncOperationWithProgressUInt32_UInt32: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32 }
 
-    internal func put_ProgressImpl(_ handler: AsyncOperationProgressHandler<UInt32, UInt32>?) throws {
+    open func put_ProgressImpl(_ handler: AsyncOperationProgressHandler<UInt32, UInt32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32Wrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32.self) { pThis in
@@ -12193,7 +12193,7 @@ internal class IAsyncOperationWithProgressUInt32_UInt32: test_component.IInspect
         }
     }
 
-    internal func get_ProgressImpl() throws -> AsyncOperationProgressHandler<UInt32, UInt32>? {
+    open func get_ProgressImpl() throws -> AsyncOperationProgressHandler<UInt32, UInt32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Progress(pThis, &resultAbi))
@@ -12202,7 +12202,7 @@ internal class IAsyncOperationWithProgressUInt32_UInt32: test_component.IInspect
         return test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32Wrapper.unwrapFrom(abi: result)
     }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationWithProgressCompletedHandler<UInt32, UInt32>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationWithProgressCompletedHandler<UInt32, UInt32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32Wrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32.self) { pThis in
@@ -12210,7 +12210,7 @@ internal class IAsyncOperationWithProgressUInt32_UInt32: test_component.IInspect
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationWithProgressCompletedHandler<UInt32, UInt32>? {
+    open func get_CompletedImpl() throws -> AsyncOperationWithProgressCompletedHandler<UInt32, UInt32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12219,7 +12219,7 @@ internal class IAsyncOperationWithProgressUInt32_UInt32: test_component.IInspect
         return test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32Wrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> UInt32 {
+    open func GetResultsImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -12374,10 +12374,10 @@ internal var __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorag
     }
 )
 typealias __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Bridge>
-internal class IAsyncOperationWithProgressIBuffer_UInt32: test_component.IInspectable {
+public class IAsyncOperationWithProgressIBuffer_UInt32: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32 }
 
-    internal func put_ProgressImpl(_ handler: AsyncOperationProgressHandler<test_component.AnyIBuffer?, UInt32>?) throws {
+    open func put_ProgressImpl(_ handler: AsyncOperationProgressHandler<test_component.AnyIBuffer?, UInt32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
@@ -12385,7 +12385,7 @@ internal class IAsyncOperationWithProgressIBuffer_UInt32: test_component.IInspec
         }
     }
 
-    internal func get_ProgressImpl() throws -> AsyncOperationProgressHandler<test_component.AnyIBuffer?, UInt32>? {
+    open func get_ProgressImpl() throws -> AsyncOperationProgressHandler<test_component.AnyIBuffer?, UInt32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Progress(pThis, &resultAbi))
@@ -12394,7 +12394,7 @@ internal class IAsyncOperationWithProgressIBuffer_UInt32: test_component.IInspec
         return test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper.unwrapFrom(abi: result)
     }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationWithProgressCompletedHandler<test_component.AnyIBuffer?, UInt32>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationWithProgressCompletedHandler<test_component.AnyIBuffer?, UInt32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
@@ -12402,7 +12402,7 @@ internal class IAsyncOperationWithProgressIBuffer_UInt32: test_component.IInspec
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationWithProgressCompletedHandler<test_component.AnyIBuffer?, UInt32>? {
+    open func get_CompletedImpl() throws -> AsyncOperationWithProgressCompletedHandler<test_component.AnyIBuffer?, UInt32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12411,7 +12411,7 @@ internal class IAsyncOperationWithProgressIBuffer_UInt32: test_component.IInspec
         return test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIBuffer? {
+    open func GetResultsImpl() throws -> test_component.AnyIBuffer? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -12551,10 +12551,10 @@ internal var __x_ABI_C__FIAsyncOperation_1_booleanVTable: __x_ABI_C__FIAsyncOper
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1_booleanWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1_booleanBridge>
-internal class IAsyncOperationBool: test_component.IInspectable {
+public class IAsyncOperationBool: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1_boolean }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<Bool>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<Bool>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_boolean.self) { pThis in
@@ -12562,7 +12562,7 @@ internal class IAsyncOperationBool: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<Bool>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<Bool>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_boolean.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12571,7 +12571,7 @@ internal class IAsyncOperationBool: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> Bool {
+    open func GetResultsImpl() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_boolean.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -12703,10 +12703,10 @@ internal var __x_ABI_C__FIAsyncOperation_1_intVTable: __x_ABI_C__FIAsyncOperatio
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1_intWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1_intBridge>
-internal class IAsyncOperationInt32: test_component.IInspectable {
+public class IAsyncOperationInt32: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1_int }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<Int32>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<Int32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_int.self) { pThis in
@@ -12714,7 +12714,7 @@ internal class IAsyncOperationInt32: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<Int32>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<Int32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_int.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12723,7 +12723,7 @@ internal class IAsyncOperationInt32: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> Int32 {
+    open func GetResultsImpl() throws -> Int32 {
         var result: INT32 = 0
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_int.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -12855,10 +12855,10 @@ internal var __x_ABI_C__FIAsyncOperation_1_HSTRINGVTable: __x_ABI_C__FIAsyncOper
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1_HSTRINGBridge>
-internal class IAsyncOperationString: test_component.IInspectable {
+public class IAsyncOperationString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1_HSTRING }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<String>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<String>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_HSTRING.self) { pThis in
@@ -12866,7 +12866,7 @@ internal class IAsyncOperationString: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<String>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12875,7 +12875,7 @@ internal class IAsyncOperationString: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> String {
+    open func GetResultsImpl() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -13007,10 +13007,10 @@ internal var __x_ABI_C__FIAsyncOperation_1_UINT32VTable: __x_ABI_C__FIAsyncOpera
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1_UINT32Wrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1_UINT32Bridge>
-internal class IAsyncOperationUInt32: test_component.IInspectable {
+public class IAsyncOperationUInt32: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1_UINT32 }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<UInt32>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<UInt32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32Wrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_UINT32.self) { pThis in
@@ -13018,7 +13018,7 @@ internal class IAsyncOperationUInt32: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<UInt32>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<UInt32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13027,7 +13027,7 @@ internal class IAsyncOperationUInt32: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32Wrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> UInt32 {
+    open func GetResultsImpl() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_UINT32.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -13160,10 +13160,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectab
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectableBridge>
-internal class IAsyncOperationIMapString_Any: test_component.IInspectable {
+public class IAsyncOperationIMapString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectable }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIMap<String, Any?>?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIMap<String, Any?>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
@@ -13171,7 +13171,7 @@ internal class IAsyncOperationIMapString_Any: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIMap<String, Any?>?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIMap<String, Any?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13180,7 +13180,7 @@ internal class IAsyncOperationIMapString_Any: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIMap<String, Any?>? {
+    open func GetResultsImpl() throws -> test_component.AnyIMap<String, Any?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -13314,10 +13314,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWi
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
-internal class IAsyncOperationIVectorViewIStorageItem: test_component.IInspectable {
+public class IAsyncOperationIVectorViewIStorageItem: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
@@ -13325,7 +13325,7 @@ internal class IAsyncOperationIVectorViewIStorageItem: test_component.IInspectab
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13334,7 +13334,7 @@ internal class IAsyncOperationIVectorViewIStorageItem: test_component.IInspectab
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.AnyIStorageItem?>? {
+    open func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.AnyIStorageItem?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -13468,10 +13468,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWi
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
-internal class IAsyncOperationIVectorViewStorageFile: test_component.IInspectable {
+public class IAsyncOperationIVectorViewStorageFile: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFile?>?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFile?>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
@@ -13479,7 +13479,7 @@ internal class IAsyncOperationIVectorViewStorageFile: test_component.IInspectabl
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13488,7 +13488,7 @@ internal class IAsyncOperationIVectorViewStorageFile: test_component.IInspectabl
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.StorageFile?>? {
+    open func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.StorageFile?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -13622,10 +13622,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWi
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
-internal class IAsyncOperationIVectorViewStorageFolder: test_component.IInspectable {
+public class IAsyncOperationIVectorViewStorageFolder: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFolder?>?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFolder?>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
@@ -13633,7 +13633,7 @@ internal class IAsyncOperationIVectorViewStorageFolder: test_component.IInspecta
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13642,7 +13642,7 @@ internal class IAsyncOperationIVectorViewStorageFolder: test_component.IInspecta
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.StorageFolder?>? {
+    open func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.StorageFolder?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -13776,10 +13776,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWi
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge>
-internal class IAsyncOperationIVectorViewStorageLibraryChange: test_component.IInspectable {
+public class IAsyncOperationIVectorViewStorageLibraryChange: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
@@ -13787,7 +13787,7 @@ internal class IAsyncOperationIVectorViewStorageLibraryChange: test_component.II
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13796,7 +13796,7 @@ internal class IAsyncOperationIVectorViewStorageLibraryChange: test_component.II
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.StorageLibraryChange?>? {
+    open func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.StorageLibraryChange?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -13930,10 +13930,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGVTable: 
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGBridge>
-internal class IAsyncOperationIVectorString: test_component.IInspectable {
+public class IAsyncOperationIVectorString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRING }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVector<String>?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVector<String>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRINGWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRING.self) { pThis in
@@ -13941,7 +13941,7 @@ internal class IAsyncOperationIVectorString: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVector<String>?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVector<String>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13950,7 +13950,7 @@ internal class IAsyncOperationIVectorString: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIVector<String>? {
+    open func GetResultsImpl() throws -> test_component.AnyIVector<String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14083,10 +14083,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesBridge>
-internal class IAsyncOperationBasicProperties: test_component.IInspectable {
+public class IAsyncOperationBasicProperties: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.BasicProperties?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.BasicProperties?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties.self) { pThis in
@@ -14094,7 +14094,7 @@ internal class IAsyncOperationBasicProperties: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.BasicProperties?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.BasicProperties?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14103,7 +14103,7 @@ internal class IAsyncOperationBasicProperties: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.BasicProperties? {
+    open func GetResultsImpl() throws -> test_component.BasicProperties? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14236,10 +14236,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesBridge>
-internal class IAsyncOperationDocumentProperties: test_component.IInspectable {
+public class IAsyncOperationDocumentProperties: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.DocumentProperties?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.DocumentProperties?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties.self) { pThis in
@@ -14247,7 +14247,7 @@ internal class IAsyncOperationDocumentProperties: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.DocumentProperties?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.DocumentProperties?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14256,7 +14256,7 @@ internal class IAsyncOperationDocumentProperties: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.DocumentProperties? {
+    open func GetResultsImpl() throws -> test_component.DocumentProperties? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14389,10 +14389,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesBridge>
-internal class IAsyncOperationImageProperties: test_component.IInspectable {
+public class IAsyncOperationImageProperties: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.ImageProperties?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.ImageProperties?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties.self) { pThis in
@@ -14400,7 +14400,7 @@ internal class IAsyncOperationImageProperties: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.ImageProperties?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.ImageProperties?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14409,7 +14409,7 @@ internal class IAsyncOperationImageProperties: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.ImageProperties? {
+    open func GetResultsImpl() throws -> test_component.ImageProperties? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14542,10 +14542,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesBridge>
-internal class IAsyncOperationMusicProperties: test_component.IInspectable {
+public class IAsyncOperationMusicProperties: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.MusicProperties?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.MusicProperties?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties.self) { pThis in
@@ -14553,7 +14553,7 @@ internal class IAsyncOperationMusicProperties: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.MusicProperties?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.MusicProperties?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14562,7 +14562,7 @@ internal class IAsyncOperationMusicProperties: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.MusicProperties? {
+    open func GetResultsImpl() throws -> test_component.MusicProperties? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14695,10 +14695,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailBridge>
-internal class IAsyncOperationStorageItemThumbnail: test_component.IInspectable {
+public class IAsyncOperationStorageItemThumbnail: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageItemThumbnail?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageItemThumbnail?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail.self) { pThis in
@@ -14706,7 +14706,7 @@ internal class IAsyncOperationStorageItemThumbnail: test_component.IInspectable 
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageItemThumbnail?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageItemThumbnail?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14715,7 +14715,7 @@ internal class IAsyncOperationStorageItemThumbnail: test_component.IInspectable 
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.StorageItemThumbnail? {
+    open func GetResultsImpl() throws -> test_component.StorageItemThumbnail? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14848,10 +14848,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProp
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesBridge>
-internal class IAsyncOperationVideoProperties: test_component.IInspectable {
+public class IAsyncOperationVideoProperties: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.VideoProperties?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.VideoProperties?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties.self) { pThis in
@@ -14859,7 +14859,7 @@ internal class IAsyncOperationVideoProperties: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.VideoProperties?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.VideoProperties?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14868,7 +14868,7 @@ internal class IAsyncOperationVideoProperties: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.VideoProperties? {
+    open func GetResultsImpl() throws -> test_component.VideoProperties? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15002,10 +15002,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorage
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItemBridge>
-internal class IAsyncOperationIStorageItem: test_component.IInspectable {
+public class IAsyncOperationIStorageItem: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIStorageItem?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIStorageItem?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
@@ -15013,7 +15013,7 @@ internal class IAsyncOperationIStorageItem: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIStorageItem?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIStorageItem?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15022,7 +15022,7 @@ internal class IAsyncOperationIStorageItem: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIStorageItem? {
+    open func GetResultsImpl() throws -> test_component.AnyIStorageItem? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15155,10 +15155,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateBridge>
-internal class IAsyncOperationIndexedState: test_component.IInspectable {
+public class IAsyncOperationIndexedState: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.IndexedState>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.IndexedState>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState.self) { pThis in
@@ -15166,7 +15166,7 @@ internal class IAsyncOperationIndexedState: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.IndexedState>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.IndexedState>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15175,7 +15175,7 @@ internal class IAsyncOperationIndexedState: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.IndexedState {
+    open func GetResultsImpl() throws -> test_component.IndexedState {
         var result: __x_ABI_CWindows_CStorage_CSearch_CIndexedState = .init(0)
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -15307,10 +15307,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageF
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileBridge>
-internal class IAsyncOperationStorageFile: test_component.IInspectable {
+public class IAsyncOperationStorageFile: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageFile?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageFile?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
@@ -15318,7 +15318,7 @@ internal class IAsyncOperationStorageFile: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageFile?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageFile?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15327,7 +15327,7 @@ internal class IAsyncOperationStorageFile: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.StorageFile? {
+    open func GetResultsImpl() throws -> test_component.StorageFile? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15460,10 +15460,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageF
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderBridge>
-internal class IAsyncOperationStorageFolder: test_component.IInspectable {
+public class IAsyncOperationStorageFolder: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageFolder?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageFolder?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
@@ -15471,7 +15471,7 @@ internal class IAsyncOperationStorageFolder: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageFolder?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageFolder?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15480,7 +15480,7 @@ internal class IAsyncOperationStorageFolder: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.StorageFolder? {
+    open func GetResultsImpl() throws -> test_component.StorageFolder? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15613,10 +15613,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageS
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionBridge>
-internal class IAsyncOperationStorageStreamTransaction: test_component.IInspectable {
+public class IAsyncOperationStorageStreamTransaction: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageStreamTransaction?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageStreamTransaction?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction.self) { pThis in
@@ -15624,7 +15624,7 @@ internal class IAsyncOperationStorageStreamTransaction: test_component.IInspecta
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageStreamTransaction?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageStreamTransaction?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15633,7 +15633,7 @@ internal class IAsyncOperationStorageStreamTransaction: test_component.IInspecta
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.StorageStreamTransaction? {
+    open func GetResultsImpl() throws -> test_component.StorageStreamTransaction? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15767,10 +15767,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams_
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferBridge>
-internal class IAsyncOperationIBuffer: test_component.IInspectable {
+public class IAsyncOperationIBuffer: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIBuffer?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIBuffer?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer.self) { pThis in
@@ -15778,7 +15778,7 @@ internal class IAsyncOperationIBuffer: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIBuffer?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIBuffer?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15787,7 +15787,7 @@ internal class IAsyncOperationIBuffer: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIBuffer? {
+    open func GetResultsImpl() throws -> test_component.AnyIBuffer? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15921,10 +15921,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams_
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamBridge>
-internal class IAsyncOperationIInputStream: test_component.IInspectable {
+public class IAsyncOperationIInputStream: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIInputStream?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIInputStream?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream.self) { pThis in
@@ -15932,7 +15932,7 @@ internal class IAsyncOperationIInputStream: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIInputStream?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIInputStream?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15941,7 +15941,7 @@ internal class IAsyncOperationIInputStream: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIInputStream? {
+    open func GetResultsImpl() throws -> test_component.AnyIInputStream? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -16075,10 +16075,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams_
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamBridge>
-internal class IAsyncOperationIRandomAccessStream: test_component.IInspectable {
+public class IAsyncOperationIRandomAccessStream: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStream?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStream?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream.self) { pThis in
@@ -16086,7 +16086,7 @@ internal class IAsyncOperationIRandomAccessStream: test_component.IInspectable {
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStream?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStream?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -16095,7 +16095,7 @@ internal class IAsyncOperationIRandomAccessStream: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIRandomAccessStream? {
+    open func GetResultsImpl() throws -> test_component.AnyIRandomAccessStream? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -16229,10 +16229,10 @@ internal var __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams_
     }
 )
 typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeBridge>
-internal class IAsyncOperationIRandomAccessStreamWithContentType: test_component.IInspectable {
+public class IAsyncOperationIRandomAccessStreamWithContentType: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType }
 
-    internal func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStreamWithContentType?>?) throws {
+    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStreamWithContentType?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType.self) { pThis in
@@ -16240,7 +16240,7 @@ internal class IAsyncOperationIRandomAccessStreamWithContentType: test_component
         }
     }
 
-    internal func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStreamWithContentType?>? {
+    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStreamWithContentType?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -16249,7 +16249,7 @@ internal class IAsyncOperationIRandomAccessStreamWithContentType: test_component
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeWrapper.unwrapFrom(abi: result)
     }
 
-    internal func GetResultsImpl() throws -> test_component.AnyIRandomAccessStreamWithContentType? {
+    open func GetResultsImpl() throws -> test_component.AnyIRandomAccessStreamWithContentType? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -16582,10 +16582,10 @@ internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__CIM
     }
 )
 typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__CIMemoryBufferReference_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__CIMemoryBufferReference_IInspectableBridge>
-internal class TypedEventHandlerIMemoryBufferReference_Any: test_component.IUnknown {
+public class TypedEventHandlerIMemoryBufferReference_Any: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__CIMemoryBufferReference_IInspectable }
 
-    internal func InvokeImpl(_ sender: test_component.AnyIMemoryBufferReference?, _ args: Any?) throws {
+    open func InvokeImpl(_ sender: test_component.AnyIMemoryBufferReference?, _ args: Any?) throws {
         let senderWrapper = __ABI_Windows_Foundation.IMemoryBufferReferenceWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let argsWrapper = __ABI_.AnyWrapper(args)
@@ -16637,10 +16637,10 @@ internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearc
     }
 )
 typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearch__CIStorageQueryResultBase_IInspectableWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearch__CIStorageQueryResultBase_IInspectableBridge>
-internal class TypedEventHandlerIStorageQueryResultBase_Any: test_component.IUnknown {
+public class TypedEventHandlerIStorageQueryResultBase_Any: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearch__CIStorageQueryResultBase_IInspectable }
 
-    internal func InvokeImpl(_ sender: test_component.AnyIStorageQueryResultBase?, _ args: Any?) throws {
+    open func InvokeImpl(_ sender: test_component.AnyIStorageQueryResultBase?, _ args: Any?) throws {
         let senderWrapper = __ABI_Windows_Storage_Search.IStorageQueryResultBaseWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let argsWrapper = __ABI_.AnyWrapper(args)
@@ -16692,10 +16692,10 @@ internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass_
     }
 )
 typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsBridge>
-internal class TypedEventHandlerClass_DeferrableEventArgs: test_component.IUnknown {
+public class TypedEventHandlerClass_DeferrableEventArgs: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgs }
 
-    internal func InvokeImpl(_ sender: test_component.Class?, _ args: test_component.DeferrableEventArgs?) throws {
+    open func InvokeImpl(_ sender: test_component.Class?, _ args: test_component.DeferrableEventArgs?) throws {
         _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgs.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
         }
@@ -16743,10 +16743,10 @@ internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple
     }
 )
 typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsWrapper = InterfaceWrapperBase<test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsBridge>
-internal class TypedEventHandlerSimple_SimpleEventArgs: test_component.IUnknown {
+public class TypedEventHandlerSimple_SimpleEventArgs: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgs }
 
-    internal func InvokeImpl(_ sender: test_component.Simple?, _ args: test_component.SimpleEventArgs) throws {
+    open func InvokeImpl(_ sender: test_component.Simple?, _ args: test_component.SimpleEventArgs) throws {
         _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgs.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), .from(swift: args)))
         }

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Ctest_component
 
+@_spi(WinRTInternal)
 public enum __IMPL_test_component {
     public enum IAsyncMethodsWithProgressBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_Ctest__component_CIAsyncMethodsWithProgress

--- a/tests/test_component/Sources/test_component/test_component.Delegates+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+ABI.swift
@@ -19,6 +19,7 @@ private var IID___x_ABI_Ctest__component_CDelegates_CISignalDelegate: test_compo
     .init(Data1: 0x9EA7161A, Data2: 0xFCAB, Data3: 0x5037, Data4: ( 0x87,0xF0,0xB5,0x73,0xA5,0xE9,0x7B,0xE9 ))// 9EA7161A-FCAB-5037-87F0-B573A5E97BE9
 }
 
+@_spi(WinRTInternal)
 public enum __ABI_test_component_Delegates {
 }
 // MARK - InDelegate

--- a/tests/test_component/Sources/test_component/test_component.Delegates+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+Impl.swift
@@ -3,6 +3,7 @@
 import Foundation
 import Ctest_component
 
+@_spi(WinRTInternal)
 public enum __IMPL_test_component_Delegates {
     public class InDelegateBridge : WinRTDelegateBridge {
         public typealias Handler = InDelegate

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -159,17 +159,19 @@ open class Base : WinRTClass {
         try _IBaseOverrides.OnDoTheThingImpl()
     }
 
-    internal enum IBaseOverrides : ComposableImpl {
-        internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
-        internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        internal typealias Class = Base
-        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
-        internal enum Default : AbiInterface {
-            internal typealias CABI = __x_ABI_Ctest__component_CIBase
-            internal typealias SwiftABI = __ABI_test_component.IBase
+    @_spi(WinRTInternal)
+        public enum IBaseOverrides : ComposableImpl {
+        public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
+        public typealias SwiftABI = __ABI_test_component.IBaseOverrides
+        public typealias Class = Base
+        public typealias SwiftProjection = WinRTClassWeakReference<Class>
+        public enum Default : AbiInterface {
+            public typealias CABI = __x_ABI_Ctest__component_CIBase
+            public typealias SwiftABI = __ABI_test_component.IBase
         }
     }
-    internal typealias Composable = IBaseOverrides
+    @_spi(WinRTInternal)
+    public typealias Composable = IBaseOverrides
     deinit {
         _default = nil
         _IBaseOverrides = nil
@@ -296,17 +298,19 @@ open class BaseCollection : WinRTClass, IVector, IIterable {
         try! _IIterable.FirstImpl()
     }
 
-    internal enum IVectorBase : ComposableImpl {
-        internal typealias CABI = C_IInspectable
-        internal typealias SwiftABI = test_component.IInspectable
-        internal typealias Class = BaseCollection
-        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
-        internal enum Default : AbiInterface {
-            internal typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase
-            internal typealias SwiftABI = test_component.IVectorBase
+    @_spi(WinRTInternal)
+        public enum IVectorBase : ComposableImpl {
+        public typealias CABI = C_IInspectable
+        public typealias SwiftABI = test_component.IInspectable
+        public typealias Class = BaseCollection
+        public typealias SwiftProjection = WinRTClassWeakReference<Class>
+        public enum Default : AbiInterface {
+            public typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase
+            public typealias SwiftABI = test_component.IVectorBase
         }
     }
-    internal typealias Composable = IVectorBase
+    @_spi(WinRTInternal)
+    public typealias Composable = IVectorBase
     deinit {
         _default = nil
         _IIterable = nil
@@ -429,17 +433,19 @@ open class BaseNoOverrides : WinRTClass {
         return try _IBaseNoOverridesStatics.CreateFromStringImpl(value)
     }
 
-    internal enum IBaseNoOverrides : ComposableImpl {
-        internal typealias CABI = C_IInspectable
-        internal typealias SwiftABI = test_component.IInspectable
-        internal typealias Class = BaseNoOverrides
-        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
-        internal enum Default : AbiInterface {
-            internal typealias CABI = __x_ABI_Ctest__component_CIBaseNoOverrides
-            internal typealias SwiftABI = __ABI_test_component.IBaseNoOverrides
+    @_spi(WinRTInternal)
+        public enum IBaseNoOverrides : ComposableImpl {
+        public typealias CABI = C_IInspectable
+        public typealias SwiftABI = test_component.IInspectable
+        public typealias Class = BaseNoOverrides
+        public typealias SwiftProjection = WinRTClassWeakReference<Class>
+        public enum Default : AbiInterface {
+            public typealias CABI = __x_ABI_Ctest__component_CIBaseNoOverrides
+            public typealias SwiftABI = __ABI_test_component.IBaseNoOverrides
         }
     }
-    internal typealias Composable = IBaseNoOverrides
+    @_spi(WinRTInternal)
+    public typealias Composable = IBaseNoOverrides
     deinit {
         _default = nil
     }
@@ -953,17 +959,19 @@ public final class Derived : test_component.Base {
         set { try! _default.put_PropImpl(newValue) }
     }
 
-    internal enum IBaseOverrides : ComposableImpl {
-        internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
-        internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        internal typealias Class = Derived
-        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
-        internal enum Default : AbiInterface {
-            internal typealias CABI = __x_ABI_Ctest__component_CIDerived
-            internal typealias SwiftABI = __ABI_test_component.IDerived
+    @_spi(WinRTInternal)
+        public enum IBaseOverrides : ComposableImpl {
+        public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
+        public typealias SwiftABI = __ABI_test_component.IBaseOverrides
+        public typealias Class = Derived
+        public typealias SwiftProjection = WinRTClassWeakReference<Class>
+        public enum Default : AbiInterface {
+            public typealias CABI = __x_ABI_Ctest__component_CIDerived
+            public typealias SwiftABI = __ABI_test_component.IDerived
         }
     }
-    internal typealias Composable = IBaseOverrides
+    @_spi(WinRTInternal)
+    public typealias Composable = IBaseOverrides
     deinit {
         _default = nil
     }
@@ -996,17 +1004,19 @@ public final class DerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
         try _default.MethodImpl()
     }
 
-    internal enum IBaseOverrides : ComposableImpl {
-        internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
-        internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        internal typealias Class = DerivedFromNoConstructor
-        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
-        internal enum Default : AbiInterface {
-            internal typealias CABI = __x_ABI_Ctest__component_CIDerivedFromNoConstructor
-            internal typealias SwiftABI = __ABI_test_component.IDerivedFromNoConstructor
+    @_spi(WinRTInternal)
+        public enum IBaseOverrides : ComposableImpl {
+        public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
+        public typealias SwiftABI = __ABI_test_component.IBaseOverrides
+        public typealias Class = DerivedFromNoConstructor
+        public typealias SwiftProjection = WinRTClassWeakReference<Class>
+        public enum Default : AbiInterface {
+            public typealias CABI = __x_ABI_Ctest__component_CIDerivedFromNoConstructor
+            public typealias SwiftABI = __ABI_test_component.IDerivedFromNoConstructor
         }
     }
-    internal typealias Composable = IBaseOverrides
+    @_spi(WinRTInternal)
+    public typealias Composable = IBaseOverrides
     deinit {
         _default = nil
     }
@@ -1382,30 +1392,33 @@ open class UnsealedDerived : test_component.Base {
         try _IUnsealedDerivedOverloads2.OnAfterDoTheThingImpl()
     }
 
-    internal enum IUnsealedDerivedOverloads2 : ComposableImpl {
-        internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
-        internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
-        internal typealias Class = UnsealedDerived
-        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
-        internal enum Default : AbiInterface {
-            internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
-            internal typealias SwiftABI = __ABI_test_component.IUnsealedDerived
+    @_spi(WinRTInternal)
+        public enum IUnsealedDerivedOverloads2 : ComposableImpl {
+        public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
+        public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
+        public typealias Class = UnsealedDerived
+        public typealias SwiftProjection = WinRTClassWeakReference<Class>
+        public enum Default : AbiInterface {
+            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
+            public typealias SwiftABI = __ABI_test_component.IUnsealedDerived
         }
     }
-    internal typealias Composable = IUnsealedDerivedOverloads2
+    @_spi(WinRTInternal)
+    public typealias Composable = IUnsealedDerivedOverloads2
     private lazy var _IUnsealedDerivedOverrides: __ABI_test_component.IUnsealedDerivedOverrides! = getInterfaceForCaching()
     open func onBeforeDoTheThing() throws {
         try _IUnsealedDerivedOverrides.OnBeforeDoTheThingImpl()
     }
 
-    internal enum IUnsealedDerivedOverrides : ComposableImpl {
-        internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverrides
-        internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverrides
-        internal typealias Class = UnsealedDerived
-        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
-        internal enum Default : AbiInterface {
-            internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
-            internal typealias SwiftABI = __ABI_test_component.IUnsealedDerived
+    @_spi(WinRTInternal)
+        public enum IUnsealedDerivedOverrides : ComposableImpl {
+        public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverrides
+        public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverrides
+        public typealias Class = UnsealedDerived
+        public typealias SwiftProjection = WinRTClassWeakReference<Class>
+        public enum Default : AbiInterface {
+            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
+            public typealias SwiftABI = __ABI_test_component.IUnsealedDerived
         }
     }
     deinit {
@@ -1468,17 +1481,19 @@ open class UnsealedDerived2 : test_component.UnsealedDerived {
         try _default.MethodImpl()
     }
 
-    internal enum IUnsealedDerivedOverloads2 : ComposableImpl {
-        internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
-        internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
-        internal typealias Class = UnsealedDerived2
-        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
-        internal enum Default : AbiInterface {
-            internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived2
-            internal typealias SwiftABI = __ABI_test_component.IUnsealedDerived2
+    @_spi(WinRTInternal)
+        public enum IUnsealedDerivedOverloads2 : ComposableImpl {
+        public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
+        public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
+        public typealias Class = UnsealedDerived2
+        public typealias SwiftProjection = WinRTClassWeakReference<Class>
+        public enum Default : AbiInterface {
+            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived2
+            public typealias SwiftABI = __ABI_test_component.IUnsealedDerived2
         }
     }
-    internal typealias Composable = IUnsealedDerivedOverloads2
+    @_spi(WinRTInternal)
+    public typealias Composable = IUnsealedDerivedOverloads2
     deinit {
         _default = nil
     }
@@ -1525,17 +1540,19 @@ open class UnsealedDerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
         }
     }
 
-    internal enum IBaseOverrides : ComposableImpl {
-        internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
-        internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        internal typealias Class = UnsealedDerivedFromNoConstructor
-        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
-        internal enum Default : AbiInterface {
-            internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor
-            internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedFromNoConstructor
+    @_spi(WinRTInternal)
+        public enum IBaseOverrides : ComposableImpl {
+        public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
+        public typealias SwiftABI = __ABI_test_component.IBaseOverrides
+        public typealias Class = UnsealedDerivedFromNoConstructor
+        public typealias SwiftProjection = WinRTClassWeakReference<Class>
+        public enum Default : AbiInterface {
+            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor
+            public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedFromNoConstructor
         }
     }
-    internal typealias Composable = IBaseOverrides
+    @_spi(WinRTInternal)
+    public typealias Composable = IBaseOverrides
     deinit {
         _default = nil
     }
@@ -1576,17 +1593,19 @@ open class UnsealedDerivedNoConstructor : test_component.Base {
     }
     private static var _IUnsealedDerivedNoConstructorFactory : __ABI_test_component.IUnsealedDerivedNoConstructorFactory =  try! RoGetActivationFactory("test_component.UnsealedDerivedNoConstructor")
 
-    internal enum IBaseOverrides : ComposableImpl {
-        internal typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
-        internal typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        internal typealias Class = UnsealedDerivedNoConstructor
-        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
-        internal enum Default : AbiInterface {
-            internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor
-            internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoConstructor
+    @_spi(WinRTInternal)
+        public enum IBaseOverrides : ComposableImpl {
+        public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
+        public typealias SwiftABI = __ABI_test_component.IBaseOverrides
+        public typealias Class = UnsealedDerivedNoConstructor
+        public typealias SwiftProjection = WinRTClassWeakReference<Class>
+        public enum Default : AbiInterface {
+            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor
+            public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoConstructor
         }
     }
-    internal typealias Composable = IBaseOverrides
+    @_spi(WinRTInternal)
+    public typealias Composable = IBaseOverrides
     deinit {
         _default = nil
     }
@@ -1633,17 +1652,19 @@ open class UnsealedDerivedNoOverrides : test_component.BaseNoOverrides {
         }
     }
 
-    internal enum IUnsealedDerivedNoOverrides : ComposableImpl {
-        internal typealias CABI = C_IInspectable
-        internal typealias SwiftABI = test_component.IInspectable
-        internal typealias Class = UnsealedDerivedNoOverrides
-        internal typealias SwiftProjection = WinRTClassWeakReference<Class>
-        internal enum Default : AbiInterface {
-            internal typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides
-            internal typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoOverrides
+    @_spi(WinRTInternal)
+        public enum IUnsealedDerivedNoOverrides : ComposableImpl {
+        public typealias CABI = C_IInspectable
+        public typealias SwiftABI = test_component.IInspectable
+        public typealias Class = UnsealedDerivedNoOverrides
+        public typealias SwiftProjection = WinRTClassWeakReference<Class>
+        public enum Default : AbiInterface {
+            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides
+            public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoOverrides
         }
     }
-    internal typealias Composable = IUnsealedDerivedNoOverrides
+    @_spi(WinRTInternal)
+    public typealias Composable = IUnsealedDerivedNoOverrides
     deinit {
         _default = nil
     }


### PR DESCRIPTION
this pr makes the internals public, since it doesn't affect the export count on debug builds and puts them all behind `@_spi(WinRTInternal)`. this will make it easier to fall back to something like this for accessing the throwing set/get of properties

```
let abi: __ABI_Microsoft_UI_Xaml.IFoo = try swift.thisPtr.QueryInterface()
let foo = try abi.get_Foo()
```