### PR TITLE
remove impl from ABI names

### DIFF
--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -411,7 +411,7 @@ namespace swiftwinrt
                     written_params.append(w.write_temp("_ baseInterface: UnsealedWinRTClassWrapper<%.Composable>?, _ innerInterface: inout %.IInspectable?", classType, w.support));
                 }
 
-                w.write("% func %Impl(%) throws% {\n",
+                w.write("% func %(%) throws% {\n",
                     is_exclusive(type) ? "public" : "open",
                     func_name,
                     written_params,
@@ -1732,7 +1732,7 @@ vtable);
 
         auto swift_name = get_swift_name(factory);
         auto return_name = method.return_type.value().name;
-        auto func_call = w.write_temp("try! Self.%.%Impl(%)",
+        auto func_call = w.write_temp("try! Self.%.%(%)",
             swift_name,
             func_name,
             bind<write_implementation_args>(method));
@@ -2022,7 +2022,7 @@ public init<Composable: ComposableImpl>(
                             w.write("super.init()\n");
                             w.write("MakeComposed(composing: Self.Composable.self, self) { baseInterface, innerInterface in \n");
                         }
-                        w.write("    try! Self.%.%Impl(%)\n",
+                        w.write("    try! Self.%.%(%)\n",
                             get_swift_name(factory_info),
                             func_name,
                             bind<write_implementation_args>(method));
@@ -2086,7 +2086,7 @@ public init<Composable: ComposableImpl>(
         std::string_view func_name = get_abi_name(function);
         auto impl = get_swift_name(iface);
         auto try_flavor = is_noexcept ? "try!" : "try";
-        w.write("% %.%Impl(%)\n",
+        w.write("% %.%(%)\n",
             try_flavor,
             impl,
             func_name,
@@ -2157,7 +2157,7 @@ public init<Composable: ComposableImpl>(
                 get_swift_name(prop),
                 bind<write_type>(*prop.getter->return_type->type, swift_write_type_params_for(*iface.type)));
 
-            w.write("    get { try! %.%Impl() }\n",
+            w.write("    get { try! %.%() }\n",
                 impl,
                 get_swift_name(prop.getter.value()));
 
@@ -2165,7 +2165,7 @@ public init<Composable: ComposableImpl>(
             // right now require that both getter and setter are defined in the same version
             if (prop.setter)
             {
-                w.write("    set { try! %.%Impl(newValue) }\n", impl, get_swift_name(prop.setter.value()));
+                w.write("    set { try! %.%(newValue) }\n", impl, get_swift_name(prop.setter.value()));
 
             }
             w.write("}\n\n");
@@ -2206,10 +2206,10 @@ public init<Composable: ComposableImpl>(
   .init(
     add: { [weak self] in
       guard let this = self?.% else { return .init() }
-      return try! this.add_%Impl($0)
+      return try! this.add_%($0)
     },
     remove: { [weak self] in
-     try? self?.%.remove_%Impl($0)
+     try? self?.%.remove_%($0)
    }
   )
 }()
@@ -2218,8 +2218,8 @@ public init<Composable: ComposableImpl>(
 
         auto static_format = R"(%var % : Event<%> = {
   .init(
-    add: { try! %.add_%Impl($0) },
-    remove: { try? %.remove_%Impl($0) }
+    add: { try! %.add_%($0) },
+    remove: { try? %.remove_%($0) }
   )
 }()
 
@@ -2262,7 +2262,7 @@ public init<Composable: ComposableImpl>(
         {
             w.write("return ");
         }
-        w.write("try _%.%Impl(%)\n",
+        w.write("try _%.%(%)\n",
             statics.swift_type_name(),
             func_name,
             bind<write_implementation_args>(method));

--- a/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
@@ -116,7 +116,7 @@ public enum __ABI_Windows_Foundation {
     public class IAsyncAction: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIAsyncAction }
 
-        open func put_CompletedImpl(_ handler: test_component.AsyncActionCompletedHandler?) throws {
+        open func put_Completed(_ handler: test_component.AsyncActionCompletedHandler?) throws {
             let handlerWrapper = __ABI_Windows_Foundation.AsyncActionCompletedHandlerWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIAsyncAction.self) { pThis in
@@ -124,7 +124,7 @@ public enum __ABI_Windows_Foundation {
             }
         }
 
-        open func get_CompletedImpl() throws -> test_component.AsyncActionCompletedHandler? {
+        open func get_Completed() throws -> test_component.AsyncActionCompletedHandler? {
             let (handler) = try ComPtrs.initialize { handlerAbi in
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIAsyncAction.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &handlerAbi))
@@ -133,7 +133,7 @@ public enum __ABI_Windows_Foundation {
             return __ABI_Windows_Foundation.AsyncActionCompletedHandlerWrapper.unwrapFrom(abi: handler)
         }
 
-        open func GetResultsImpl() throws {
+        open func GetResults() throws {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIAsyncAction.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis))
             }
@@ -198,7 +198,7 @@ public enum __ABI_Windows_Foundation {
     public class IAsyncInfo: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIAsyncInfo }
 
-        open func get_IdImpl() throws -> UInt32 {
+        open func get_Id() throws -> UInt32 {
             var result: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIAsyncInfo.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Id(pThis, &result))
@@ -206,7 +206,7 @@ public enum __ABI_Windows_Foundation {
             return result
         }
 
-        open func get_StatusImpl() throws -> test_component.AsyncStatus {
+        open func get_Status() throws -> test_component.AsyncStatus {
             var result: __x_ABI_CWindows_CFoundation_CAsyncStatus = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIAsyncInfo.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Status(pThis, &result))
@@ -214,7 +214,7 @@ public enum __ABI_Windows_Foundation {
             return result
         }
 
-        open func get_ErrorCodeImpl() throws -> HRESULT {
+        open func get_ErrorCode() throws -> HRESULT {
             var result: HRESULT = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIAsyncInfo.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ErrorCode(pThis, &result))
@@ -222,13 +222,13 @@ public enum __ABI_Windows_Foundation {
             return result
         }
 
-        open func CancelImpl() throws {
+        open func Cancel() throws {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIAsyncInfo.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Cancel(pThis))
             }
         }
 
-        open func CloseImpl() throws {
+        open func Close() throws {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIAsyncInfo.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Close(pThis))
             }
@@ -306,7 +306,7 @@ public enum __ABI_Windows_Foundation {
     public class IClosable: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIClosable }
 
-        open func CloseImpl() throws {
+        open func Close() throws {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIClosable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Close(pThis))
             }
@@ -355,7 +355,7 @@ public enum __ABI_Windows_Foundation {
     public class IDeferral: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIDeferral }
 
-        public func CompleteImpl() throws {
+        public func Complete() throws {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIDeferral.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Complete(pThis))
             }
@@ -366,7 +366,7 @@ public enum __ABI_Windows_Foundation {
     public class IDeferralFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIDeferralFactory }
 
-        public func CreateImpl(_ handler: test_component.DeferralCompletedHandler?) throws -> IDeferral {
+        public func Create(_ handler: test_component.DeferralCompletedHandler?) throws -> IDeferral {
             let (result) = try ComPtrs.initialize { resultAbi in
                 let handlerWrapper = __ABI_Windows_Foundation.DeferralCompletedHandlerWrapper(handler)
                 let _handler = try! handlerWrapper?.toABI { $0 }
@@ -382,7 +382,7 @@ public enum __ABI_Windows_Foundation {
     public class IMemoryBuffer: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIMemoryBuffer }
 
-        open func CreateReferenceImpl() throws -> test_component.AnyIMemoryBufferReference? {
+        open func CreateReference() throws -> test_component.AnyIMemoryBufferReference? {
             let (reference) = try ComPtrs.initialize { referenceAbi in
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIMemoryBuffer.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateReference(pThis, &referenceAbi))
@@ -437,7 +437,7 @@ public enum __ABI_Windows_Foundation {
     public class IMemoryBufferFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIMemoryBufferFactory }
 
-        public func CreateImpl(_ capacity: UInt32) throws -> IMemoryBuffer {
+        public func Create(_ capacity: UInt32) throws -> IMemoryBuffer {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIMemoryBufferFactory.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Create(pThis, capacity, &valueAbi))
@@ -451,7 +451,7 @@ public enum __ABI_Windows_Foundation {
     public class IMemoryBufferReference: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIMemoryBufferReference }
 
-        open func get_CapacityImpl() throws -> UInt32 {
+        open func get_Capacity() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIMemoryBufferReference.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Capacity(pThis, &value))
@@ -459,7 +459,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        open func add_ClosedImpl(_ handler: TypedEventHandler<test_component.AnyIMemoryBufferReference?, Any?>?) throws -> EventRegistrationToken {
+        open func add_Closed(_ handler: TypedEventHandler<test_component.AnyIMemoryBufferReference?, Any?>?) throws -> EventRegistrationToken {
             var cookie: EventRegistrationToken = .init()
             let handlerWrapper = test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__CIMemoryBufferReference_IInspectableWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -469,7 +469,7 @@ public enum __ABI_Windows_Foundation {
             return cookie
         }
 
-        open func remove_ClosedImpl(_ cookie: EventRegistrationToken) throws {
+        open func remove_Closed(_ cookie: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIMemoryBufferReference.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_Closed(pThis, cookie))
             }
@@ -534,7 +534,7 @@ public enum __ABI_Windows_Foundation {
     public class IPropertyValue: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIPropertyValue }
 
-        open func get_TypeImpl() throws -> test_component.PropertyType {
+        open func get_Type() throws -> test_component.PropertyType {
             var value: __x_ABI_CWindows_CFoundation_CPropertyType = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Type(pThis, &value))
@@ -542,7 +542,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        open func get_IsNumericScalarImpl() throws -> Bool {
+        open func get_IsNumericScalar() throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsNumericScalar(pThis, &value))
@@ -550,7 +550,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        open func GetUInt8Impl() throws -> UInt8 {
+        open func GetUInt8() throws -> UInt8 {
             var value: UINT8 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetUInt8(pThis, &value))
@@ -558,7 +558,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        open func GetInt16Impl() throws -> Int16 {
+        open func GetInt16() throws -> Int16 {
             var value: INT16 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetInt16(pThis, &value))
@@ -566,7 +566,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        open func GetUInt16Impl() throws -> UInt16 {
+        open func GetUInt16() throws -> UInt16 {
             var value: UINT16 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetUInt16(pThis, &value))
@@ -574,7 +574,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        open func GetInt32Impl() throws -> Int32 {
+        open func GetInt32() throws -> Int32 {
             var value: INT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetInt32(pThis, &value))
@@ -582,7 +582,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        open func GetUInt32Impl() throws -> UInt32 {
+        open func GetUInt32() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetUInt32(pThis, &value))
@@ -590,7 +590,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        open func GetInt64Impl() throws -> Int64 {
+        open func GetInt64() throws -> Int64 {
             var value: INT64 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetInt64(pThis, &value))
@@ -598,7 +598,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        open func GetUInt64Impl() throws -> UInt64 {
+        open func GetUInt64() throws -> UInt64 {
             var value: UINT64 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetUInt64(pThis, &value))
@@ -606,7 +606,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        open func GetSingleImpl() throws -> Float {
+        open func GetSingle() throws -> Float {
             var value: FLOAT = 0.0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetSingle(pThis, &value))
@@ -614,7 +614,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        open func GetDoubleImpl() throws -> Double {
+        open func GetDouble() throws -> Double {
             var value: DOUBLE = 0.0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetDouble(pThis, &value))
@@ -622,7 +622,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        open func GetChar16Impl() throws -> Character {
+        open func GetChar16() throws -> Character {
             var value: WCHAR = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetChar16(pThis, &value))
@@ -630,7 +630,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        open func GetBooleanImpl() throws -> Bool {
+        open func GetBoolean() throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetBoolean(pThis, &value))
@@ -638,7 +638,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        open func GetStringImpl() throws -> String {
+        open func GetString() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetString(pThis, &value))
@@ -646,7 +646,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        open func GetGuidImpl() throws -> Foundation.UUID {
+        open func GetGuid() throws -> Foundation.UUID {
             var value: test_component.GUID = .init()
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetGuid(pThis, &value))
@@ -654,7 +654,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        open func GetDateTimeImpl() throws -> test_component.DateTime {
+        open func GetDateTime() throws -> test_component.DateTime {
             var value: __x_ABI_CWindows_CFoundation_CDateTime = .init()
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetDateTime(pThis, &value))
@@ -662,7 +662,7 @@ public enum __ABI_Windows_Foundation {
             return .from(abi: value)
         }
 
-        open func GetTimeSpanImpl() throws -> test_component.TimeSpan {
+        open func GetTimeSpan() throws -> test_component.TimeSpan {
             var value: __x_ABI_CWindows_CFoundation_CTimeSpan = .init()
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetTimeSpan(pThis, &value))
@@ -670,7 +670,7 @@ public enum __ABI_Windows_Foundation {
             return .from(abi: value)
         }
 
-        open func GetPointImpl() throws -> test_component.Point {
+        open func GetPoint() throws -> test_component.Point {
             var value: __x_ABI_CWindows_CFoundation_CPoint = .init()
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetPoint(pThis, &value))
@@ -678,7 +678,7 @@ public enum __ABI_Windows_Foundation {
             return .from(abi: value)
         }
 
-        open func GetSizeImpl() throws -> test_component.Size {
+        open func GetSize() throws -> test_component.Size {
             var value: __x_ABI_CWindows_CFoundation_CSize = .init()
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetSize(pThis, &value))
@@ -686,7 +686,7 @@ public enum __ABI_Windows_Foundation {
             return .from(abi: value)
         }
 
-        open func GetRectImpl() throws -> test_component.Rect {
+        open func GetRect() throws -> test_component.Rect {
             var value: __x_ABI_CWindows_CFoundation_CRect = .init()
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetRect(pThis, &value))
@@ -943,7 +943,7 @@ public enum __ABI_Windows_Foundation {
     public class IStringable: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIStringable }
 
-        open func ToStringImpl() throws -> String {
+        open func ToString() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIStringable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ToString(pThis, &value))
@@ -995,7 +995,7 @@ public enum __ABI_Windows_Foundation {
     public class IUriEscapeStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIUriEscapeStatics }
 
-        public func UnescapeComponentImpl(_ toUnescape: String) throws -> String {
+        public func UnescapeComponent(_ toUnescape: String) throws -> String {
             var value: HSTRING?
             let _toUnescape = try! HString(toUnescape)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriEscapeStatics.self) { pThis in
@@ -1004,7 +1004,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func EscapeComponentImpl(_ toEscape: String) throws -> String {
+        public func EscapeComponent(_ toEscape: String) throws -> String {
             var value: HSTRING?
             let _toEscape = try! HString(toEscape)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriEscapeStatics.self) { pThis in
@@ -1018,7 +1018,7 @@ public enum __ABI_Windows_Foundation {
     public class IUriRuntimeClass: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIUriRuntimeClass }
 
-        public func get_AbsoluteUriImpl() throws -> String {
+        public func get_AbsoluteUri() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AbsoluteUri(pThis, &value))
@@ -1026,7 +1026,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_DisplayUriImpl() throws -> String {
+        public func get_DisplayUri() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayUri(pThis, &value))
@@ -1034,7 +1034,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_DomainImpl() throws -> String {
+        public func get_Domain() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Domain(pThis, &value))
@@ -1042,7 +1042,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_ExtensionImpl() throws -> String {
+        public func get_Extension() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Extension(pThis, &value))
@@ -1050,7 +1050,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_FragmentImpl() throws -> String {
+        public func get_Fragment() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Fragment(pThis, &value))
@@ -1058,7 +1058,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_HostImpl() throws -> String {
+        public func get_Host() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Host(pThis, &value))
@@ -1066,7 +1066,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_PasswordImpl() throws -> String {
+        public func get_Password() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Password(pThis, &value))
@@ -1074,7 +1074,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_PathImpl() throws -> String {
+        public func get_Path() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Path(pThis, &value))
@@ -1082,7 +1082,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_QueryImpl() throws -> String {
+        public func get_Query() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Query(pThis, &value))
@@ -1090,7 +1090,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_QueryParsedImpl() throws -> test_component.WwwFormUrlDecoder? {
+        public func get_QueryParsed() throws -> test_component.WwwFormUrlDecoder? {
             let (ppWwwFormUrlDecoder) = try ComPtrs.initialize { ppWwwFormUrlDecoderAbi in
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_QueryParsed(pThis, &ppWwwFormUrlDecoderAbi))
@@ -1099,7 +1099,7 @@ public enum __ABI_Windows_Foundation {
             return .from(abi: ppWwwFormUrlDecoder)
         }
 
-        public func get_RawUriImpl() throws -> String {
+        public func get_RawUri() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_RawUri(pThis, &value))
@@ -1107,7 +1107,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_SchemeNameImpl() throws -> String {
+        public func get_SchemeName() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_SchemeName(pThis, &value))
@@ -1115,7 +1115,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_UserNameImpl() throws -> String {
+        public func get_UserName() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_UserName(pThis, &value))
@@ -1123,7 +1123,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_PortImpl() throws -> Int32 {
+        public func get_Port() throws -> Int32 {
             var value: INT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Port(pThis, &value))
@@ -1131,7 +1131,7 @@ public enum __ABI_Windows_Foundation {
             return value
         }
 
-        public func get_SuspiciousImpl() throws -> Bool {
+        public func get_Suspicious() throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Suspicious(pThis, &value))
@@ -1139,7 +1139,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func EqualsImpl(_ pUri: test_component.Uri?) throws -> Bool {
+        public func Equals(_ pUri: test_component.Uri?) throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Equals(pThis, RawPointer(pUri), &value))
@@ -1147,7 +1147,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func CombineUriImpl(_ relativeUri: String) throws -> test_component.Uri? {
+        public func CombineUri(_ relativeUri: String) throws -> test_component.Uri? {
             let (instance) = try ComPtrs.initialize { instanceAbi in
                 let _relativeUri = try! HString(relativeUri)
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
@@ -1162,7 +1162,7 @@ public enum __ABI_Windows_Foundation {
     public class IUriRuntimeClassFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIUriRuntimeClassFactory }
 
-        public func CreateUriImpl(_ uri: String) throws -> IUriRuntimeClass {
+        public func CreateUri(_ uri: String) throws -> IUriRuntimeClass {
             let (instance) = try ComPtrs.initialize { instanceAbi in
                 let _uri = try! HString(uri)
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClassFactory.self) { pThis in
@@ -1172,7 +1172,7 @@ public enum __ABI_Windows_Foundation {
             return IUriRuntimeClass(instance!)
         }
 
-        public func CreateWithRelativeUriImpl(_ baseUri: String, _ relativeUri: String) throws -> IUriRuntimeClass {
+        public func CreateWithRelativeUri(_ baseUri: String, _ relativeUri: String) throws -> IUriRuntimeClass {
             let (instance) = try ComPtrs.initialize { instanceAbi in
                 let _baseUri = try! HString(baseUri)
                 let _relativeUri = try! HString(relativeUri)
@@ -1188,7 +1188,7 @@ public enum __ABI_Windows_Foundation {
     public class IUriRuntimeClassWithAbsoluteCanonicalUri: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIUriRuntimeClassWithAbsoluteCanonicalUri }
 
-        public func get_AbsoluteCanonicalUriImpl() throws -> String {
+        public func get_AbsoluteCanonicalUri() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClassWithAbsoluteCanonicalUri.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AbsoluteCanonicalUri(pThis, &value))
@@ -1196,7 +1196,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        public func get_DisplayIriImpl() throws -> String {
+        public func get_DisplayIri() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClassWithAbsoluteCanonicalUri.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayIri(pThis, &value))
@@ -1209,7 +1209,7 @@ public enum __ABI_Windows_Foundation {
     public class IWwwFormUrlDecoderEntry: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderEntry }
 
-        open func get_NameImpl() throws -> String {
+        open func get_Name() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Name(pThis, &value))
@@ -1217,7 +1217,7 @@ public enum __ABI_Windows_Foundation {
             return .init(from: value)
         }
 
-        open func get_ValueImpl() throws -> String {
+        open func get_Value() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &value))
@@ -1274,7 +1274,7 @@ public enum __ABI_Windows_Foundation {
     public class IWwwFormUrlDecoderRuntimeClass: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass }
 
-        public func GetFirstValueByNameImpl(_ name: String) throws -> String {
+        public func GetFirstValueByName(_ name: String) throws -> String {
             var phstrValue: HSTRING?
             let _name = try! HString(name)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass.self) { pThis in
@@ -1288,7 +1288,7 @@ public enum __ABI_Windows_Foundation {
     public class IWwwFormUrlDecoderRuntimeClassFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClassFactory }
 
-        public func CreateWwwFormUrlDecoderImpl(_ query: String) throws -> IWwwFormUrlDecoderRuntimeClass {
+        public func CreateWwwFormUrlDecoder(_ query: String) throws -> IWwwFormUrlDecoderRuntimeClass {
             let (instance) = try ComPtrs.initialize { instanceAbi in
                 let _query = try! HString(query)
                 _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClassFactory.self) { pThis in
@@ -1331,7 +1331,7 @@ extension __ABI_Windows_Foundation {
     public class AsyncActionCompletedHandler: test_component.IUnknown {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIAsyncActionCompletedHandler }
 
-        open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncAction?, _ asyncStatus: test_component.AsyncStatus) throws {
+        open func Invoke(_ asyncInfo: test_component.AnyIAsyncAction?, _ asyncStatus: test_component.AsyncStatus) throws {
             let asyncInfoWrapper = __ABI_Windows_Foundation.IAsyncActionWrapper(asyncInfo)
             let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIAsyncActionCompletedHandler.self) { pThis in
@@ -1370,7 +1370,7 @@ extension __ABI_Windows_Foundation {
     public class DeferralCompletedHandler: test_component.IUnknown {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CIDeferralCompletedHandler }
 
-        open func InvokeImpl() throws {
+        open func Invoke() throws {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIDeferralCompletedHandler.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis))
             }

--- a/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
@@ -30,39 +30,39 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncaction.getresults)
         fileprivate func getResults() throws {
-            try _default.GetResultsImpl()
+            try _default.GetResults()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncaction.completed)
         fileprivate var completed : AsyncActionCompletedHandler! {
-            get { try! _default.get_CompletedImpl() }
-            set { try! _default.put_CompletedImpl(newValue) }
+            get { try! _default.get_Completed() }
+            set { try! _default.put_Completed(newValue) }
         }
 
         private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncaction.cancel)
         fileprivate func cancel() throws {
-            try _IAsyncInfo.CancelImpl()
+            try _IAsyncInfo.Cancel()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncaction.close)
         fileprivate func close() throws {
-            try _IAsyncInfo.CloseImpl()
+            try _IAsyncInfo.Close()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncaction.errorcode)
         fileprivate var errorCode : HRESULT {
-            get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+            get { try! _IAsyncInfo.get_ErrorCode() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncaction.id)
         fileprivate var id : UInt32 {
-            get { try! _IAsyncInfo.get_IdImpl() }
+            get { try! _IAsyncInfo.get_Id() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncaction.status)
         fileprivate var status : AsyncStatus {
-            get { try! _IAsyncInfo.get_StatusImpl() }
+            get { try! _IAsyncInfo.get_Status() }
         }
 
     }
@@ -92,27 +92,27 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncinfo.cancel)
         fileprivate func cancel() throws {
-            try _default.CancelImpl()
+            try _default.Cancel()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncinfo.close)
         fileprivate func close() throws {
-            try _default.CloseImpl()
+            try _default.Close()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncinfo.errorcode)
         fileprivate var errorCode : HRESULT {
-            get { try! _default.get_ErrorCodeImpl() }
+            get { try! _default.get_ErrorCode() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncinfo.id)
         fileprivate var id : UInt32 {
-            get { try! _default.get_IdImpl() }
+            get { try! _default.get_Id() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncinfo.status)
         fileprivate var status : AsyncStatus {
-            get { try! _default.get_StatusImpl() }
+            get { try! _default.get_Status() }
         }
 
     }
@@ -142,7 +142,7 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iclosable.close)
         fileprivate func close() throws {
-            try _default.CloseImpl()
+            try _default.Close()
         }
 
     }
@@ -172,13 +172,13 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.imemorybuffer.createreference)
         fileprivate func createReference() throws -> AnyIMemoryBufferReference! {
-            try _default.CreateReferenceImpl()
+            try _default.CreateReference()
         }
 
         private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.imemorybuffer.close)
         fileprivate func close() throws {
-            try _IClosable.CloseImpl()
+            try _IClosable.Close()
         }
 
     }
@@ -208,7 +208,7 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.imemorybufferreference.capacity)
         fileprivate var capacity : UInt32 {
-            get { try! _default.get_CapacityImpl() }
+            get { try! _default.get_Capacity() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.imemorybufferreference.closed)
@@ -216,10 +216,10 @@ public enum __IMPL_Windows_Foundation {
           .init(
             add: { [weak self] in
               guard let this = self?._default else { return .init() }
-              return try! this.add_ClosedImpl($0)
+              return try! this.add_Closed($0)
             },
             remove: { [weak self] in
-             try? self?._default.remove_ClosedImpl($0)
+             try? self?._default.remove_Closed($0)
            }
           )
         }()
@@ -227,7 +227,7 @@ public enum __IMPL_Windows_Foundation {
         private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.imemorybufferreference.close)
         fileprivate func close() throws {
-            try _IClosable.CloseImpl()
+            try _IClosable.Close()
         }
 
         private lazy var _IMemoryBufferByteAccess: __ABI_.IMemoryBufferByteAccess! = getInterfaceForCaching()
@@ -357,7 +357,7 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.istringable.tostring)
         fileprivate func toString() throws -> String {
-            try _default.ToStringImpl()
+            try _default.ToString()
         }
 
     }
@@ -387,12 +387,12 @@ public enum __IMPL_Windows_Foundation {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iwwwformurldecoderentry.name)
         fileprivate var name : String {
-            get { try! _default.get_NameImpl() }
+            get { try! _default.get_Name() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iwwwformurldecoderentry.value)
         fileprivate var value : String {
-            get { try! _default.get_ValueImpl() }
+            get { try! _default.get_Value() }
         }
 
     }
@@ -406,7 +406,7 @@ public enum __IMPL_Windows_Foundation {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (asyncInfo, asyncStatus) in
-                try _default.InvokeImpl(asyncInfo, asyncStatus)
+                try _default.Invoke(asyncInfo, asyncStatus)
             }
             return handler
         }
@@ -420,7 +420,7 @@ public enum __IMPL_Windows_Foundation {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in
-                try _default.InvokeImpl()
+                try _default.Invoke()
             }
             return handler
         }

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections+ABI.swift
@@ -102,7 +102,7 @@ public enum __ABI_Windows_Foundation_Collections {
     public class IVectorChangedEventArgs: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CFoundation_CCollections_CIVectorChangedEventArgs }
 
-        open func get_CollectionChangeImpl() throws -> test_component.CollectionChange {
+        open func get_CollectionChange() throws -> test_component.CollectionChange {
             var value: __x_ABI_CWindows_CFoundation_CCollections_CCollectionChange = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CCollections_CIVectorChangedEventArgs.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_CollectionChange(pThis, &value))
@@ -110,7 +110,7 @@ public enum __ABI_Windows_Foundation_Collections {
             return value
         }
 
-        open func get_IndexImpl() throws -> UInt32 {
+        open func get_Index() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CCollections_CIVectorChangedEventArgs.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Index(pThis, &value))

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
@@ -37,10 +37,10 @@ public enum __IMPL_Windows_Foundation_Collections {
           .init(
             add: { [weak self] in
               guard let this = self?._IObservableMap else { return .init() }
-              return try! this.add_MapChangedImpl($0)
+              return try! this.add_MapChanged($0)
             },
             remove: { [weak self] in
-             try? self?._IObservableMap.remove_MapChangedImpl($0)
+             try? self?._IObservableMap.remove_MapChanged($0)
            }
           )
         }()
@@ -48,43 +48,43 @@ public enum __IMPL_Windows_Foundation_Collections {
         private lazy var _IMap: IMapString_Any! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ipropertyset.lookup)
         fileprivate func lookup(_ key: String) -> Any? {
-            try! _IMap.LookupImpl(key)
+            try! _IMap.Lookup(key)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ipropertyset.haskey)
         fileprivate func hasKey(_ key: String) -> Bool {
-            try! _IMap.HasKeyImpl(key)
+            try! _IMap.HasKey(key)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ipropertyset.getview)
         fileprivate func getView() -> AnyIMapView<String, Any?>? {
-            try! _IMap.GetViewImpl()
+            try! _IMap.GetView()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ipropertyset.insert)
         fileprivate func insert(_ key: String, _ value: Any?) -> Bool {
-            try! _IMap.InsertImpl(key, value)
+            try! _IMap.Insert(key, value)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ipropertyset.remove)
         fileprivate func remove(_ key: String) {
-            try! _IMap.RemoveImpl(key)
+            try! _IMap.Remove(key)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ipropertyset.clear)
         fileprivate func clear() {
-            try! _IMap.ClearImpl()
+            try! _IMap.Clear()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ipropertyset.size)
         fileprivate var size : UInt32 {
-            get { try! _IMap.get_SizeImpl() }
+            get { try! _IMap.get_Size() }
         }
 
         private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ipropertyset.first)
         fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, Any?>?>? {
-            try! _IIterable.FirstImpl()
+            try! _IIterable.First()
         }
 
     }
@@ -114,12 +114,12 @@ public enum __IMPL_Windows_Foundation_Collections {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorchangedeventargs.collectionchange)
         fileprivate var collectionChange : CollectionChange {
-            get { try! _default.get_CollectionChangeImpl() }
+            get { try! _default.get_CollectionChange() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorchangedeventargs.index)
         fileprivate var index : UInt32 {
-            get { try! _default.get_IndexImpl() }
+            get { try! _default.get_Index() }
         }
 
     }

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
@@ -46,10 +46,10 @@ public final class PropertySet : WinRTClass, IObservableMap, IMap, IIterable, IP
       .init(
         add: { [weak self] in
           guard let this = self?._IObservableMap else { return .init() }
-          return try! this.add_MapChangedImpl($0)
+          return try! this.add_MapChanged($0)
         },
         remove: { [weak self] in
-         try? self?._IObservableMap.remove_MapChangedImpl($0)
+         try? self?._IObservableMap.remove_MapChanged($0)
        }
       )
     }()
@@ -57,43 +57,43 @@ public final class PropertySet : WinRTClass, IObservableMap, IMap, IIterable, IP
     private lazy var _IMap: IMapString_Any! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.propertyset.lookup)
     public func lookup(_ key: String) -> Any? {
-        try! _IMap.LookupImpl(key)
+        try! _IMap.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.propertyset.haskey)
     public func hasKey(_ key: String) -> Bool {
-        try! _IMap.HasKeyImpl(key)
+        try! _IMap.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.propertyset.getview)
     public func getView() -> AnyIMapView<String, Any?>? {
-        try! _IMap.GetViewImpl()
+        try! _IMap.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.propertyset.insert)
     public func insert(_ key: String, _ value: Any?) -> Bool {
-        try! _IMap.InsertImpl(key, value)
+        try! _IMap.Insert(key, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.propertyset.remove)
     public func remove(_ key: String) {
-        try! _IMap.RemoveImpl(key)
+        try! _IMap.Remove(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.propertyset.clear)
     public func clear() {
-        try! _IMap.ClearImpl()
+        try! _IMap.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.propertyset.size)
     public var size : UInt32 {
-        get { try! _IMap.get_SizeImpl() }
+        get { try! _IMap.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.propertyset.first)
     public func first() -> AnyIIterator<AnyIKeyValuePair<String, Any?>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     deinit {
@@ -141,43 +141,43 @@ public final class StringMap : WinRTClass, IMap, IIterable, IObservableMap {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.stringmap.lookup)
     public func lookup(_ key: String) -> String {
-        try! _default.LookupImpl(key)
+        try! _default.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.stringmap.haskey)
     public func hasKey(_ key: String) -> Bool {
-        try! _default.HasKeyImpl(key)
+        try! _default.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.stringmap.getview)
     public func getView() -> AnyIMapView<String, String>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.stringmap.insert)
     public func insert(_ key: String, _ value: String) -> Bool {
-        try! _default.InsertImpl(key, value)
+        try! _default.Insert(key, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.stringmap.remove)
     public func remove(_ key: String) {
-        try! _default.RemoveImpl(key)
+        try! _default.Remove(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.stringmap.clear)
     public func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.stringmap.size)
     public var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_String! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.stringmap.first)
     public func first() -> AnyIIterator<AnyIKeyValuePair<String, String>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     private lazy var _IObservableMap: IObservableMapString_String! = getInterfaceForCaching()
@@ -186,10 +186,10 @@ public final class StringMap : WinRTClass, IMap, IIterable, IObservableMap {
       .init(
         add: { [weak self] in
           guard let this = self?._IObservableMap else { return .init() }
-          return try! this.add_MapChangedImpl($0)
+          return try! this.add_MapChanged($0)
         },
         remove: { [weak self] in
-         try? self?._IObservableMap.remove_MapChangedImpl($0)
+         try? self?._IObservableMap.remove_MapChanged($0)
        }
       )
     }()
@@ -242,10 +242,10 @@ public final class ValueSet : WinRTClass, IObservableMap, IMap, IIterable, IProp
       .init(
         add: { [weak self] in
           guard let this = self?._IObservableMap else { return .init() }
-          return try! this.add_MapChangedImpl($0)
+          return try! this.add_MapChanged($0)
         },
         remove: { [weak self] in
-         try? self?._IObservableMap.remove_MapChangedImpl($0)
+         try? self?._IObservableMap.remove_MapChanged($0)
        }
       )
     }()
@@ -253,43 +253,43 @@ public final class ValueSet : WinRTClass, IObservableMap, IMap, IIterable, IProp
     private lazy var _IMap: IMapString_Any! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.valueset.lookup)
     public func lookup(_ key: String) -> Any? {
-        try! _IMap.LookupImpl(key)
+        try! _IMap.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.valueset.haskey)
     public func hasKey(_ key: String) -> Bool {
-        try! _IMap.HasKeyImpl(key)
+        try! _IMap.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.valueset.getview)
     public func getView() -> AnyIMapView<String, Any?>? {
-        try! _IMap.GetViewImpl()
+        try! _IMap.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.valueset.insert)
     public func insert(_ key: String, _ value: Any?) -> Bool {
-        try! _IMap.InsertImpl(key, value)
+        try! _IMap.Insert(key, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.valueset.remove)
     public func remove(_ key: String) {
-        try! _IMap.RemoveImpl(key)
+        try! _IMap.Remove(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.valueset.clear)
     public func clear() {
-        try! _IMap.ClearImpl()
+        try! _IMap.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.valueset.size)
     public var size : UInt32 {
-        get { try! _IMap.get_SizeImpl() }
+        get { try! _IMap.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.valueset.first)
     public func first() -> AnyIIterator<AnyIKeyValuePair<String, Any?>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     deinit {

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -36,18 +36,18 @@ public final class Deferral : WinRTClass, IClosable {
     }
     private static let _IDeferralFactory: __ABI_Windows_Foundation.IDeferralFactory = try! RoGetActivationFactory("Windows.Foundation.Deferral")
     public init(_ handler: DeferralCompletedHandler!) {
-        super.init(try! Self._IDeferralFactory.CreateImpl(handler))
+        super.init(try! Self._IDeferralFactory.Create(handler))
     }
 
     private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.deferral.close)
     public func close() throws {
-        try _IClosable.CloseImpl()
+        try _IClosable.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.deferral.complete)
     public func complete() throws {
-        try _default.CompleteImpl()
+        try _default.Complete()
     }
 
     deinit {
@@ -85,18 +85,18 @@ public final class MemoryBuffer : WinRTClass, IClosable, IMemoryBuffer {
     }
     private static let _IMemoryBufferFactory: __ABI_Windows_Foundation.IMemoryBufferFactory = try! RoGetActivationFactory("Windows.Foundation.MemoryBuffer")
     public init(_ capacity: UInt32) {
-        super.init(try! Self._IMemoryBufferFactory.CreateImpl(capacity))
+        super.init(try! Self._IMemoryBufferFactory.Create(capacity))
     }
 
     private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.memorybuffer.close)
     public func close() throws {
-        try _IClosable.CloseImpl()
+        try _IClosable.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.memorybuffer.createreference)
     public func createReference() throws -> AnyIMemoryBufferReference! {
-        try _default.CreateReferenceImpl()
+        try _default.CreateReference()
     }
 
     deinit {
@@ -135,123 +135,123 @@ public final class Uri : WinRTClass, IStringable {
     private static let _IUriEscapeStatics: __ABI_Windows_Foundation.IUriEscapeStatics = try! RoGetActivationFactory("Windows.Foundation.Uri")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.unescapecomponent)
     public static func unescapeComponent(_ toUnescape: String) throws -> String {
-        return try _IUriEscapeStatics.UnescapeComponentImpl(toUnescape)
+        return try _IUriEscapeStatics.UnescapeComponent(toUnescape)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.escapecomponent)
     public static func escapeComponent(_ toEscape: String) throws -> String {
-        return try _IUriEscapeStatics.EscapeComponentImpl(toEscape)
+        return try _IUriEscapeStatics.EscapeComponent(toEscape)
     }
 
     private static let _IUriRuntimeClassFactory: __ABI_Windows_Foundation.IUriRuntimeClassFactory = try! RoGetActivationFactory("Windows.Foundation.Uri")
     public init(_ uri: String) {
-        super.init(try! Self._IUriRuntimeClassFactory.CreateUriImpl(uri))
+        super.init(try! Self._IUriRuntimeClassFactory.CreateUri(uri))
     }
 
     public init(_ baseUri: String, _ relativeUri: String) {
-        super.init(try! Self._IUriRuntimeClassFactory.CreateWithRelativeUriImpl(baseUri, relativeUri))
+        super.init(try! Self._IUriRuntimeClassFactory.CreateWithRelativeUri(baseUri, relativeUri))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.equals)
     public func equals(_ pUri: Uri!) throws -> Bool {
-        try _default.EqualsImpl(pUri)
+        try _default.Equals(pUri)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.combineuri)
     public func combineUri(_ relativeUri: String) throws -> Uri! {
-        try _default.CombineUriImpl(relativeUri)
+        try _default.CombineUri(relativeUri)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.absoluteuri)
     public var absoluteUri : String {
-        get { try! _default.get_AbsoluteUriImpl() }
+        get { try! _default.get_AbsoluteUri() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.displayuri)
     public var displayUri : String {
-        get { try! _default.get_DisplayUriImpl() }
+        get { try! _default.get_DisplayUri() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.domain)
     public var domain : String {
-        get { try! _default.get_DomainImpl() }
+        get { try! _default.get_Domain() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.extension)
     public var `extension` : String {
-        get { try! _default.get_ExtensionImpl() }
+        get { try! _default.get_Extension() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.fragment)
     public var fragment : String {
-        get { try! _default.get_FragmentImpl() }
+        get { try! _default.get_Fragment() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.host)
     public var host : String {
-        get { try! _default.get_HostImpl() }
+        get { try! _default.get_Host() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.password)
     public var password : String {
-        get { try! _default.get_PasswordImpl() }
+        get { try! _default.get_Password() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.path)
     public var path : String {
-        get { try! _default.get_PathImpl() }
+        get { try! _default.get_Path() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.port)
     public var port : Int32 {
-        get { try! _default.get_PortImpl() }
+        get { try! _default.get_Port() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.query)
     public var query : String {
-        get { try! _default.get_QueryImpl() }
+        get { try! _default.get_Query() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.queryparsed)
     public var queryParsed : WwwFormUrlDecoder! {
-        get { try! _default.get_QueryParsedImpl() }
+        get { try! _default.get_QueryParsed() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.rawuri)
     public var rawUri : String {
-        get { try! _default.get_RawUriImpl() }
+        get { try! _default.get_RawUri() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.schemename)
     public var schemeName : String {
-        get { try! _default.get_SchemeNameImpl() }
+        get { try! _default.get_SchemeName() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.suspicious)
     public var suspicious : Bool {
-        get { try! _default.get_SuspiciousImpl() }
+        get { try! _default.get_Suspicious() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.username)
     public var userName : String {
-        get { try! _default.get_UserNameImpl() }
+        get { try! _default.get_UserName() }
     }
 
     private lazy var _IUriRuntimeClassWithAbsoluteCanonicalUri: __ABI_Windows_Foundation.IUriRuntimeClassWithAbsoluteCanonicalUri! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.absolutecanonicaluri)
     public var absoluteCanonicalUri : String {
-        get { try! _IUriRuntimeClassWithAbsoluteCanonicalUri.get_AbsoluteCanonicalUriImpl() }
+        get { try! _IUriRuntimeClassWithAbsoluteCanonicalUri.get_AbsoluteCanonicalUri() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.displayiri)
     public var displayIri : String {
-        get { try! _IUriRuntimeClassWithAbsoluteCanonicalUri.get_DisplayIriImpl() }
+        get { try! _IUriRuntimeClassWithAbsoluteCanonicalUri.get_DisplayIri() }
     }
 
     private lazy var _IStringable: __ABI_Windows_Foundation.IStringable! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.uri.tostring)
     public func toString() throws -> String {
-        try _IStringable.ToStringImpl()
+        try _IStringable.ToString()
     }
 
     deinit {
@@ -291,13 +291,13 @@ public final class WwwFormUrlDecoder : WinRTClass, IIterable, IVectorView {
     }
     private static let _IWwwFormUrlDecoderRuntimeClassFactory: __ABI_Windows_Foundation.IWwwFormUrlDecoderRuntimeClassFactory = try! RoGetActivationFactory("Windows.Foundation.WwwFormUrlDecoder")
     public init(_ query: String) {
-        super.init(try! Self._IWwwFormUrlDecoderRuntimeClassFactory.CreateWwwFormUrlDecoderImpl(query))
+        super.init(try! Self._IWwwFormUrlDecoderRuntimeClassFactory.CreateWwwFormUrlDecoder(query))
     }
 
     private lazy var _IIterable: IIterableIWwwFormUrlDecoderEntry! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.wwwformurldecoder.first)
     public func first() -> AnyIIterator<AnyIWwwFormUrlDecoderEntry?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     // MARK: Collection
@@ -325,22 +325,22 @@ public final class WwwFormUrlDecoder : WinRTClass, IIterable, IVectorView {
     private lazy var _IVectorView: IVectorViewIWwwFormUrlDecoderEntry! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.wwwformurldecoder.getat)
     public func getAt(_ index: UInt32) -> AnyIWwwFormUrlDecoderEntry? {
-        try! _IVectorView.GetAtImpl(index)
+        try! _IVectorView.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.wwwformurldecoder.indexof)
     public func indexOf(_ value: AnyIWwwFormUrlDecoderEntry?, _ index: inout UInt32) -> Bool {
-        try! _IVectorView.IndexOfImpl(value, &index)
+        try! _IVectorView.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.wwwformurldecoder.size)
     public var size : UInt32 {
-        get { try! _IVectorView.get_SizeImpl() }
+        get { try! _IVectorView.get_Size() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.wwwformurldecoder.getfirstvaluebyname)
     public func getFirstValueByName(_ name: String) throws -> String {
-        try _default.GetFirstValueByNameImpl(name)
+        try _default.GetFirstValueByName(name)
     }
 
     deinit {

--- a/tests/test_component/Sources/test_component/Windows.Storage+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage+ABI.swift
@@ -96,7 +96,7 @@ public enum __ABI_Windows_Storage {
     public class IPathIOStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIPathIOStatics }
 
-        public func ReadTextAsyncImpl(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<String>? {
+        public func ReadTextAsync(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<String>? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIPathIOStatics.self) { pThis in
@@ -106,7 +106,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1_HSTRINGWrapper.unwrapFrom(abi: textOperation)
         }
 
-        public func ReadTextWithEncodingAsyncImpl(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncOperation<String>? {
+        public func ReadTextWithEncodingAsync(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncOperation<String>? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIPathIOStatics.self) { pThis in
@@ -116,7 +116,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1_HSTRINGWrapper.unwrapFrom(abi: textOperation)
         }
 
-        public func WriteTextAsyncImpl(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction? {
+        public func WriteTextAsync(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let _contents = try! HString(contents)
@@ -127,7 +127,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: textOperation)
         }
 
-        public func WriteTextWithEncodingAsyncImpl(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
+        public func WriteTextWithEncodingAsync(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let _contents = try! HString(contents)
@@ -138,7 +138,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: textOperation)
         }
 
-        public func AppendTextAsyncImpl(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction? {
+        public func AppendTextAsync(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let _contents = try! HString(contents)
@@ -149,7 +149,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: textOperation)
         }
 
-        public func AppendTextWithEncodingAsyncImpl(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
+        public func AppendTextWithEncodingAsync(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
             let (textOperation) = try ComPtrs.initialize { textOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let _contents = try! HString(contents)
@@ -160,7 +160,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: textOperation)
         }
 
-        public func ReadLinesAsyncImpl(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>? {
+        public func ReadLinesAsync(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>? {
             let (linesOperation) = try ComPtrs.initialize { linesOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIPathIOStatics.self) { pThis in
@@ -170,7 +170,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: linesOperation)
         }
 
-        public func ReadLinesWithEncodingAsyncImpl(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>? {
+        public func ReadLinesWithEncodingAsync(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>? {
             let (linesOperation) = try ComPtrs.initialize { linesOperationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIPathIOStatics.self) { pThis in
@@ -180,7 +180,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: linesOperation)
         }
 
-        public func WriteLinesAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?) throws -> test_component.AnyIAsyncAction? {
+        public func WriteLinesAsync(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let linesWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(lines)
@@ -192,7 +192,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        public func WriteLinesWithEncodingAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
+        public func WriteLinesWithEncodingAsync(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let linesWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(lines)
@@ -204,7 +204,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        public func AppendLinesAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?) throws -> test_component.AnyIAsyncAction? {
+        public func AppendLinesAsync(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let linesWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(lines)
@@ -216,7 +216,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        public func AppendLinesWithEncodingAsyncImpl(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
+        public func AppendLinesWithEncodingAsync(_ absolutePath: String, _ lines: test_component.AnyIIterable<String>?, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let linesWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(lines)
@@ -228,7 +228,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        public func ReadBufferAsyncImpl(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIBuffer?>? {
+        public func ReadBufferAsync(_ absolutePath: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIBuffer?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIPathIOStatics.self) { pThis in
@@ -238,7 +238,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper.unwrapFrom(abi: operation)
         }
 
-        public func WriteBufferAsyncImpl(_ absolutePath: String, _ buffer: test_component.AnyIBuffer?) throws -> test_component.AnyIAsyncAction? {
+        public func WriteBufferAsync(_ absolutePath: String, _ buffer: test_component.AnyIBuffer?) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _absolutePath = try! HString(absolutePath)
                 let bufferWrapper = __ABI_Windows_Storage_Streams.IBufferWrapper(buffer)
@@ -255,7 +255,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageFile: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFile }
 
-        open func get_FileTypeImpl() throws -> String {
+        open func get_FileType() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_FileType(pThis, &value))
@@ -263,7 +263,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        open func get_ContentTypeImpl() throws -> String {
+        open func get_ContentType() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ContentType(pThis, &value))
@@ -271,7 +271,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        open func OpenAsyncImpl(_ accessMode: test_component.FileAccessMode) throws -> test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>? {
+        open func OpenAsync(_ accessMode: test_component.FileAccessMode) throws -> test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFile.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OpenAsync(pThis, accessMode, &operationAbi))
@@ -280,7 +280,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper.unwrapFrom(abi: operation)
         }
 
-        open func OpenTransactedWriteAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.StorageStreamTransaction?>? {
+        open func OpenTransactedWriteAsync() throws -> test_component.AnyIAsyncOperation<test_component.StorageStreamTransaction?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFile.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OpenTransactedWriteAsync(pThis, &operationAbi))
@@ -289,7 +289,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper.unwrapFrom(abi: operation)
         }
 
-        open func CopyOverloadDefaultNameAndOptionsImpl(_ destinationFolder: test_component.AnyIStorageFolder?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        open func CopyOverloadDefaultNameAndOptions(_ destinationFolder: test_component.AnyIStorageFolder?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let destinationFolderWrapper = __ABI_Windows_Storage.IStorageFolderWrapper(destinationFolder)
                 let _destinationFolder = try! destinationFolderWrapper?.toABI { $0 }
@@ -300,7 +300,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        open func CopyOverloadDefaultOptionsImpl(_ destinationFolder: test_component.AnyIStorageFolder?, _ desiredNewName: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        open func CopyOverloadDefaultOptions(_ destinationFolder: test_component.AnyIStorageFolder?, _ desiredNewName: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let destinationFolderWrapper = __ABI_Windows_Storage.IStorageFolderWrapper(destinationFolder)
                 let _destinationFolder = try! destinationFolderWrapper?.toABI { $0 }
@@ -312,7 +312,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        open func CopyOverloadImpl(_ destinationFolder: test_component.AnyIStorageFolder?, _ desiredNewName: String, _ option: test_component.NameCollisionOption) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        open func CopyOverload(_ destinationFolder: test_component.AnyIStorageFolder?, _ desiredNewName: String, _ option: test_component.NameCollisionOption) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let destinationFolderWrapper = __ABI_Windows_Storage.IStorageFolderWrapper(destinationFolder)
                 let _destinationFolder = try! destinationFolderWrapper?.toABI { $0 }
@@ -324,7 +324,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        open func CopyAndReplaceAsyncImpl(_ fileToReplace: test_component.AnyIStorageFile?) throws -> test_component.AnyIAsyncAction? {
+        open func CopyAndReplaceAsync(_ fileToReplace: test_component.AnyIStorageFile?) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let fileToReplaceWrapper = __ABI_Windows_Storage.IStorageFileWrapper(fileToReplace)
                 let _fileToReplace = try! fileToReplaceWrapper?.toABI { $0 }
@@ -335,7 +335,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        open func MoveOverloadDefaultNameAndOptionsImpl(_ destinationFolder: test_component.AnyIStorageFolder?) throws -> test_component.AnyIAsyncAction? {
+        open func MoveOverloadDefaultNameAndOptions(_ destinationFolder: test_component.AnyIStorageFolder?) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let destinationFolderWrapper = __ABI_Windows_Storage.IStorageFolderWrapper(destinationFolder)
                 let _destinationFolder = try! destinationFolderWrapper?.toABI { $0 }
@@ -346,7 +346,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        open func MoveOverloadDefaultOptionsImpl(_ destinationFolder: test_component.AnyIStorageFolder?, _ desiredNewName: String) throws -> test_component.AnyIAsyncAction? {
+        open func MoveOverloadDefaultOptions(_ destinationFolder: test_component.AnyIStorageFolder?, _ desiredNewName: String) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let destinationFolderWrapper = __ABI_Windows_Storage.IStorageFolderWrapper(destinationFolder)
                 let _destinationFolder = try! destinationFolderWrapper?.toABI { $0 }
@@ -358,7 +358,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        open func MoveOverloadImpl(_ destinationFolder: test_component.AnyIStorageFolder?, _ desiredNewName: String, _ option: test_component.NameCollisionOption) throws -> test_component.AnyIAsyncAction? {
+        open func MoveOverload(_ destinationFolder: test_component.AnyIStorageFolder?, _ desiredNewName: String, _ option: test_component.NameCollisionOption) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let destinationFolderWrapper = __ABI_Windows_Storage.IStorageFolderWrapper(destinationFolder)
                 let _destinationFolder = try! destinationFolderWrapper?.toABI { $0 }
@@ -370,7 +370,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        open func MoveAndReplaceAsyncImpl(_ fileToReplace: test_component.AnyIStorageFile?) throws -> test_component.AnyIAsyncAction? {
+        open func MoveAndReplaceAsync(_ fileToReplace: test_component.AnyIStorageFile?) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let fileToReplaceWrapper = __ABI_Windows_Storage.IStorageFileWrapper(fileToReplace)
                 let _fileToReplace = try! fileToReplaceWrapper?.toABI { $0 }
@@ -548,7 +548,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageFile2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFile2 }
 
-        open func OpenWithOptionsAsyncImpl(_ accessMode: test_component.FileAccessMode, _ options: test_component.StorageOpenOptions) throws -> test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>? {
+        open func OpenWithOptionsAsync(_ accessMode: test_component.FileAccessMode, _ options: test_component.StorageOpenOptions) throws -> test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFile2.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OpenWithOptionsAsync(pThis, accessMode, options, &operationAbi))
@@ -557,7 +557,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper.unwrapFrom(abi: operation)
         }
 
-        open func OpenTransactedWriteWithOptionsAsyncImpl(_ options: test_component.StorageOpenOptions) throws -> test_component.AnyIAsyncOperation<test_component.StorageStreamTransaction?>? {
+        open func OpenTransactedWriteWithOptionsAsync(_ options: test_component.StorageOpenOptions) throws -> test_component.AnyIAsyncOperation<test_component.StorageStreamTransaction?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFile2.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OpenTransactedWriteWithOptionsAsync(pThis, options, &operationAbi))
@@ -624,7 +624,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageFilePropertiesWithAvailability: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFilePropertiesWithAvailability }
 
-        open func get_IsAvailableImpl() throws -> Bool {
+        open func get_IsAvailable() throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFilePropertiesWithAvailability.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_IsAvailable(pThis, &value))
@@ -674,7 +674,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageFileStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFileStatics }
 
-        public func GetFileFromPathAsyncImpl(_ path: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func GetFileFromPathAsync(_ path: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _path = try! HString(path)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFileStatics.self) { pThis in
@@ -684,7 +684,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        public func GetFileFromApplicationUriAsyncImpl(_ uri: test_component.Uri?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func GetFileFromApplicationUriAsync(_ uri: test_component.Uri?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFileStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFileFromApplicationUriAsync(pThis, RawPointer(uri), &operationAbi))
@@ -693,7 +693,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        public func CreateStreamedFileAsyncImpl(_ displayNameWithExtension: String, _ dataRequested: test_component.StreamedFileDataRequestedHandler?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func CreateStreamedFileAsync(_ displayNameWithExtension: String, _ dataRequested: test_component.StreamedFileDataRequestedHandler?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _displayNameWithExtension = try! HString(displayNameWithExtension)
                 let dataRequestedWrapper = __ABI_Windows_Storage.StreamedFileDataRequestedHandlerWrapper(dataRequested)
@@ -707,7 +707,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        public func ReplaceWithStreamedFileAsyncImpl(_ fileToReplace: test_component.AnyIStorageFile?, _ dataRequested: test_component.StreamedFileDataRequestedHandler?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func ReplaceWithStreamedFileAsync(_ fileToReplace: test_component.AnyIStorageFile?, _ dataRequested: test_component.StreamedFileDataRequestedHandler?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let fileToReplaceWrapper = __ABI_Windows_Storage.IStorageFileWrapper(fileToReplace)
                 let _fileToReplace = try! fileToReplaceWrapper?.toABI { $0 }
@@ -722,7 +722,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        public func CreateStreamedFileFromUriAsyncImpl(_ displayNameWithExtension: String, _ uri: test_component.Uri?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func CreateStreamedFileFromUriAsync(_ displayNameWithExtension: String, _ uri: test_component.Uri?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _displayNameWithExtension = try! HString(displayNameWithExtension)
                 let thumbnailWrapper = __ABI_Windows_Storage_Streams.IRandomAccessStreamReferenceWrapper(thumbnail)
@@ -734,7 +734,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        public func ReplaceWithStreamedFileFromUriAsyncImpl(_ fileToReplace: test_component.AnyIStorageFile?, _ uri: test_component.Uri?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        public func ReplaceWithStreamedFileFromUriAsync(_ fileToReplace: test_component.AnyIStorageFile?, _ uri: test_component.Uri?, _ thumbnail: test_component.AnyIRandomAccessStreamReference?) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let fileToReplaceWrapper = __ABI_Windows_Storage.IStorageFileWrapper(fileToReplace)
                 let _fileToReplace = try! fileToReplaceWrapper?.toABI { $0 }
@@ -752,7 +752,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageFolder: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFolder }
 
-        open func CreateFileAsyncOverloadDefaultOptionsImpl(_ desiredName: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        open func CreateFileAsyncOverloadDefaultOptions(_ desiredName: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _desiredName = try! HString(desiredName)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder.self) { pThis in
@@ -762,7 +762,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        open func CreateFileAsyncImpl(_ desiredName: String, _ options: test_component.CreationCollisionOption) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        open func CreateFileAsync(_ desiredName: String, _ options: test_component.CreationCollisionOption) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _desiredName = try! HString(desiredName)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder.self) { pThis in
@@ -772,7 +772,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        open func CreateFolderAsyncOverloadDefaultOptionsImpl(_ desiredName: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
+        open func CreateFolderAsyncOverloadDefaultOptions(_ desiredName: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _desiredName = try! HString(desiredName)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder.self) { pThis in
@@ -782,7 +782,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: operation)
         }
 
-        open func CreateFolderAsyncImpl(_ desiredName: String, _ options: test_component.CreationCollisionOption) throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
+        open func CreateFolderAsync(_ desiredName: String, _ options: test_component.CreationCollisionOption) throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _desiredName = try! HString(desiredName)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder.self) { pThis in
@@ -792,7 +792,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetFileAsyncImpl(_ name: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
+        open func GetFileAsync(_ name: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFile?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _name = try! HString(name)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder.self) { pThis in
@@ -802,7 +802,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetFolderAsyncImpl(_ name: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
+        open func GetFolderAsync(_ name: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _name = try! HString(name)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder.self) { pThis in
@@ -812,7 +812,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetItemAsyncImpl(_ name: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>? {
+        open func GetItemAsync(_ name: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _name = try! HString(name)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder.self) { pThis in
@@ -822,7 +822,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetFilesAsyncOverloadDefaultOptionsStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
+        open func GetFilesAsyncOverloadDefaultOptionsStartAndCount() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFilesAsyncOverloadDefaultOptionsStartAndCount(pThis, &operationAbi))
@@ -831,7 +831,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetFoldersAsyncOverloadDefaultOptionsStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
+        open func GetFoldersAsyncOverloadDefaultOptionsStartAndCount() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFoldersAsyncOverloadDefaultOptionsStartAndCount(pThis, &operationAbi))
@@ -840,7 +840,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetItemsAsyncOverloadDefaultStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
+        open func GetItemsAsyncOverloadDefaultStartAndCount() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetItemsAsyncOverloadDefaultStartAndCount(pThis, &operationAbi))
@@ -994,7 +994,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageFolder2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFolder2 }
 
-        open func TryGetItemAsyncImpl(_ name: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>? {
+        open func TryGetItemAsync(_ name: String) throws -> test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _name = try! HString(name)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder2.self) { pThis in
@@ -1050,7 +1050,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageFolder3: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFolder3 }
 
-        public func TryGetChangeTrackerImpl() throws -> test_component.StorageLibraryChangeTracker? {
+        public func TryGetChangeTracker() throws -> test_component.StorageLibraryChangeTracker? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolder3.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.TryGetChangeTracker(pThis, &resultAbi))
@@ -1064,7 +1064,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageFolderStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageFolderStatics }
 
-        public func GetFolderFromPathAsyncImpl(_ path: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
+        public func GetFolderFromPathAsync(_ path: String) throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _path = try! HString(path)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFolderStatics.self) { pThis in
@@ -1079,7 +1079,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageItem: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageItem }
 
-        open func RenameAsyncOverloadDefaultOptionsImpl(_ desiredName: String) throws -> test_component.AnyIAsyncAction? {
+        open func RenameAsyncOverloadDefaultOptions(_ desiredName: String) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _desiredName = try! HString(desiredName)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
@@ -1089,7 +1089,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        open func RenameAsyncImpl(_ desiredName: String, _ option: test_component.NameCollisionOption) throws -> test_component.AnyIAsyncAction? {
+        open func RenameAsync(_ desiredName: String, _ option: test_component.NameCollisionOption) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _desiredName = try! HString(desiredName)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
@@ -1099,7 +1099,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        open func DeleteAsyncOverloadDefaultOptionsImpl() throws -> test_component.AnyIAsyncAction? {
+        open func DeleteAsyncOverloadDefaultOptions() throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.DeleteAsyncOverloadDefaultOptions(pThis, &operationAbi))
@@ -1108,7 +1108,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        open func DeleteAsyncImpl(_ option: test_component.StorageDeleteOption) throws -> test_component.AnyIAsyncAction? {
+        open func DeleteAsync(_ option: test_component.StorageDeleteOption) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.DeleteAsync(pThis, option, &operationAbi))
@@ -1117,7 +1117,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetBasicPropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.BasicProperties?>? {
+        open func GetBasicPropertiesAsync() throws -> test_component.AnyIAsyncOperation<test_component.BasicProperties?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetBasicPropertiesAsync(pThis, &operationAbi))
@@ -1126,7 +1126,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper.unwrapFrom(abi: operation)
         }
 
-        open func get_NameImpl() throws -> String {
+        open func get_Name() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Name(pThis, &value))
@@ -1134,7 +1134,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        open func get_PathImpl() throws -> String {
+        open func get_Path() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Path(pThis, &value))
@@ -1142,7 +1142,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        open func get_AttributesImpl() throws -> test_component.FileAttributes {
+        open func get_Attributes() throws -> test_component.FileAttributes {
             var value: __x_ABI_CWindows_CStorage_CFileAttributes = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Attributes(pThis, &value))
@@ -1150,7 +1150,7 @@ public enum __ABI_Windows_Storage {
             return value
         }
 
-        open func get_DateCreatedImpl() throws -> test_component.DateTime {
+        open func get_DateCreated() throws -> test_component.DateTime {
             var value: __x_ABI_CWindows_CFoundation_CDateTime = .init()
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DateCreated(pThis, &value))
@@ -1158,7 +1158,7 @@ public enum __ABI_Windows_Storage {
             return .from(abi: value)
         }
 
-        open func IsOfTypeImpl(_ type: test_component.StorageItemTypes) throws -> Bool {
+        open func IsOfType(_ type: test_component.StorageItemTypes) throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.IsOfType(pThis, type, &value))
@@ -1293,7 +1293,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageItem2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageItem2 }
 
-        open func GetParentAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
+        open func GetParentAsync() throws -> test_component.AnyIAsyncOperation<test_component.StorageFolder?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem2.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetParentAsync(pThis, &operationAbi))
@@ -1302,7 +1302,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: operation)
         }
 
-        open func IsEqualImpl(_ item: test_component.AnyIStorageItem?) throws -> Bool {
+        open func IsEqual(_ item: test_component.AnyIStorageItem?) throws -> Bool {
             var value: boolean = 0
             let itemWrapper = __ABI_Windows_Storage.IStorageItemWrapper(item)
             let _item = try! itemWrapper?.toABI { $0 }
@@ -1368,7 +1368,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageItemProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageItemProperties }
 
-        open func GetThumbnailAsyncOverloadDefaultSizeDefaultOptionsImpl(_ mode: test_component.ThumbnailMode) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
+        open func GetThumbnailAsyncOverloadDefaultSizeDefaultOptions(_ mode: test_component.ThumbnailMode) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetThumbnailAsyncOverloadDefaultSizeDefaultOptions(pThis, mode, &operationAbi))
@@ -1377,7 +1377,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetThumbnailAsyncOverloadDefaultOptionsImpl(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
+        open func GetThumbnailAsyncOverloadDefaultOptions(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetThumbnailAsyncOverloadDefaultOptions(pThis, mode, requestedSize, &operationAbi))
@@ -1386,7 +1386,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetThumbnailAsyncImpl(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
+        open func GetThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetThumbnailAsync(pThis, mode, requestedSize, options, &operationAbi))
@@ -1395,7 +1395,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper.unwrapFrom(abi: operation)
         }
 
-        open func get_DisplayNameImpl() throws -> String {
+        open func get_DisplayName() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayName(pThis, &value))
@@ -1403,7 +1403,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        open func get_DisplayTypeImpl() throws -> String {
+        open func get_DisplayType() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayType(pThis, &value))
@@ -1411,7 +1411,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        open func get_FolderRelativeIdImpl() throws -> String {
+        open func get_FolderRelativeId() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_FolderRelativeId(pThis, &value))
@@ -1419,7 +1419,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        open func get_PropertiesImpl() throws -> test_component.StorageItemContentProperties? {
+        open func get_Properties() throws -> test_component.StorageItemContentProperties? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Properties(pThis, &valueAbi))
@@ -1527,7 +1527,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageItemProperties2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageItemProperties2 }
 
-        open func GetScaledImageAsThumbnailAsyncOverloadDefaultSizeDefaultOptionsImpl(_ mode: test_component.ThumbnailMode) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
+        open func GetScaledImageAsThumbnailAsyncOverloadDefaultSizeDefaultOptions(_ mode: test_component.ThumbnailMode) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties2.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetScaledImageAsThumbnailAsyncOverloadDefaultSizeDefaultOptions(pThis, mode, &operationAbi))
@@ -1536,7 +1536,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetScaledImageAsThumbnailAsyncOverloadDefaultOptionsImpl(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
+        open func GetScaledImageAsThumbnailAsyncOverloadDefaultOptions(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties2.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetScaledImageAsThumbnailAsyncOverloadDefaultOptions(pThis, mode, requestedSize, &operationAbi))
@@ -1545,7 +1545,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetScaledImageAsThumbnailAsyncImpl(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
+        open func GetScaledImageAsThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties2.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetScaledImageAsThumbnailAsync(pThis, mode, requestedSize, options, &operationAbi))
@@ -1626,7 +1626,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageItemPropertiesWithProvider: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageItemPropertiesWithProvider }
 
-        open func get_ProviderImpl() throws -> test_component.StorageProvider? {
+        open func get_Provider() throws -> test_component.StorageProvider? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemPropertiesWithProvider.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Provider(pThis, &valueAbi))
@@ -1678,7 +1678,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageLibraryChange: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageLibraryChange }
 
-        public func get_ChangeTypeImpl() throws -> test_component.StorageLibraryChangeType {
+        public func get_ChangeType() throws -> test_component.StorageLibraryChangeType {
             var value: __x_ABI_CWindows_CStorage_CStorageLibraryChangeType = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ChangeType(pThis, &value))
@@ -1686,7 +1686,7 @@ public enum __ABI_Windows_Storage {
             return value
         }
 
-        public func get_PathImpl() throws -> String {
+        public func get_Path() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Path(pThis, &value))
@@ -1694,7 +1694,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        public func get_PreviousPathImpl() throws -> String {
+        public func get_PreviousPath() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_PreviousPath(pThis, &value))
@@ -1702,7 +1702,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        public func IsOfTypeImpl(_ type: test_component.StorageItemTypes) throws -> Bool {
+        public func IsOfType(_ type: test_component.StorageItemTypes) throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.IsOfType(pThis, type, &value))
@@ -1710,7 +1710,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        public func GetStorageItemAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>? {
+        public func GetStorageItemAsync() throws -> test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetStorageItemAsync(pThis, &operationAbi))
@@ -1724,7 +1724,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageLibraryChangeReader: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader }
 
-        public func ReadBatchAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>? {
+        public func ReadBatchAsync() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.ReadBatchAsync(pThis, &operationAbi))
@@ -1733,7 +1733,7 @@ public enum __ABI_Windows_Storage {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper.unwrapFrom(abi: operation)
         }
 
-        public func AcceptChangesAsyncImpl() throws -> test_component.AnyIAsyncAction? {
+        public func AcceptChangesAsync() throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.AcceptChangesAsync(pThis, &operationAbi))
@@ -1747,7 +1747,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageLibraryChangeTracker: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker }
 
-        public func GetChangeReaderImpl() throws -> test_component.StorageLibraryChangeReader? {
+        public func GetChangeReader() throws -> test_component.StorageLibraryChangeReader? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetChangeReader(pThis, &valueAbi))
@@ -1756,13 +1756,13 @@ public enum __ABI_Windows_Storage {
             return .from(abi: value)
         }
 
-        public func EnableImpl() throws {
+        public func Enable() throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Enable(pThis))
             }
         }
 
-        public func ResetImpl() throws {
+        public func Reset() throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Reset(pThis))
             }
@@ -1773,7 +1773,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageProvider: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageProvider }
 
-        public func get_IdImpl() throws -> String {
+        public func get_Id() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageProvider.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Id(pThis, &value))
@@ -1781,7 +1781,7 @@ public enum __ABI_Windows_Storage {
             return .init(from: value)
         }
 
-        public func get_DisplayNameImpl() throws -> String {
+        public func get_DisplayName() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageProvider.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayName(pThis, &value))
@@ -1794,7 +1794,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageProvider2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageProvider2 }
 
-        public func IsPropertySupportedForPartialFileAsyncImpl(_ propertyCanonicalName: String) throws -> test_component.AnyIAsyncOperation<Bool>? {
+        public func IsPropertySupportedForPartialFileAsync(_ propertyCanonicalName: String) throws -> test_component.AnyIAsyncOperation<Bool>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let _propertyCanonicalName = try! HString(propertyCanonicalName)
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageProvider2.self) { pThis in
@@ -1809,7 +1809,7 @@ public enum __ABI_Windows_Storage {
     public class IStorageStreamTransaction: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStorageStreamTransaction }
 
-        public func get_StreamImpl() throws -> test_component.AnyIRandomAccessStream? {
+        public func get_Stream() throws -> test_component.AnyIRandomAccessStream? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageStreamTransaction.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Stream(pThis, &valueAbi))
@@ -1818,7 +1818,7 @@ public enum __ABI_Windows_Storage {
             return __ABI_Windows_Storage_Streams.IRandomAccessStreamWrapper.unwrapFrom(abi: value)
         }
 
-        public func CommitAsyncImpl() throws -> test_component.AnyIAsyncAction? {
+        public func CommitAsync() throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageStreamTransaction.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CommitAsync(pThis, &operationAbi))
@@ -1832,7 +1832,7 @@ public enum __ABI_Windows_Storage {
     public class IStreamedFileDataRequest: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStreamedFileDataRequest }
 
-        open func FailAndCloseImpl(_ failureMode: test_component.StreamedFileFailureMode) throws {
+        open func FailAndClose(_ failureMode: test_component.StreamedFileFailureMode) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStreamedFileDataRequest.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.FailAndClose(pThis, failureMode))
             }
@@ -1885,7 +1885,7 @@ extension __ABI_Windows_Storage {
     public class StreamedFileDataRequestedHandler: test_component.IUnknown {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CIStreamedFileDataRequestedHandler }
 
-        open func InvokeImpl(_ stream: test_component.StreamedFileDataRequest?) throws {
+        open func Invoke(_ stream: test_component.StreamedFileDataRequest?) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStreamedFileDataRequestedHandler.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(stream)))
             }

--- a/tests/test_component/Sources/test_component/Windows.Storage+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage+Impl.swift
@@ -30,125 +30,125 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.openasync)
         fileprivate func openAsync(_ accessMode: FileAccessMode) throws -> AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>! {
-            try _default.OpenAsyncImpl(accessMode)
+            try _default.OpenAsync(accessMode)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.opentransactedwriteasync)
         fileprivate func openTransactedWriteAsync() throws -> AnyIAsyncOperation<StorageStreamTransaction?>! {
-            try _default.OpenTransactedWriteAsyncImpl()
+            try _default.OpenTransactedWriteAsync()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.copyasync)
         fileprivate func copyAsync(_ destinationFolder: AnyIStorageFolder!) throws -> AnyIAsyncOperation<StorageFile?>! {
-            try _default.CopyOverloadDefaultNameAndOptionsImpl(destinationFolder)
+            try _default.CopyOverloadDefaultNameAndOptions(destinationFolder)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.copyasync)
         fileprivate func copyAsync(_ destinationFolder: AnyIStorageFolder!, _ desiredNewName: String) throws -> AnyIAsyncOperation<StorageFile?>! {
-            try _default.CopyOverloadDefaultOptionsImpl(destinationFolder, desiredNewName)
+            try _default.CopyOverloadDefaultOptions(destinationFolder, desiredNewName)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.copyasync)
         fileprivate func copyAsync(_ destinationFolder: AnyIStorageFolder!, _ desiredNewName: String, _ option: NameCollisionOption) throws -> AnyIAsyncOperation<StorageFile?>! {
-            try _default.CopyOverloadImpl(destinationFolder, desiredNewName, option)
+            try _default.CopyOverload(destinationFolder, desiredNewName, option)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.copyandreplaceasync)
         fileprivate func copyAndReplaceAsync(_ fileToReplace: AnyIStorageFile!) throws -> test_component.AnyIAsyncAction! {
-            try _default.CopyAndReplaceAsyncImpl(fileToReplace)
+            try _default.CopyAndReplaceAsync(fileToReplace)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.moveasync)
         fileprivate func moveAsync(_ destinationFolder: AnyIStorageFolder!) throws -> test_component.AnyIAsyncAction! {
-            try _default.MoveOverloadDefaultNameAndOptionsImpl(destinationFolder)
+            try _default.MoveOverloadDefaultNameAndOptions(destinationFolder)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.moveasync)
         fileprivate func moveAsync(_ destinationFolder: AnyIStorageFolder!, _ desiredNewName: String) throws -> test_component.AnyIAsyncAction! {
-            try _default.MoveOverloadDefaultOptionsImpl(destinationFolder, desiredNewName)
+            try _default.MoveOverloadDefaultOptions(destinationFolder, desiredNewName)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.moveasync)
         fileprivate func moveAsync(_ destinationFolder: AnyIStorageFolder!, _ desiredNewName: String, _ option: NameCollisionOption) throws -> test_component.AnyIAsyncAction! {
-            try _default.MoveOverloadImpl(destinationFolder, desiredNewName, option)
+            try _default.MoveOverload(destinationFolder, desiredNewName, option)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.moveandreplaceasync)
         fileprivate func moveAndReplaceAsync(_ fileToReplace: AnyIStorageFile!) throws -> test_component.AnyIAsyncAction! {
-            try _default.MoveAndReplaceAsyncImpl(fileToReplace)
+            try _default.MoveAndReplaceAsync(fileToReplace)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.contenttype)
         fileprivate var contentType : String {
-            get { try! _default.get_ContentTypeImpl() }
+            get { try! _default.get_ContentType() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.filetype)
         fileprivate var fileType : String {
-            get { try! _default.get_FileTypeImpl() }
+            get { try! _default.get_FileType() }
         }
 
         private lazy var _IStorageItem: __ABI_Windows_Storage.IStorageItem! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.renameasync)
         fileprivate func renameAsync(_ desiredName: String) throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.RenameAsyncOverloadDefaultOptionsImpl(desiredName)
+            try _IStorageItem.RenameAsyncOverloadDefaultOptions(desiredName)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.renameasync)
         fileprivate func renameAsync(_ desiredName: String, _ option: NameCollisionOption) throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.RenameAsyncImpl(desiredName, option)
+            try _IStorageItem.RenameAsync(desiredName, option)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.deleteasync)
         fileprivate func deleteAsync() throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.DeleteAsyncOverloadDefaultOptionsImpl()
+            try _IStorageItem.DeleteAsyncOverloadDefaultOptions()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.deleteasync)
         fileprivate func deleteAsync(_ option: StorageDeleteOption) throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.DeleteAsyncImpl(option)
+            try _IStorageItem.DeleteAsync(option)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.getbasicpropertiesasync)
         fileprivate func getBasicPropertiesAsync() throws -> AnyIAsyncOperation<test_component.BasicProperties?>! {
-            try _IStorageItem.GetBasicPropertiesAsyncImpl()
+            try _IStorageItem.GetBasicPropertiesAsync()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.isoftype)
         fileprivate func isOfType(_ type: StorageItemTypes) throws -> Bool {
-            try _IStorageItem.IsOfTypeImpl(type)
+            try _IStorageItem.IsOfType(type)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.attributes)
         fileprivate var attributes : FileAttributes {
-            get { try! _IStorageItem.get_AttributesImpl() }
+            get { try! _IStorageItem.get_Attributes() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.datecreated)
         fileprivate var dateCreated : test_component.DateTime {
-            get { try! _IStorageItem.get_DateCreatedImpl() }
+            get { try! _IStorageItem.get_DateCreated() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.name)
         fileprivate var name : String {
-            get { try! _IStorageItem.get_NameImpl() }
+            get { try! _IStorageItem.get_Name() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.path)
         fileprivate var path : String {
-            get { try! _IStorageItem.get_PathImpl() }
+            get { try! _IStorageItem.get_Path() }
         }
 
         private lazy var _IRandomAccessStreamReference: __ABI_Windows_Storage_Streams.IRandomAccessStreamReference! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.openreadasync)
         fileprivate func openReadAsync() throws -> AnyIAsyncOperation<test_component.AnyIRandomAccessStreamWithContentType?>! {
-            try _IRandomAccessStreamReference.OpenReadAsyncImpl()
+            try _IRandomAccessStreamReference.OpenReadAsync()
         }
 
         private lazy var _IInputStreamReference: __ABI_Windows_Storage_Streams.IInputStreamReference! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile.opensequentialreadasync)
         fileprivate func openSequentialReadAsync() throws -> AnyIAsyncOperation<test_component.AnyIInputStream?>! {
-            try _IInputStreamReference.OpenSequentialReadAsyncImpl()
+            try _IInputStreamReference.OpenSequentialReadAsync()
         }
 
     }
@@ -178,12 +178,12 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile2.openasync)
         fileprivate func openAsync(_ accessMode: FileAccessMode, _ options: StorageOpenOptions) throws -> AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>! {
-            try _default.OpenWithOptionsAsyncImpl(accessMode, options)
+            try _default.OpenWithOptionsAsync(accessMode, options)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefile2.opentransactedwriteasync)
         fileprivate func openTransactedWriteAsync(_ options: StorageOpenOptions) throws -> AnyIAsyncOperation<StorageStreamTransaction?>! {
-            try _default.OpenTransactedWriteWithOptionsAsyncImpl(options)
+            try _default.OpenTransactedWriteWithOptionsAsync(options)
         }
 
     }
@@ -213,7 +213,7 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefilepropertieswithavailability.isavailable)
         fileprivate var isAvailable : Bool {
-            get { try! _default.get_IsAvailableImpl() }
+            get { try! _default.get_IsAvailable() }
         }
 
     }
@@ -243,103 +243,103 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.createfileasync)
         fileprivate func createFileAsync(_ desiredName: String) throws -> AnyIAsyncOperation<StorageFile?>! {
-            try _default.CreateFileAsyncOverloadDefaultOptionsImpl(desiredName)
+            try _default.CreateFileAsyncOverloadDefaultOptions(desiredName)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.createfileasync)
         fileprivate func createFileAsync(_ desiredName: String, _ options: CreationCollisionOption) throws -> AnyIAsyncOperation<StorageFile?>! {
-            try _default.CreateFileAsyncImpl(desiredName, options)
+            try _default.CreateFileAsync(desiredName, options)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.createfolderasync)
         fileprivate func createFolderAsync(_ desiredName: String) throws -> AnyIAsyncOperation<StorageFolder?>! {
-            try _default.CreateFolderAsyncOverloadDefaultOptionsImpl(desiredName)
+            try _default.CreateFolderAsyncOverloadDefaultOptions(desiredName)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.createfolderasync)
         fileprivate func createFolderAsync(_ desiredName: String, _ options: CreationCollisionOption) throws -> AnyIAsyncOperation<StorageFolder?>! {
-            try _default.CreateFolderAsyncImpl(desiredName, options)
+            try _default.CreateFolderAsync(desiredName, options)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.getfileasync)
         fileprivate func getFileAsync(_ name: String) throws -> AnyIAsyncOperation<StorageFile?>! {
-            try _default.GetFileAsyncImpl(name)
+            try _default.GetFileAsync(name)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.getfolderasync)
         fileprivate func getFolderAsync(_ name: String) throws -> AnyIAsyncOperation<StorageFolder?>! {
-            try _default.GetFolderAsyncImpl(name)
+            try _default.GetFolderAsync(name)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.getitemasync)
         fileprivate func getItemAsync(_ name: String) throws -> AnyIAsyncOperation<AnyIStorageItem?>! {
-            try _default.GetItemAsyncImpl(name)
+            try _default.GetItemAsync(name)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.getfilesasync)
         fileprivate func getFilesAsync() throws -> AnyIAsyncOperation<AnyIVectorView<StorageFile?>?>! {
-            try _default.GetFilesAsyncOverloadDefaultOptionsStartAndCountImpl()
+            try _default.GetFilesAsyncOverloadDefaultOptionsStartAndCount()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.getfoldersasync)
         fileprivate func getFoldersAsync() throws -> AnyIAsyncOperation<AnyIVectorView<StorageFolder?>?>! {
-            try _default.GetFoldersAsyncOverloadDefaultOptionsStartAndCountImpl()
+            try _default.GetFoldersAsyncOverloadDefaultOptionsStartAndCount()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.getitemsasync)
         fileprivate func getItemsAsync() throws -> AnyIAsyncOperation<AnyIVectorView<AnyIStorageItem?>?>! {
-            try _default.GetItemsAsyncOverloadDefaultStartAndCountImpl()
+            try _default.GetItemsAsyncOverloadDefaultStartAndCount()
         }
 
         private lazy var _IStorageItem: __ABI_Windows_Storage.IStorageItem! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.renameasync)
         fileprivate func renameAsync(_ desiredName: String) throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.RenameAsyncOverloadDefaultOptionsImpl(desiredName)
+            try _IStorageItem.RenameAsyncOverloadDefaultOptions(desiredName)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.renameasync)
         fileprivate func renameAsync(_ desiredName: String, _ option: NameCollisionOption) throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.RenameAsyncImpl(desiredName, option)
+            try _IStorageItem.RenameAsync(desiredName, option)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.deleteasync)
         fileprivate func deleteAsync() throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.DeleteAsyncOverloadDefaultOptionsImpl()
+            try _IStorageItem.DeleteAsyncOverloadDefaultOptions()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.deleteasync)
         fileprivate func deleteAsync(_ option: StorageDeleteOption) throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.DeleteAsyncImpl(option)
+            try _IStorageItem.DeleteAsync(option)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.getbasicpropertiesasync)
         fileprivate func getBasicPropertiesAsync() throws -> AnyIAsyncOperation<test_component.BasicProperties?>! {
-            try _IStorageItem.GetBasicPropertiesAsyncImpl()
+            try _IStorageItem.GetBasicPropertiesAsync()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.isoftype)
         fileprivate func isOfType(_ type: StorageItemTypes) throws -> Bool {
-            try _IStorageItem.IsOfTypeImpl(type)
+            try _IStorageItem.IsOfType(type)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.attributes)
         fileprivate var attributes : FileAttributes {
-            get { try! _IStorageItem.get_AttributesImpl() }
+            get { try! _IStorageItem.get_Attributes() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.datecreated)
         fileprivate var dateCreated : test_component.DateTime {
-            get { try! _IStorageItem.get_DateCreatedImpl() }
+            get { try! _IStorageItem.get_DateCreated() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.name)
         fileprivate var name : String {
-            get { try! _IStorageItem.get_NameImpl() }
+            get { try! _IStorageItem.get_Name() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder.path)
         fileprivate var path : String {
-            get { try! _IStorageItem.get_PathImpl() }
+            get { try! _IStorageItem.get_Path() }
         }
 
     }
@@ -369,7 +369,7 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istoragefolder2.trygetitemasync)
         fileprivate func tryGetItemAsync(_ name: String) throws -> AnyIAsyncOperation<AnyIStorageItem?>! {
-            try _default.TryGetItemAsyncImpl(name)
+            try _default.TryGetItemAsync(name)
         }
 
     }
@@ -399,52 +399,52 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.renameasync)
         fileprivate func renameAsync(_ desiredName: String) throws -> test_component.AnyIAsyncAction! {
-            try _default.RenameAsyncOverloadDefaultOptionsImpl(desiredName)
+            try _default.RenameAsyncOverloadDefaultOptions(desiredName)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.renameasync)
         fileprivate func renameAsync(_ desiredName: String, _ option: NameCollisionOption) throws -> test_component.AnyIAsyncAction! {
-            try _default.RenameAsyncImpl(desiredName, option)
+            try _default.RenameAsync(desiredName, option)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.deleteasync)
         fileprivate func deleteAsync() throws -> test_component.AnyIAsyncAction! {
-            try _default.DeleteAsyncOverloadDefaultOptionsImpl()
+            try _default.DeleteAsyncOverloadDefaultOptions()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.deleteasync)
         fileprivate func deleteAsync(_ option: StorageDeleteOption) throws -> test_component.AnyIAsyncAction! {
-            try _default.DeleteAsyncImpl(option)
+            try _default.DeleteAsync(option)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.getbasicpropertiesasync)
         fileprivate func getBasicPropertiesAsync() throws -> AnyIAsyncOperation<test_component.BasicProperties?>! {
-            try _default.GetBasicPropertiesAsyncImpl()
+            try _default.GetBasicPropertiesAsync()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.isoftype)
         fileprivate func isOfType(_ type: StorageItemTypes) throws -> Bool {
-            try _default.IsOfTypeImpl(type)
+            try _default.IsOfType(type)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.attributes)
         fileprivate var attributes : FileAttributes {
-            get { try! _default.get_AttributesImpl() }
+            get { try! _default.get_Attributes() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.datecreated)
         fileprivate var dateCreated : test_component.DateTime {
-            get { try! _default.get_DateCreatedImpl() }
+            get { try! _default.get_DateCreated() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.name)
         fileprivate var name : String {
-            get { try! _default.get_NameImpl() }
+            get { try! _default.get_Name() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem.path)
         fileprivate var path : String {
-            get { try! _default.get_PathImpl() }
+            get { try! _default.get_Path() }
         }
 
     }
@@ -474,63 +474,63 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.getparentasync)
         fileprivate func getParentAsync() throws -> AnyIAsyncOperation<StorageFolder?>! {
-            try _default.GetParentAsyncImpl()
+            try _default.GetParentAsync()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.isequal)
         fileprivate func isEqual(_ item: AnyIStorageItem!) throws -> Bool {
-            try _default.IsEqualImpl(item)
+            try _default.IsEqual(item)
         }
 
         private lazy var _IStorageItem: __ABI_Windows_Storage.IStorageItem! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.renameasync)
         fileprivate func renameAsync(_ desiredName: String) throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.RenameAsyncOverloadDefaultOptionsImpl(desiredName)
+            try _IStorageItem.RenameAsyncOverloadDefaultOptions(desiredName)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.renameasync)
         fileprivate func renameAsync(_ desiredName: String, _ option: NameCollisionOption) throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.RenameAsyncImpl(desiredName, option)
+            try _IStorageItem.RenameAsync(desiredName, option)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.deleteasync)
         fileprivate func deleteAsync() throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.DeleteAsyncOverloadDefaultOptionsImpl()
+            try _IStorageItem.DeleteAsyncOverloadDefaultOptions()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.deleteasync)
         fileprivate func deleteAsync(_ option: StorageDeleteOption) throws -> test_component.AnyIAsyncAction! {
-            try _IStorageItem.DeleteAsyncImpl(option)
+            try _IStorageItem.DeleteAsync(option)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.getbasicpropertiesasync)
         fileprivate func getBasicPropertiesAsync() throws -> AnyIAsyncOperation<test_component.BasicProperties?>! {
-            try _IStorageItem.GetBasicPropertiesAsyncImpl()
+            try _IStorageItem.GetBasicPropertiesAsync()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.isoftype)
         fileprivate func isOfType(_ type: StorageItemTypes) throws -> Bool {
-            try _IStorageItem.IsOfTypeImpl(type)
+            try _IStorageItem.IsOfType(type)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.attributes)
         fileprivate var attributes : FileAttributes {
-            get { try! _IStorageItem.get_AttributesImpl() }
+            get { try! _IStorageItem.get_Attributes() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.datecreated)
         fileprivate var dateCreated : test_component.DateTime {
-            get { try! _IStorageItem.get_DateCreatedImpl() }
+            get { try! _IStorageItem.get_DateCreated() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.name)
         fileprivate var name : String {
-            get { try! _IStorageItem.get_NameImpl() }
+            get { try! _IStorageItem.get_Name() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitem2.path)
         fileprivate var path : String {
-            get { try! _IStorageItem.get_PathImpl() }
+            get { try! _IStorageItem.get_Path() }
         }
 
     }
@@ -560,37 +560,37 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties.getthumbnailasync)
         fileprivate func getThumbnailAsync(_ mode: test_component.ThumbnailMode) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _default.GetThumbnailAsyncOverloadDefaultSizeDefaultOptionsImpl(mode)
+            try _default.GetThumbnailAsyncOverloadDefaultSizeDefaultOptions(mode)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties.getthumbnailasync)
         fileprivate func getThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _default.GetThumbnailAsyncOverloadDefaultOptionsImpl(mode, requestedSize)
+            try _default.GetThumbnailAsyncOverloadDefaultOptions(mode, requestedSize)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties.getthumbnailasync)
         fileprivate func getThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _default.GetThumbnailAsyncImpl(mode, requestedSize, options)
+            try _default.GetThumbnailAsync(mode, requestedSize, options)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties.displayname)
         fileprivate var displayName : String {
-            get { try! _default.get_DisplayNameImpl() }
+            get { try! _default.get_DisplayName() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties.displaytype)
         fileprivate var displayType : String {
-            get { try! _default.get_DisplayTypeImpl() }
+            get { try! _default.get_DisplayType() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties.folderrelativeid)
         fileprivate var folderRelativeId : String {
-            get { try! _default.get_FolderRelativeIdImpl() }
+            get { try! _default.get_FolderRelativeId() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties.properties)
         fileprivate var properties : test_component.StorageItemContentProperties! {
-            get { try! _default.get_PropertiesImpl() }
+            get { try! _default.get_Properties() }
         }
 
     }
@@ -620,53 +620,53 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.getscaledimageasthumbnailasync)
         fileprivate func getScaledImageAsThumbnailAsync(_ mode: test_component.ThumbnailMode) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _default.GetScaledImageAsThumbnailAsyncOverloadDefaultSizeDefaultOptionsImpl(mode)
+            try _default.GetScaledImageAsThumbnailAsyncOverloadDefaultSizeDefaultOptions(mode)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.getscaledimageasthumbnailasync)
         fileprivate func getScaledImageAsThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _default.GetScaledImageAsThumbnailAsyncOverloadDefaultOptionsImpl(mode, requestedSize)
+            try _default.GetScaledImageAsThumbnailAsyncOverloadDefaultOptions(mode, requestedSize)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.getscaledimageasthumbnailasync)
         fileprivate func getScaledImageAsThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _default.GetScaledImageAsThumbnailAsyncImpl(mode, requestedSize, options)
+            try _default.GetScaledImageAsThumbnailAsync(mode, requestedSize, options)
         }
 
         private lazy var _IStorageItemProperties: __ABI_Windows_Storage.IStorageItemProperties! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.getthumbnailasync)
         fileprivate func getThumbnailAsync(_ mode: test_component.ThumbnailMode) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultSizeDefaultOptionsImpl(mode)
+            try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultSizeDefaultOptions(mode)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.getthumbnailasync)
         fileprivate func getThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultOptionsImpl(mode, requestedSize)
+            try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultOptions(mode, requestedSize)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.getthumbnailasync)
         fileprivate func getThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _IStorageItemProperties.GetThumbnailAsyncImpl(mode, requestedSize, options)
+            try _IStorageItemProperties.GetThumbnailAsync(mode, requestedSize, options)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.displayname)
         fileprivate var displayName : String {
-            get { try! _IStorageItemProperties.get_DisplayNameImpl() }
+            get { try! _IStorageItemProperties.get_DisplayName() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.displaytype)
         fileprivate var displayType : String {
-            get { try! _IStorageItemProperties.get_DisplayTypeImpl() }
+            get { try! _IStorageItemProperties.get_DisplayType() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.folderrelativeid)
         fileprivate var folderRelativeId : String {
-            get { try! _IStorageItemProperties.get_FolderRelativeIdImpl() }
+            get { try! _IStorageItemProperties.get_FolderRelativeId() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitemproperties2.properties)
         fileprivate var properties : test_component.StorageItemContentProperties! {
-            get { try! _IStorageItemProperties.get_PropertiesImpl() }
+            get { try! _IStorageItemProperties.get_Properties() }
         }
 
     }
@@ -696,43 +696,43 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.provider)
         fileprivate var provider : StorageProvider! {
-            get { try! _default.get_ProviderImpl() }
+            get { try! _default.get_Provider() }
         }
 
         private lazy var _IStorageItemProperties: __ABI_Windows_Storage.IStorageItemProperties! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.getthumbnailasync)
         fileprivate func getThumbnailAsync(_ mode: test_component.ThumbnailMode) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultSizeDefaultOptionsImpl(mode)
+            try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultSizeDefaultOptions(mode)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.getthumbnailasync)
         fileprivate func getThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultOptionsImpl(mode, requestedSize)
+            try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultOptions(mode, requestedSize)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.getthumbnailasync)
         fileprivate func getThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-            try _IStorageItemProperties.GetThumbnailAsyncImpl(mode, requestedSize, options)
+            try _IStorageItemProperties.GetThumbnailAsync(mode, requestedSize, options)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.displayname)
         fileprivate var displayName : String {
-            get { try! _IStorageItemProperties.get_DisplayNameImpl() }
+            get { try! _IStorageItemProperties.get_DisplayName() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.displaytype)
         fileprivate var displayType : String {
-            get { try! _IStorageItemProperties.get_DisplayTypeImpl() }
+            get { try! _IStorageItemProperties.get_DisplayType() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.folderrelativeid)
         fileprivate var folderRelativeId : String {
-            get { try! _IStorageItemProperties.get_FolderRelativeIdImpl() }
+            get { try! _IStorageItemProperties.get_FolderRelativeId() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istorageitempropertieswithprovider.properties)
         fileprivate var properties : test_component.StorageItemContentProperties! {
-            get { try! _IStorageItemProperties.get_PropertiesImpl() }
+            get { try! _IStorageItemProperties.get_Properties() }
         }
 
     }
@@ -762,7 +762,7 @@ public enum __IMPL_Windows_Storage {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.istreamedfiledatarequest.failandclose)
         fileprivate func failAndClose(_ failureMode: StreamedFileFailureMode) throws {
-            try _default.FailAndCloseImpl(failureMode)
+            try _default.FailAndClose(failureMode)
         }
 
     }
@@ -776,7 +776,7 @@ public enum __IMPL_Windows_Storage {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (stream) in
-                try _default.InvokeImpl(stream)
+                try _default.Invoke(stream)
             }
             return handler
         }

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+ABI.swift
@@ -40,7 +40,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IBasicProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties }
 
-        public func get_SizeImpl() throws -> UInt64 {
+        public func get_Size() throws -> UInt64 {
             var value: UINT64 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &value))
@@ -48,7 +48,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func get_DateModifiedImpl() throws -> test_component.DateTime {
+        public func get_DateModified() throws -> test_component.DateTime {
             var value: __x_ABI_CWindows_CFoundation_CDateTime = .init()
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DateModified(pThis, &value))
@@ -56,7 +56,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .from(abi: value)
         }
 
-        public func get_ItemDateImpl() throws -> test_component.DateTime {
+        public func get_ItemDate() throws -> test_component.DateTime {
             var value: __x_ABI_CWindows_CFoundation_CDateTime = .init()
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ItemDate(pThis, &value))
@@ -69,7 +69,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IDocumentProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties }
 
-        public func get_AuthorImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Author() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Author(pThis, &valueAbi))
@@ -78,7 +78,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_TitleImpl() throws -> String {
+        public func get_Title() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
@@ -86,14 +86,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_TitleImpl(_ value: String) throws {
+        public func put_Title(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Title(pThis, _value.get()))
             }
         }
 
-        public func get_KeywordsImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Keywords() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Keywords(pThis, &valueAbi))
@@ -102,7 +102,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_CommentImpl() throws -> String {
+        public func get_Comment() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Comment(pThis, &value))
@@ -110,7 +110,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_CommentImpl(_ value: String) throws {
+        public func put_Comment(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Comment(pThis, _value.get()))
@@ -122,7 +122,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IImageProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties }
 
-        public func get_RatingImpl() throws -> UInt32 {
+        public func get_Rating() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Rating(pThis, &value))
@@ -130,13 +130,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func put_RatingImpl(_ value: UInt32) throws {
+        public func put_Rating(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Rating(pThis, value))
             }
         }
 
-        public func get_KeywordsImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Keywords() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Keywords(pThis, &valueAbi))
@@ -145,7 +145,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_DateTakenImpl() throws -> test_component.DateTime {
+        public func get_DateTaken() throws -> test_component.DateTime {
             var value: __x_ABI_CWindows_CFoundation_CDateTime = .init()
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DateTaken(pThis, &value))
@@ -153,13 +153,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .from(abi: value)
         }
 
-        public func put_DateTakenImpl(_ value: test_component.DateTime) throws {
+        public func put_DateTaken(_ value: test_component.DateTime) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_DateTaken(pThis, .from(swift: value)))
             }
         }
 
-        public func get_WidthImpl() throws -> UInt32 {
+        public func get_Width() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Width(pThis, &value))
@@ -167,7 +167,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func get_HeightImpl() throws -> UInt32 {
+        public func get_Height() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Height(pThis, &value))
@@ -175,7 +175,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func get_TitleImpl() throws -> String {
+        public func get_Title() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
@@ -183,14 +183,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_TitleImpl(_ value: String) throws {
+        public func put_Title(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Title(pThis, _value.get()))
             }
         }
 
-        public func get_LatitudeImpl() throws -> Double? {
+        public func get_Latitude() throws -> Double? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Latitude(pThis, &valueAbi))
@@ -199,7 +199,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIReference_1_doubleWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_LongitudeImpl() throws -> Double? {
+        public func get_Longitude() throws -> Double? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Longitude(pThis, &valueAbi))
@@ -208,7 +208,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIReference_1_doubleWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_CameraManufacturerImpl() throws -> String {
+        public func get_CameraManufacturer() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_CameraManufacturer(pThis, &value))
@@ -216,14 +216,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_CameraManufacturerImpl(_ value: String) throws {
+        public func put_CameraManufacturer(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_CameraManufacturer(pThis, _value.get()))
             }
         }
 
-        public func get_CameraModelImpl() throws -> String {
+        public func get_CameraModel() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_CameraModel(pThis, &value))
@@ -231,14 +231,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_CameraModelImpl(_ value: String) throws {
+        public func put_CameraModel(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_CameraModel(pThis, _value.get()))
             }
         }
 
-        public func get_OrientationImpl() throws -> test_component.PhotoOrientation {
+        public func get_Orientation() throws -> test_component.PhotoOrientation {
             var value: __x_ABI_CWindows_CStorage_CFileProperties_CPhotoOrientation = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Orientation(pThis, &value))
@@ -246,7 +246,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func get_PeopleNamesImpl() throws -> test_component.AnyIVectorView<String>? {
+        public func get_PeopleNames() throws -> test_component.AnyIVectorView<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_PeopleNames(pThis, &valueAbi))
@@ -260,7 +260,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IMusicProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties }
 
-        public func get_AlbumImpl() throws -> String {
+        public func get_Album() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Album(pThis, &value))
@@ -268,14 +268,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_AlbumImpl(_ value: String) throws {
+        public func put_Album(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Album(pThis, _value.get()))
             }
         }
 
-        public func get_ArtistImpl() throws -> String {
+        public func get_Artist() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Artist(pThis, &value))
@@ -283,14 +283,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_ArtistImpl(_ value: String) throws {
+        public func put_Artist(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Artist(pThis, _value.get()))
             }
         }
 
-        public func get_GenreImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Genre() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Genre(pThis, &valueAbi))
@@ -299,7 +299,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_TrackNumberImpl() throws -> UInt32 {
+        public func get_TrackNumber() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_TrackNumber(pThis, &value))
@@ -307,13 +307,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func put_TrackNumberImpl(_ value: UInt32) throws {
+        public func put_TrackNumber(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_TrackNumber(pThis, value))
             }
         }
 
-        public func get_TitleImpl() throws -> String {
+        public func get_Title() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
@@ -321,14 +321,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_TitleImpl(_ value: String) throws {
+        public func put_Title(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Title(pThis, _value.get()))
             }
         }
 
-        public func get_RatingImpl() throws -> UInt32 {
+        public func get_Rating() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Rating(pThis, &value))
@@ -336,13 +336,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func put_RatingImpl(_ value: UInt32) throws {
+        public func put_Rating(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Rating(pThis, value))
             }
         }
 
-        public func get_DurationImpl() throws -> test_component.TimeSpan {
+        public func get_Duration() throws -> test_component.TimeSpan {
             var value: __x_ABI_CWindows_CFoundation_CTimeSpan = .init()
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Duration(pThis, &value))
@@ -350,7 +350,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .from(abi: value)
         }
 
-        public func get_BitrateImpl() throws -> UInt32 {
+        public func get_Bitrate() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Bitrate(pThis, &value))
@@ -358,7 +358,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func get_AlbumArtistImpl() throws -> String {
+        public func get_AlbumArtist() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AlbumArtist(pThis, &value))
@@ -366,14 +366,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_AlbumArtistImpl(_ value: String) throws {
+        public func put_AlbumArtist(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_AlbumArtist(pThis, _value.get()))
             }
         }
 
-        public func get_ComposersImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Composers() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Composers(pThis, &valueAbi))
@@ -382,7 +382,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_ConductorsImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Conductors() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Conductors(pThis, &valueAbi))
@@ -391,7 +391,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_SubtitleImpl() throws -> String {
+        public func get_Subtitle() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Subtitle(pThis, &value))
@@ -399,14 +399,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_SubtitleImpl(_ value: String) throws {
+        public func put_Subtitle(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Subtitle(pThis, _value.get()))
             }
         }
 
-        public func get_ProducersImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Producers() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Producers(pThis, &valueAbi))
@@ -415,7 +415,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_PublisherImpl() throws -> String {
+        public func get_Publisher() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Publisher(pThis, &value))
@@ -423,14 +423,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_PublisherImpl(_ value: String) throws {
+        public func put_Publisher(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Publisher(pThis, _value.get()))
             }
         }
 
-        public func get_WritersImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Writers() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Writers(pThis, &valueAbi))
@@ -439,7 +439,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_YearImpl() throws -> UInt32 {
+        public func get_Year() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Year(pThis, &value))
@@ -447,7 +447,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func put_YearImpl(_ value: UInt32) throws {
+        public func put_Year(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Year(pThis, value))
             }
@@ -458,7 +458,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IStorageItemContentProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties }
 
-        public func GetMusicPropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.MusicProperties?>? {
+        public func GetMusicPropertiesAsync() throws -> test_component.AnyIAsyncOperation<test_component.MusicProperties?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetMusicPropertiesAsync(pThis, &operationAbi))
@@ -467,7 +467,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper.unwrapFrom(abi: operation)
         }
 
-        public func GetVideoPropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.VideoProperties?>? {
+        public func GetVideoPropertiesAsync() throws -> test_component.AnyIAsyncOperation<test_component.VideoProperties?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetVideoPropertiesAsync(pThis, &operationAbi))
@@ -476,7 +476,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper.unwrapFrom(abi: operation)
         }
 
-        public func GetImagePropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.ImageProperties?>? {
+        public func GetImagePropertiesAsync() throws -> test_component.AnyIAsyncOperation<test_component.ImageProperties?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetImagePropertiesAsync(pThis, &operationAbi))
@@ -485,7 +485,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper.unwrapFrom(abi: operation)
         }
 
-        public func GetDocumentPropertiesAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.DocumentProperties?>? {
+        public func GetDocumentPropertiesAsync() throws -> test_component.AnyIAsyncOperation<test_component.DocumentProperties?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetDocumentPropertiesAsync(pThis, &operationAbi))
@@ -499,7 +499,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IStorageItemExtraProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemExtraProperties }
 
-        open func RetrievePropertiesAsyncImpl(_ propertiesToRetrieve: test_component.AnyIIterable<String>?) throws -> test_component.AnyIAsyncOperation<test_component.AnyIMap<String, Any?>?>? {
+        open func RetrievePropertiesAsync(_ propertiesToRetrieve: test_component.AnyIIterable<String>?) throws -> test_component.AnyIAsyncOperation<test_component.AnyIMap<String, Any?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let propertiesToRetrieveWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(propertiesToRetrieve)
                 let _propertiesToRetrieve = try! propertiesToRetrieveWrapper?.toABI { $0 }
@@ -510,7 +510,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: operation)
         }
 
-        open func SavePropertiesAsyncImpl(_ propertiesToSave: test_component.AnyIIterable<test_component.AnyIKeyValuePair<String, Any?>?>?) throws -> test_component.AnyIAsyncAction? {
+        open func SavePropertiesAsync(_ propertiesToSave: test_component.AnyIIterable<test_component.AnyIKeyValuePair<String, Any?>?>?) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let propertiesToSaveWrapper = test_component.__x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper(propertiesToSave)
                 let _propertiesToSave = try! propertiesToSaveWrapper?.toABI { $0 }
@@ -521,7 +521,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        open func SavePropertiesAsyncOverloadDefaultImpl() throws -> test_component.AnyIAsyncAction? {
+        open func SavePropertiesAsyncOverloadDefault() throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemExtraProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.SavePropertiesAsyncOverloadDefault(pThis, &operationAbi))
@@ -597,7 +597,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IThumbnailProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIThumbnailProperties }
 
-        public func get_OriginalWidthImpl() throws -> UInt32 {
+        public func get_OriginalWidth() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIThumbnailProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_OriginalWidth(pThis, &value))
@@ -605,7 +605,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func get_OriginalHeightImpl() throws -> UInt32 {
+        public func get_OriginalHeight() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIThumbnailProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_OriginalHeight(pThis, &value))
@@ -613,7 +613,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func get_ReturnedSmallerCachedSizeImpl() throws -> Bool {
+        public func get_ReturnedSmallerCachedSize() throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIThumbnailProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ReturnedSmallerCachedSize(pThis, &value))
@@ -621,7 +621,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func get_TypeImpl() throws -> test_component.ThumbnailType {
+        public func get_Type() throws -> test_component.ThumbnailType {
             var value: __x_ABI_CWindows_CStorage_CFileProperties_CThumbnailType = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIThumbnailProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Type(pThis, &value))
@@ -634,7 +634,7 @@ public enum __ABI_Windows_Storage_FileProperties {
     public class IVideoProperties: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties }
 
-        public func get_RatingImpl() throws -> UInt32 {
+        public func get_Rating() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Rating(pThis, &value))
@@ -642,13 +642,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func put_RatingImpl(_ value: UInt32) throws {
+        public func put_Rating(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Rating(pThis, value))
             }
         }
 
-        public func get_KeywordsImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Keywords() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Keywords(pThis, &valueAbi))
@@ -657,7 +657,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_WidthImpl() throws -> UInt32 {
+        public func get_Width() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Width(pThis, &value))
@@ -665,7 +665,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func get_HeightImpl() throws -> UInt32 {
+        public func get_Height() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Height(pThis, &value))
@@ -673,7 +673,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func get_DurationImpl() throws -> test_component.TimeSpan {
+        public func get_Duration() throws -> test_component.TimeSpan {
             var value: __x_ABI_CWindows_CFoundation_CTimeSpan = .init()
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Duration(pThis, &value))
@@ -681,7 +681,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .from(abi: value)
         }
 
-        public func get_LatitudeImpl() throws -> Double? {
+        public func get_Latitude() throws -> Double? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Latitude(pThis, &valueAbi))
@@ -690,7 +690,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIReference_1_doubleWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_LongitudeImpl() throws -> Double? {
+        public func get_Longitude() throws -> Double? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Longitude(pThis, &valueAbi))
@@ -699,7 +699,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIReference_1_doubleWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_TitleImpl() throws -> String {
+        public func get_Title() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
@@ -707,14 +707,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_TitleImpl(_ value: String) throws {
+        public func put_Title(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Title(pThis, _value.get()))
             }
         }
 
-        public func get_SubtitleImpl() throws -> String {
+        public func get_Subtitle() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Subtitle(pThis, &value))
@@ -722,14 +722,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_SubtitleImpl(_ value: String) throws {
+        public func put_Subtitle(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Subtitle(pThis, _value.get()))
             }
         }
 
-        public func get_ProducersImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Producers() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Producers(pThis, &valueAbi))
@@ -738,7 +738,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_PublisherImpl() throws -> String {
+        public func get_Publisher() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Publisher(pThis, &value))
@@ -746,14 +746,14 @@ public enum __ABI_Windows_Storage_FileProperties {
             return .init(from: value)
         }
 
-        public func put_PublisherImpl(_ value: String) throws {
+        public func put_Publisher(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Publisher(pThis, _value.get()))
             }
         }
 
-        public func get_WritersImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Writers() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Writers(pThis, &valueAbi))
@@ -762,7 +762,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_YearImpl() throws -> UInt32 {
+        public func get_Year() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Year(pThis, &value))
@@ -770,13 +770,13 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func put_YearImpl(_ value: UInt32) throws {
+        public func put_Year(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Year(pThis, value))
             }
         }
 
-        public func get_BitrateImpl() throws -> UInt32 {
+        public func get_Bitrate() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Bitrate(pThis, &value))
@@ -784,7 +784,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return value
         }
 
-        public func get_DirectorsImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_Directors() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Directors(pThis, &valueAbi))
@@ -793,7 +793,7 @@ public enum __ABI_Windows_Storage_FileProperties {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_OrientationImpl() throws -> test_component.VideoOrientation {
+        public func get_Orientation() throws -> test_component.VideoOrientation {
             var value: __x_ABI_CWindows_CStorage_CFileProperties_CVideoOrientation = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Orientation(pThis, &value))

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+Impl.swift
@@ -30,17 +30,17 @@ public enum __IMPL_Windows_Storage_FileProperties {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.istorageitemextraproperties.retrievepropertiesasync)
         fileprivate func retrievePropertiesAsync(_ propertiesToRetrieve: AnyIIterable<String>!) throws -> AnyIAsyncOperation<AnyIMap<String, Any?>?>! {
-            try _default.RetrievePropertiesAsyncImpl(propertiesToRetrieve)
+            try _default.RetrievePropertiesAsync(propertiesToRetrieve)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.istorageitemextraproperties.savepropertiesasync)
         fileprivate func savePropertiesAsync(_ propertiesToSave: AnyIIterable<AnyIKeyValuePair<String, Any?>?>!) throws -> test_component.AnyIAsyncAction! {
-            try _default.SavePropertiesAsyncImpl(propertiesToSave)
+            try _default.SavePropertiesAsync(propertiesToSave)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.istorageitemextraproperties.savepropertiesasync)
         fileprivate func savePropertiesAsync() throws -> test_component.AnyIAsyncAction! {
-            try _default.SavePropertiesAsyncOverloadDefaultImpl()
+            try _default.SavePropertiesAsyncOverloadDefault()
         }
 
     }

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties.swift
@@ -44,33 +44,33 @@ public final class BasicProperties : WinRTClass, IStorageItemExtraProperties {
     }
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.basicproperties.datemodified)
     public var dateModified : test_component.DateTime {
-        get { try! _default.get_DateModifiedImpl() }
+        get { try! _default.get_DateModified() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.basicproperties.itemdate)
     public var itemDate : test_component.DateTime {
-        get { try! _default.get_ItemDateImpl() }
+        get { try! _default.get_ItemDate() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.basicproperties.size)
     public var size : UInt64 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IStorageItemExtraProperties: __ABI_Windows_Storage_FileProperties.IStorageItemExtraProperties! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.basicproperties.retrievepropertiesasync)
     public func retrievePropertiesAsync(_ propertiesToRetrieve: AnyIIterable<String>!) throws -> AnyIAsyncOperation<AnyIMap<String, Any?>?>! {
-        try _IStorageItemExtraProperties.RetrievePropertiesAsyncImpl(propertiesToRetrieve)
+        try _IStorageItemExtraProperties.RetrievePropertiesAsync(propertiesToRetrieve)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.basicproperties.savepropertiesasync)
     public func savePropertiesAsync(_ propertiesToSave: AnyIIterable<AnyIKeyValuePair<String, Any?>?>!) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncImpl(propertiesToSave)
+        try _IStorageItemExtraProperties.SavePropertiesAsync(propertiesToSave)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.basicproperties.savepropertiesasync)
     public func savePropertiesAsync() throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefaultImpl()
+        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefault()
     }
 
     deinit {
@@ -109,39 +109,39 @@ public final class DocumentProperties : WinRTClass, IStorageItemExtraProperties 
     private lazy var _IStorageItemExtraProperties: __ABI_Windows_Storage_FileProperties.IStorageItemExtraProperties! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.documentproperties.retrievepropertiesasync)
     public func retrievePropertiesAsync(_ propertiesToRetrieve: AnyIIterable<String>!) throws -> AnyIAsyncOperation<AnyIMap<String, Any?>?>! {
-        try _IStorageItemExtraProperties.RetrievePropertiesAsyncImpl(propertiesToRetrieve)
+        try _IStorageItemExtraProperties.RetrievePropertiesAsync(propertiesToRetrieve)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.documentproperties.savepropertiesasync)
     public func savePropertiesAsync(_ propertiesToSave: AnyIIterable<AnyIKeyValuePair<String, Any?>?>!) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncImpl(propertiesToSave)
+        try _IStorageItemExtraProperties.SavePropertiesAsync(propertiesToSave)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.documentproperties.savepropertiesasync)
     public func savePropertiesAsync() throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefaultImpl()
+        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefault()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.documentproperties.author)
     public var author : AnyIVector<String>! {
-        get { try! _default.get_AuthorImpl() }
+        get { try! _default.get_Author() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.documentproperties.comment)
     public var comment : String {
-        get { try! _default.get_CommentImpl() }
-        set { try! _default.put_CommentImpl(newValue) }
+        get { try! _default.get_Comment() }
+        set { try! _default.put_Comment(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.documentproperties.keywords)
     public var keywords : AnyIVector<String>! {
-        get { try! _default.get_KeywordsImpl() }
+        get { try! _default.get_Keywords() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.documentproperties.title)
     public var title : String {
-        get { try! _default.get_TitleImpl() }
-        set { try! _default.put_TitleImpl(newValue) }
+        get { try! _default.get_Title() }
+        set { try! _default.put_Title(newValue) }
     }
 
     deinit {
@@ -180,82 +180,82 @@ public final class ImageProperties : WinRTClass, IStorageItemExtraProperties {
     private lazy var _IStorageItemExtraProperties: __ABI_Windows_Storage_FileProperties.IStorageItemExtraProperties! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.retrievepropertiesasync)
     public func retrievePropertiesAsync(_ propertiesToRetrieve: AnyIIterable<String>!) throws -> AnyIAsyncOperation<AnyIMap<String, Any?>?>! {
-        try _IStorageItemExtraProperties.RetrievePropertiesAsyncImpl(propertiesToRetrieve)
+        try _IStorageItemExtraProperties.RetrievePropertiesAsync(propertiesToRetrieve)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.savepropertiesasync)
     public func savePropertiesAsync(_ propertiesToSave: AnyIIterable<AnyIKeyValuePair<String, Any?>?>!) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncImpl(propertiesToSave)
+        try _IStorageItemExtraProperties.SavePropertiesAsync(propertiesToSave)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.savepropertiesasync)
     public func savePropertiesAsync() throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefaultImpl()
+        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefault()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.cameramanufacturer)
     public var cameraManufacturer : String {
-        get { try! _default.get_CameraManufacturerImpl() }
-        set { try! _default.put_CameraManufacturerImpl(newValue) }
+        get { try! _default.get_CameraManufacturer() }
+        set { try! _default.put_CameraManufacturer(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.cameramodel)
     public var cameraModel : String {
-        get { try! _default.get_CameraModelImpl() }
-        set { try! _default.put_CameraModelImpl(newValue) }
+        get { try! _default.get_CameraModel() }
+        set { try! _default.put_CameraModel(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.datetaken)
     public var dateTaken : test_component.DateTime {
-        get { try! _default.get_DateTakenImpl() }
-        set { try! _default.put_DateTakenImpl(newValue) }
+        get { try! _default.get_DateTaken() }
+        set { try! _default.put_DateTaken(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.height)
     public var height : UInt32 {
-        get { try! _default.get_HeightImpl() }
+        get { try! _default.get_Height() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.keywords)
     public var keywords : AnyIVector<String>! {
-        get { try! _default.get_KeywordsImpl() }
+        get { try! _default.get_Keywords() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.latitude)
     public var latitude : Double? {
-        get { try! _default.get_LatitudeImpl() }
+        get { try! _default.get_Latitude() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.longitude)
     public var longitude : Double? {
-        get { try! _default.get_LongitudeImpl() }
+        get { try! _default.get_Longitude() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.orientation)
     public var orientation : PhotoOrientation {
-        get { try! _default.get_OrientationImpl() }
+        get { try! _default.get_Orientation() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.peoplenames)
     public var peopleNames : AnyIVectorView<String>! {
-        get { try! _default.get_PeopleNamesImpl() }
+        get { try! _default.get_PeopleNames() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.rating)
     public var rating : UInt32 {
-        get { try! _default.get_RatingImpl() }
-        set { try! _default.put_RatingImpl(newValue) }
+        get { try! _default.get_Rating() }
+        set { try! _default.put_Rating(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.title)
     public var title : String {
-        get { try! _default.get_TitleImpl() }
-        set { try! _default.put_TitleImpl(newValue) }
+        get { try! _default.get_Title() }
+        set { try! _default.put_Title(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.imageproperties.width)
     public var width : UInt32 {
-        get { try! _default.get_WidthImpl() }
+        get { try! _default.get_Width() }
     }
 
     deinit {
@@ -294,106 +294,106 @@ public final class MusicProperties : WinRTClass, IStorageItemExtraProperties {
     private lazy var _IStorageItemExtraProperties: __ABI_Windows_Storage_FileProperties.IStorageItemExtraProperties! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.retrievepropertiesasync)
     public func retrievePropertiesAsync(_ propertiesToRetrieve: AnyIIterable<String>!) throws -> AnyIAsyncOperation<AnyIMap<String, Any?>?>! {
-        try _IStorageItemExtraProperties.RetrievePropertiesAsyncImpl(propertiesToRetrieve)
+        try _IStorageItemExtraProperties.RetrievePropertiesAsync(propertiesToRetrieve)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.savepropertiesasync)
     public func savePropertiesAsync(_ propertiesToSave: AnyIIterable<AnyIKeyValuePair<String, Any?>?>!) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncImpl(propertiesToSave)
+        try _IStorageItemExtraProperties.SavePropertiesAsync(propertiesToSave)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.savepropertiesasync)
     public func savePropertiesAsync() throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefaultImpl()
+        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefault()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.album)
     public var album : String {
-        get { try! _default.get_AlbumImpl() }
-        set { try! _default.put_AlbumImpl(newValue) }
+        get { try! _default.get_Album() }
+        set { try! _default.put_Album(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.albumartist)
     public var albumArtist : String {
-        get { try! _default.get_AlbumArtistImpl() }
-        set { try! _default.put_AlbumArtistImpl(newValue) }
+        get { try! _default.get_AlbumArtist() }
+        set { try! _default.put_AlbumArtist(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.artist)
     public var artist : String {
-        get { try! _default.get_ArtistImpl() }
-        set { try! _default.put_ArtistImpl(newValue) }
+        get { try! _default.get_Artist() }
+        set { try! _default.put_Artist(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.bitrate)
     public var bitrate : UInt32 {
-        get { try! _default.get_BitrateImpl() }
+        get { try! _default.get_Bitrate() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.composers)
     public var composers : AnyIVector<String>! {
-        get { try! _default.get_ComposersImpl() }
+        get { try! _default.get_Composers() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.conductors)
     public var conductors : AnyIVector<String>! {
-        get { try! _default.get_ConductorsImpl() }
+        get { try! _default.get_Conductors() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.duration)
     public var duration : test_component.TimeSpan {
-        get { try! _default.get_DurationImpl() }
+        get { try! _default.get_Duration() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.genre)
     public var genre : AnyIVector<String>! {
-        get { try! _default.get_GenreImpl() }
+        get { try! _default.get_Genre() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.producers)
     public var producers : AnyIVector<String>! {
-        get { try! _default.get_ProducersImpl() }
+        get { try! _default.get_Producers() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.publisher)
     public var publisher : String {
-        get { try! _default.get_PublisherImpl() }
-        set { try! _default.put_PublisherImpl(newValue) }
+        get { try! _default.get_Publisher() }
+        set { try! _default.put_Publisher(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.rating)
     public var rating : UInt32 {
-        get { try! _default.get_RatingImpl() }
-        set { try! _default.put_RatingImpl(newValue) }
+        get { try! _default.get_Rating() }
+        set { try! _default.put_Rating(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.subtitle)
     public var subtitle : String {
-        get { try! _default.get_SubtitleImpl() }
-        set { try! _default.put_SubtitleImpl(newValue) }
+        get { try! _default.get_Subtitle() }
+        set { try! _default.put_Subtitle(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.title)
     public var title : String {
-        get { try! _default.get_TitleImpl() }
-        set { try! _default.put_TitleImpl(newValue) }
+        get { try! _default.get_Title() }
+        set { try! _default.put_Title(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.tracknumber)
     public var trackNumber : UInt32 {
-        get { try! _default.get_TrackNumberImpl() }
-        set { try! _default.put_TrackNumberImpl(newValue) }
+        get { try! _default.get_TrackNumber() }
+        set { try! _default.put_TrackNumber(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.writers)
     public var writers : AnyIVector<String>! {
-        get { try! _default.get_WritersImpl() }
+        get { try! _default.get_Writers() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.musicproperties.year)
     public var year : UInt32 {
-        get { try! _default.get_YearImpl() }
-        set { try! _default.put_YearImpl(newValue) }
+        get { try! _default.get_Year() }
+        set { try! _default.put_Year(newValue) }
     }
 
     deinit {
@@ -432,37 +432,37 @@ public final class StorageItemContentProperties : WinRTClass, IStorageItemExtraP
     private lazy var _IStorageItemExtraProperties: __ABI_Windows_Storage_FileProperties.IStorageItemExtraProperties! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemcontentproperties.retrievepropertiesasync)
     public func retrievePropertiesAsync(_ propertiesToRetrieve: AnyIIterable<String>!) throws -> AnyIAsyncOperation<AnyIMap<String, Any?>?>! {
-        try _IStorageItemExtraProperties.RetrievePropertiesAsyncImpl(propertiesToRetrieve)
+        try _IStorageItemExtraProperties.RetrievePropertiesAsync(propertiesToRetrieve)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemcontentproperties.savepropertiesasync)
     public func savePropertiesAsync(_ propertiesToSave: AnyIIterable<AnyIKeyValuePair<String, Any?>?>!) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncImpl(propertiesToSave)
+        try _IStorageItemExtraProperties.SavePropertiesAsync(propertiesToSave)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemcontentproperties.savepropertiesasync)
     public func savePropertiesAsync() throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefaultImpl()
+        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefault()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemcontentproperties.getmusicpropertiesasync)
     public func getMusicPropertiesAsync() throws -> AnyIAsyncOperation<MusicProperties?>! {
-        try _default.GetMusicPropertiesAsyncImpl()
+        try _default.GetMusicPropertiesAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemcontentproperties.getvideopropertiesasync)
     public func getVideoPropertiesAsync() throws -> AnyIAsyncOperation<VideoProperties?>! {
-        try _default.GetVideoPropertiesAsyncImpl()
+        try _default.GetVideoPropertiesAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemcontentproperties.getimagepropertiesasync)
     public func getImagePropertiesAsync() throws -> AnyIAsyncOperation<ImageProperties?>! {
-        try _default.GetImagePropertiesAsyncImpl()
+        try _default.GetImagePropertiesAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemcontentproperties.getdocumentpropertiesasync)
     public func getDocumentPropertiesAsync() throws -> AnyIAsyncOperation<DocumentProperties?>! {
-        try _default.GetDocumentPropertiesAsyncImpl()
+        try _default.GetDocumentPropertiesAsync()
     }
 
     deinit {
@@ -501,93 +501,93 @@ public final class StorageItemThumbnail : WinRTClass, test_component.IClosable, 
     private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.close)
     public func close() throws {
-        try _IClosable.CloseImpl()
+        try _IClosable.Close()
     }
 
     private lazy var _IInputStream: __ABI_Windows_Storage_Streams.IInputStream! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.readasync)
     public func readAsync(_ buffer: test_component.AnyIBuffer!, _ count: UInt32, _ options: test_component.InputStreamOptions) throws -> AnyIAsyncOperationWithProgress<test_component.AnyIBuffer?, UInt32>! {
-        try _IInputStream.ReadAsyncImpl(buffer, count, options)
+        try _IInputStream.ReadAsync(buffer, count, options)
     }
 
     private lazy var _IOutputStream: __ABI_Windows_Storage_Streams.IOutputStream! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.writeasync)
     public func writeAsync(_ buffer: test_component.AnyIBuffer!) throws -> AnyIAsyncOperationWithProgress<UInt32, UInt32>! {
-        try _IOutputStream.WriteAsyncImpl(buffer)
+        try _IOutputStream.WriteAsync(buffer)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.flushasync)
     public func flushAsync() throws -> AnyIAsyncOperation<Bool>! {
-        try _IOutputStream.FlushAsyncImpl()
+        try _IOutputStream.FlushAsync()
     }
 
     private lazy var _IRandomAccessStream: __ABI_Windows_Storage_Streams.IRandomAccessStream! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.getinputstreamat)
     public func getInputStreamAt(_ position: UInt64) throws -> test_component.AnyIInputStream! {
-        try _IRandomAccessStream.GetInputStreamAtImpl(position)
+        try _IRandomAccessStream.GetInputStreamAt(position)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.getoutputstreamat)
     public func getOutputStreamAt(_ position: UInt64) throws -> test_component.AnyIOutputStream! {
-        try _IRandomAccessStream.GetOutputStreamAtImpl(position)
+        try _IRandomAccessStream.GetOutputStreamAt(position)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.seek)
     public func seek(_ position: UInt64) throws {
-        try _IRandomAccessStream.SeekImpl(position)
+        try _IRandomAccessStream.Seek(position)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.clonestream)
     public func cloneStream() throws -> test_component.AnyIRandomAccessStream! {
-        try _IRandomAccessStream.CloneStreamImpl()
+        try _IRandomAccessStream.CloneStream()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.canread)
     public var canRead : Bool {
-        get { try! _IRandomAccessStream.get_CanReadImpl() }
+        get { try! _IRandomAccessStream.get_CanRead() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.canwrite)
     public var canWrite : Bool {
-        get { try! _IRandomAccessStream.get_CanWriteImpl() }
+        get { try! _IRandomAccessStream.get_CanWrite() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.position)
     public var position : UInt64 {
-        get { try! _IRandomAccessStream.get_PositionImpl() }
+        get { try! _IRandomAccessStream.get_Position() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.size)
     public var size : UInt64 {
-        get { try! _IRandomAccessStream.get_SizeImpl() }
-        set { try! _IRandomAccessStream.put_SizeImpl(newValue) }
+        get { try! _IRandomAccessStream.get_Size() }
+        set { try! _IRandomAccessStream.put_Size(newValue) }
     }
 
     private lazy var _IContentTypeProvider: __ABI_Windows_Storage_Streams.IContentTypeProvider! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.contenttype)
     public var contentType : String {
-        get { try! _IContentTypeProvider.get_ContentTypeImpl() }
+        get { try! _IContentTypeProvider.get_ContentType() }
     }
 
     private lazy var _IThumbnailProperties: __ABI_Windows_Storage_FileProperties.IThumbnailProperties! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.originalheight)
     public var originalHeight : UInt32 {
-        get { try! _IThumbnailProperties.get_OriginalHeightImpl() }
+        get { try! _IThumbnailProperties.get_OriginalHeight() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.originalwidth)
     public var originalWidth : UInt32 {
-        get { try! _IThumbnailProperties.get_OriginalWidthImpl() }
+        get { try! _IThumbnailProperties.get_OriginalWidth() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.returnedsmallercachedsize)
     public var returnedSmallerCachedSize : Bool {
-        get { try! _IThumbnailProperties.get_ReturnedSmallerCachedSizeImpl() }
+        get { try! _IThumbnailProperties.get_ReturnedSmallerCachedSize() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.storageitemthumbnail.type)
     public var type : ThumbnailType {
-        get { try! _IThumbnailProperties.get_TypeImpl() }
+        get { try! _IThumbnailProperties.get_Type() }
     }
 
     deinit {
@@ -631,102 +631,102 @@ public final class VideoProperties : WinRTClass, IStorageItemExtraProperties {
     private lazy var _IStorageItemExtraProperties: __ABI_Windows_Storage_FileProperties.IStorageItemExtraProperties! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.retrievepropertiesasync)
     public func retrievePropertiesAsync(_ propertiesToRetrieve: AnyIIterable<String>!) throws -> AnyIAsyncOperation<AnyIMap<String, Any?>?>! {
-        try _IStorageItemExtraProperties.RetrievePropertiesAsyncImpl(propertiesToRetrieve)
+        try _IStorageItemExtraProperties.RetrievePropertiesAsync(propertiesToRetrieve)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.savepropertiesasync)
     public func savePropertiesAsync(_ propertiesToSave: AnyIIterable<AnyIKeyValuePair<String, Any?>?>!) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncImpl(propertiesToSave)
+        try _IStorageItemExtraProperties.SavePropertiesAsync(propertiesToSave)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.savepropertiesasync)
     public func savePropertiesAsync() throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefaultImpl()
+        try _IStorageItemExtraProperties.SavePropertiesAsyncOverloadDefault()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.bitrate)
     public var bitrate : UInt32 {
-        get { try! _default.get_BitrateImpl() }
+        get { try! _default.get_Bitrate() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.directors)
     public var directors : AnyIVector<String>! {
-        get { try! _default.get_DirectorsImpl() }
+        get { try! _default.get_Directors() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.duration)
     public var duration : test_component.TimeSpan {
-        get { try! _default.get_DurationImpl() }
+        get { try! _default.get_Duration() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.height)
     public var height : UInt32 {
-        get { try! _default.get_HeightImpl() }
+        get { try! _default.get_Height() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.keywords)
     public var keywords : AnyIVector<String>! {
-        get { try! _default.get_KeywordsImpl() }
+        get { try! _default.get_Keywords() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.latitude)
     public var latitude : Double? {
-        get { try! _default.get_LatitudeImpl() }
+        get { try! _default.get_Latitude() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.longitude)
     public var longitude : Double? {
-        get { try! _default.get_LongitudeImpl() }
+        get { try! _default.get_Longitude() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.orientation)
     public var orientation : VideoOrientation {
-        get { try! _default.get_OrientationImpl() }
+        get { try! _default.get_Orientation() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.producers)
     public var producers : AnyIVector<String>! {
-        get { try! _default.get_ProducersImpl() }
+        get { try! _default.get_Producers() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.publisher)
     public var publisher : String {
-        get { try! _default.get_PublisherImpl() }
-        set { try! _default.put_PublisherImpl(newValue) }
+        get { try! _default.get_Publisher() }
+        set { try! _default.put_Publisher(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.rating)
     public var rating : UInt32 {
-        get { try! _default.get_RatingImpl() }
-        set { try! _default.put_RatingImpl(newValue) }
+        get { try! _default.get_Rating() }
+        set { try! _default.put_Rating(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.subtitle)
     public var subtitle : String {
-        get { try! _default.get_SubtitleImpl() }
-        set { try! _default.put_SubtitleImpl(newValue) }
+        get { try! _default.get_Subtitle() }
+        set { try! _default.put_Subtitle(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.title)
     public var title : String {
-        get { try! _default.get_TitleImpl() }
-        set { try! _default.put_TitleImpl(newValue) }
+        get { try! _default.get_Title() }
+        set { try! _default.put_Title(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.width)
     public var width : UInt32 {
-        get { try! _default.get_WidthImpl() }
+        get { try! _default.get_Width() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.writers)
     public var writers : AnyIVector<String>! {
-        get { try! _default.get_WritersImpl() }
+        get { try! _default.get_Writers() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.fileproperties.videoproperties.year)
     public var year : UInt32 {
-        get { try! _default.get_YearImpl() }
-        set { try! _default.put_YearImpl(newValue) }
+        get { try! _default.get_Year() }
+        set { try! _default.put_Year(newValue) }
     }
 
     deinit {

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search+ABI.swift
@@ -44,7 +44,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IQueryOptions: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIQueryOptions }
 
-        public func get_FileTypeFilterImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_FileTypeFilter() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_FileTypeFilter(pThis, &valueAbi))
@@ -53,7 +53,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_FolderDepthImpl() throws -> test_component.FolderDepth {
+        public func get_FolderDepth() throws -> test_component.FolderDepth {
             var value: __x_ABI_CWindows_CStorage_CSearch_CFolderDepth = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_FolderDepth(pThis, &value))
@@ -61,13 +61,13 @@ public enum __ABI_Windows_Storage_Search {
             return value
         }
 
-        public func put_FolderDepthImpl(_ value: test_component.FolderDepth) throws {
+        public func put_FolderDepth(_ value: test_component.FolderDepth) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_FolderDepth(pThis, value))
             }
         }
 
-        public func get_ApplicationSearchFilterImpl() throws -> String {
+        public func get_ApplicationSearchFilter() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ApplicationSearchFilter(pThis, &value))
@@ -75,14 +75,14 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        public func put_ApplicationSearchFilterImpl(_ value: String) throws {
+        public func put_ApplicationSearchFilter(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_ApplicationSearchFilter(pThis, _value.get()))
             }
         }
 
-        public func get_UserSearchFilterImpl() throws -> String {
+        public func get_UserSearchFilter() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_UserSearchFilter(pThis, &value))
@@ -90,14 +90,14 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        public func put_UserSearchFilterImpl(_ value: String) throws {
+        public func put_UserSearchFilter(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_UserSearchFilter(pThis, _value.get()))
             }
         }
 
-        public func get_LanguageImpl() throws -> String {
+        public func get_Language() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Language(pThis, &value))
@@ -105,14 +105,14 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        public func put_LanguageImpl(_ value: String) throws {
+        public func put_Language(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Language(pThis, _value.get()))
             }
         }
 
-        public func get_IndexerOptionImpl() throws -> test_component.IndexerOption {
+        public func get_IndexerOption() throws -> test_component.IndexerOption {
             var value: __x_ABI_CWindows_CStorage_CSearch_CIndexerOption = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_IndexerOption(pThis, &value))
@@ -120,13 +120,13 @@ public enum __ABI_Windows_Storage_Search {
             return value
         }
 
-        public func put_IndexerOptionImpl(_ value: test_component.IndexerOption) throws {
+        public func put_IndexerOption(_ value: test_component.IndexerOption) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_IndexerOption(pThis, value))
             }
         }
 
-        public func get_SortOrderImpl() throws -> test_component.AnyIVector<test_component.SortEntry>? {
+        public func get_SortOrder() throws -> test_component.AnyIVector<test_component.SortEntry>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_SortOrder(pThis, &valueAbi))
@@ -135,7 +135,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryWrapper.unwrapFrom(abi: value)
         }
 
-        public func get_GroupPropertyNameImpl() throws -> String {
+        public func get_GroupPropertyName() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_GroupPropertyName(pThis, &value))
@@ -143,7 +143,7 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        public func get_DateStackOptionImpl() throws -> test_component.DateStackOption {
+        public func get_DateStackOption() throws -> test_component.DateStackOption {
             var value: __x_ABI_CWindows_CStorage_CSearch_CDateStackOption = .init(0)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DateStackOption(pThis, &value))
@@ -151,7 +151,7 @@ public enum __ABI_Windows_Storage_Search {
             return value
         }
 
-        public func SaveToStringImpl() throws -> String {
+        public func SaveToString() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.SaveToString(pThis, &value))
@@ -159,20 +159,20 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        public func LoadFromStringImpl(_ value: String) throws {
+        public func LoadFromString(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.LoadFromString(pThis, _value.get()))
             }
         }
 
-        public func SetThumbnailPrefetchImpl(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws {
+        public func SetThumbnailPrefetch(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.SetThumbnailPrefetch(pThis, mode, requestedSize, options))
             }
         }
 
-        public func SetPropertyPrefetchImpl(_ options: test_component.PropertyPrefetchOptions, _ propertiesToRetrieve: test_component.AnyIIterable<String>?) throws {
+        public func SetPropertyPrefetch(_ options: test_component.PropertyPrefetchOptions, _ propertiesToRetrieve: test_component.AnyIIterable<String>?) throws {
             let propertiesToRetrieveWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(propertiesToRetrieve)
             let _propertiesToRetrieve = try! propertiesToRetrieveWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
@@ -185,7 +185,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IQueryOptionsFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIQueryOptionsFactory }
 
-        public func CreateCommonFileQueryImpl(_ query: test_component.CommonFileQuery, _ fileTypeFilter: test_component.AnyIIterable<String>?) throws -> IQueryOptions {
+        public func CreateCommonFileQuery(_ query: test_component.CommonFileQuery, _ fileTypeFilter: test_component.AnyIIterable<String>?) throws -> IQueryOptions {
             let (queryOptions) = try ComPtrs.initialize { queryOptionsAbi in
                 let fileTypeFilterWrapper = test_component.__x_ABI_C__FIIterable_1_HSTRINGWrapper(fileTypeFilter)
                 let _fileTypeFilter = try! fileTypeFilterWrapper?.toABI { $0 }
@@ -196,7 +196,7 @@ public enum __ABI_Windows_Storage_Search {
             return IQueryOptions(queryOptions!)
         }
 
-        public func CreateCommonFolderQueryImpl(_ query: test_component.CommonFolderQuery) throws -> IQueryOptions {
+        public func CreateCommonFolderQuery(_ query: test_component.CommonFolderQuery) throws -> IQueryOptions {
             let (queryOptions) = try ComPtrs.initialize { queryOptionsAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptionsFactory.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateCommonFolderQuery(pThis, query, &queryOptionsAbi))
@@ -210,7 +210,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IQueryOptionsWithProviderFilter: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIQueryOptionsWithProviderFilter }
 
-        public func get_StorageProviderIdFilterImpl() throws -> test_component.AnyIVector<String>? {
+        public func get_StorageProviderIdFilter() throws -> test_component.AnyIVector<String>? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptionsWithProviderFilter.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_StorageProviderIdFilter(pThis, &valueAbi))
@@ -224,7 +224,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IStorageFileQueryResult: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult }
 
-        public func GetFilesAsyncImpl(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
+        public func GetFilesAsync(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFilesAsync(pThis, startIndex, maxNumberOfItems, &operationAbi))
@@ -233,7 +233,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        public func GetFilesAsyncDefaultStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
+        public func GetFilesAsyncDefaultStartAndCount() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFilesAsyncDefaultStartAndCount(pThis, &operationAbi))
@@ -247,7 +247,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IStorageFileQueryResult2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult2 }
 
-        public func GetMatchingPropertiesWithRangesImpl(_ file: test_component.StorageFile?) throws -> test_component.AnyIMap<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
+        public func GetMatchingPropertiesWithRanges(_ file: test_component.StorageFile?) throws -> test_component.AnyIMap<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult2.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetMatchingPropertiesWithRanges(pThis, RawPointer(file), &resultAbi))
@@ -261,7 +261,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IStorageFolderQueryOperations: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations }
 
-        open func GetIndexedStateAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.IndexedState>? {
+        open func GetIndexedStateAsync() throws -> test_component.AnyIAsyncOperation<test_component.IndexedState>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetIndexedStateAsync(pThis, &operationAbi))
@@ -270,7 +270,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper.unwrapFrom(abi: operation)
         }
 
-        open func CreateFileQueryOverloadDefaultImpl() throws -> test_component.StorageFileQueryResult? {
+        open func CreateFileQueryOverloadDefault() throws -> test_component.StorageFileQueryResult? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFileQueryOverloadDefault(pThis, &valueAbi))
@@ -279,7 +279,7 @@ public enum __ABI_Windows_Storage_Search {
             return .from(abi: value)
         }
 
-        open func CreateFileQueryImpl(_ query: test_component.CommonFileQuery) throws -> test_component.StorageFileQueryResult? {
+        open func CreateFileQuery(_ query: test_component.CommonFileQuery) throws -> test_component.StorageFileQueryResult? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFileQuery(pThis, query, &valueAbi))
@@ -288,7 +288,7 @@ public enum __ABI_Windows_Storage_Search {
             return .from(abi: value)
         }
 
-        open func CreateFileQueryWithOptionsImpl(_ queryOptions: test_component.QueryOptions?) throws -> test_component.StorageFileQueryResult? {
+        open func CreateFileQueryWithOptions(_ queryOptions: test_component.QueryOptions?) throws -> test_component.StorageFileQueryResult? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFileQueryWithOptions(pThis, RawPointer(queryOptions), &valueAbi))
@@ -297,7 +297,7 @@ public enum __ABI_Windows_Storage_Search {
             return .from(abi: value)
         }
 
-        open func CreateFolderQueryOverloadDefaultImpl() throws -> test_component.StorageFolderQueryResult? {
+        open func CreateFolderQueryOverloadDefault() throws -> test_component.StorageFolderQueryResult? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFolderQueryOverloadDefault(pThis, &valueAbi))
@@ -306,7 +306,7 @@ public enum __ABI_Windows_Storage_Search {
             return .from(abi: value)
         }
 
-        open func CreateFolderQueryImpl(_ query: test_component.CommonFolderQuery) throws -> test_component.StorageFolderQueryResult? {
+        open func CreateFolderQuery(_ query: test_component.CommonFolderQuery) throws -> test_component.StorageFolderQueryResult? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFolderQuery(pThis, query, &valueAbi))
@@ -315,7 +315,7 @@ public enum __ABI_Windows_Storage_Search {
             return .from(abi: value)
         }
 
-        open func CreateFolderQueryWithOptionsImpl(_ queryOptions: test_component.QueryOptions?) throws -> test_component.StorageFolderQueryResult? {
+        open func CreateFolderQueryWithOptions(_ queryOptions: test_component.QueryOptions?) throws -> test_component.StorageFolderQueryResult? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFolderQueryWithOptions(pThis, RawPointer(queryOptions), &valueAbi))
@@ -324,7 +324,7 @@ public enum __ABI_Windows_Storage_Search {
             return .from(abi: value)
         }
 
-        open func CreateItemQueryImpl() throws -> test_component.StorageItemQueryResult? {
+        open func CreateItemQuery() throws -> test_component.StorageItemQueryResult? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateItemQuery(pThis, &valueAbi))
@@ -333,7 +333,7 @@ public enum __ABI_Windows_Storage_Search {
             return .from(abi: value)
         }
 
-        open func CreateItemQueryWithOptionsImpl(_ queryOptions: test_component.QueryOptions?) throws -> test_component.StorageItemQueryResult? {
+        open func CreateItemQueryWithOptions(_ queryOptions: test_component.QueryOptions?) throws -> test_component.StorageItemQueryResult? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateItemQueryWithOptions(pThis, RawPointer(queryOptions), &valueAbi))
@@ -342,7 +342,7 @@ public enum __ABI_Windows_Storage_Search {
             return .from(abi: value)
         }
 
-        open func GetFilesAsyncImpl(_ query: test_component.CommonFileQuery, _ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
+        open func GetFilesAsync(_ query: test_component.CommonFileQuery, _ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFilesAsync(pThis, query, startIndex, maxItemsToRetrieve, &operationAbi))
@@ -351,7 +351,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetFilesAsyncOverloadDefaultStartAndCountImpl(_ query: test_component.CommonFileQuery) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
+        open func GetFilesAsyncOverloadDefaultStartAndCount(_ query: test_component.CommonFileQuery) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFilesAsyncOverloadDefaultStartAndCount(pThis, query, &operationAbi))
@@ -360,7 +360,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetFoldersAsyncImpl(_ query: test_component.CommonFolderQuery, _ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
+        open func GetFoldersAsync(_ query: test_component.CommonFolderQuery, _ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFoldersAsync(pThis, query, startIndex, maxItemsToRetrieve, &operationAbi))
@@ -369,7 +369,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetFoldersAsyncOverloadDefaultStartAndCountImpl(_ query: test_component.CommonFolderQuery) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
+        open func GetFoldersAsyncOverloadDefaultStartAndCount(_ query: test_component.CommonFolderQuery) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFoldersAsyncOverloadDefaultStartAndCount(pThis, query, &operationAbi))
@@ -378,7 +378,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetItemsAsyncImpl(_ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
+        open func GetItemsAsync(_ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetItemsAsync(pThis, startIndex, maxItemsToRetrieve, &operationAbi))
@@ -387,7 +387,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper.unwrapFrom(abi: operation)
         }
 
-        open func AreQueryOptionsSupportedImpl(_ queryOptions: test_component.QueryOptions?) throws -> Bool {
+        open func AreQueryOptionsSupported(_ queryOptions: test_component.QueryOptions?) throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.AreQueryOptionsSupported(pThis, RawPointer(queryOptions), &value))
@@ -395,7 +395,7 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        open func IsCommonFolderQuerySupportedImpl(_ query: test_component.CommonFolderQuery) throws -> Bool {
+        open func IsCommonFolderQuerySupported(_ query: test_component.CommonFolderQuery) throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.IsCommonFolderQuerySupported(pThis, query, &value))
@@ -403,7 +403,7 @@ public enum __ABI_Windows_Storage_Search {
             return .init(from: value)
         }
 
-        open func IsCommonFileQuerySupportedImpl(_ query: test_component.CommonFileQuery) throws -> Bool {
+        open func IsCommonFileQuerySupported(_ query: test_component.CommonFileQuery) throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.IsCommonFileQuerySupported(pThis, query, &value))
@@ -623,7 +623,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IStorageFolderQueryResult: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult }
 
-        public func GetFoldersAsyncImpl(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
+        public func GetFoldersAsync(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFoldersAsync(pThis, startIndex, maxNumberOfItems, &operationAbi))
@@ -632,7 +632,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: operation)
         }
 
-        public func GetFoldersAsyncDefaultStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
+        public func GetFoldersAsyncDefaultStartAndCount() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetFoldersAsyncDefaultStartAndCount(pThis, &operationAbi))
@@ -646,7 +646,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IStorageItemQueryResult: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult }
 
-        public func GetItemsAsyncImpl(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
+        public func GetItemsAsync(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetItemsAsync(pThis, startIndex, maxNumberOfItems, &operationAbi))
@@ -655,7 +655,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper.unwrapFrom(abi: operation)
         }
 
-        public func GetItemsAsyncDefaultStartAndCountImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
+        public func GetItemsAsyncDefaultStartAndCount() throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetItemsAsyncDefaultStartAndCount(pThis, &operationAbi))
@@ -669,7 +669,7 @@ public enum __ABI_Windows_Storage_Search {
     public class IStorageQueryResultBase: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CSearch_CIStorageQueryResultBase }
 
-        open func GetItemCountAsyncImpl() throws -> test_component.AnyIAsyncOperation<UInt32>? {
+        open func GetItemCountAsync() throws -> test_component.AnyIAsyncOperation<UInt32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageQueryResultBase.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetItemCountAsync(pThis, &operationAbi))
@@ -678,7 +678,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1_UINT32Wrapper.unwrapFrom(abi: operation)
         }
 
-        open func get_FolderImpl() throws -> test_component.StorageFolder? {
+        open func get_Folder() throws -> test_component.StorageFolder? {
             let (container) = try ComPtrs.initialize { containerAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageQueryResultBase.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Folder(pThis, &containerAbi))
@@ -687,7 +687,7 @@ public enum __ABI_Windows_Storage_Search {
             return .from(abi: container)
         }
 
-        open func add_ContentsChangedImpl(_ handler: TypedEventHandler<test_component.AnyIStorageQueryResultBase?, Any?>?) throws -> EventRegistrationToken {
+        open func add_ContentsChanged(_ handler: TypedEventHandler<test_component.AnyIStorageQueryResultBase?, Any?>?) throws -> EventRegistrationToken {
             var eventCookie: EventRegistrationToken = .init()
             let handlerWrapper = test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearch__CIStorageQueryResultBase_IInspectableWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -697,13 +697,13 @@ public enum __ABI_Windows_Storage_Search {
             return eventCookie
         }
 
-        open func remove_ContentsChangedImpl(_ eventCookie: EventRegistrationToken) throws {
+        open func remove_ContentsChanged(_ eventCookie: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageQueryResultBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_ContentsChanged(pThis, eventCookie))
             }
         }
 
-        open func add_OptionsChangedImpl(_ changedHandler: TypedEventHandler<test_component.AnyIStorageQueryResultBase?, Any?>?) throws -> EventRegistrationToken {
+        open func add_OptionsChanged(_ changedHandler: TypedEventHandler<test_component.AnyIStorageQueryResultBase?, Any?>?) throws -> EventRegistrationToken {
             var eventCookie: EventRegistrationToken = .init()
             let changedHandlerWrapper = test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearch__CIStorageQueryResultBase_IInspectableWrapper(changedHandler)
             let _changedHandler = try! changedHandlerWrapper?.toABI { $0 }
@@ -713,13 +713,13 @@ public enum __ABI_Windows_Storage_Search {
             return eventCookie
         }
 
-        open func remove_OptionsChangedImpl(_ eventCookie: EventRegistrationToken) throws {
+        open func remove_OptionsChanged(_ eventCookie: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageQueryResultBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_OptionsChanged(pThis, eventCookie))
             }
         }
 
-        open func FindStartIndexAsyncImpl(_ value: Any?) throws -> test_component.AnyIAsyncOperation<UInt32>? {
+        open func FindStartIndexAsync(_ value: Any?) throws -> test_component.AnyIAsyncOperation<UInt32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let valueWrapper = __ABI_.AnyWrapper(value)
                 let _value = try! valueWrapper?.toABI { $0 }
@@ -730,7 +730,7 @@ public enum __ABI_Windows_Storage_Search {
             return test_component.__x_ABI_C__FIAsyncOperation_1_UINT32Wrapper.unwrapFrom(abi: operation)
         }
 
-        open func GetCurrentQueryOptionsImpl() throws -> test_component.QueryOptions? {
+        open func GetCurrentQueryOptions() throws -> test_component.QueryOptions? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageQueryResultBase.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetCurrentQueryOptions(pThis, &valueAbi))
@@ -739,7 +739,7 @@ public enum __ABI_Windows_Storage_Search {
             return .from(abi: value)
         }
 
-        open func ApplyNewQueryOptionsImpl(_ newQueryOptions: test_component.QueryOptions?) throws {
+        open func ApplyNewQueryOptions(_ newQueryOptions: test_component.QueryOptions?) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIStorageQueryResultBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ApplyNewQueryOptions(pThis, RawPointer(newQueryOptions)))
             }

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
@@ -30,87 +30,87 @@ public enum __IMPL_Windows_Storage_Search {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.getindexedstateasync)
         fileprivate func getIndexedStateAsync() throws -> AnyIAsyncOperation<IndexedState>! {
-            try _default.GetIndexedStateAsyncImpl()
+            try _default.GetIndexedStateAsync()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.createfilequery)
         fileprivate func createFileQuery() throws -> StorageFileQueryResult! {
-            try _default.CreateFileQueryOverloadDefaultImpl()
+            try _default.CreateFileQueryOverloadDefault()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.createfilequery)
         fileprivate func createFileQuery(_ query: CommonFileQuery) throws -> StorageFileQueryResult! {
-            try _default.CreateFileQueryImpl(query)
+            try _default.CreateFileQuery(query)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.createfilequerywithoptions)
         fileprivate func createFileQueryWithOptions(_ queryOptions: QueryOptions!) throws -> StorageFileQueryResult! {
-            try _default.CreateFileQueryWithOptionsImpl(queryOptions)
+            try _default.CreateFileQueryWithOptions(queryOptions)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.createfolderquery)
         fileprivate func createFolderQuery() throws -> StorageFolderQueryResult! {
-            try _default.CreateFolderQueryOverloadDefaultImpl()
+            try _default.CreateFolderQueryOverloadDefault()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.createfolderquery)
         fileprivate func createFolderQuery(_ query: CommonFolderQuery) throws -> StorageFolderQueryResult! {
-            try _default.CreateFolderQueryImpl(query)
+            try _default.CreateFolderQuery(query)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.createfolderquerywithoptions)
         fileprivate func createFolderQueryWithOptions(_ queryOptions: QueryOptions!) throws -> StorageFolderQueryResult! {
-            try _default.CreateFolderQueryWithOptionsImpl(queryOptions)
+            try _default.CreateFolderQueryWithOptions(queryOptions)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.createitemquery)
         fileprivate func createItemQuery() throws -> StorageItemQueryResult! {
-            try _default.CreateItemQueryImpl()
+            try _default.CreateItemQuery()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.createitemquerywithoptions)
         fileprivate func createItemQueryWithOptions(_ queryOptions: QueryOptions!) throws -> StorageItemQueryResult! {
-            try _default.CreateItemQueryWithOptionsImpl(queryOptions)
+            try _default.CreateItemQueryWithOptions(queryOptions)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.getfilesasync)
         fileprivate func getFilesAsync(_ query: CommonFileQuery, _ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> AnyIAsyncOperation<AnyIVectorView<test_component.StorageFile?>?>! {
-            try _default.GetFilesAsyncImpl(query, startIndex, maxItemsToRetrieve)
+            try _default.GetFilesAsync(query, startIndex, maxItemsToRetrieve)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.getfilesasync)
         fileprivate func getFilesAsync(_ query: CommonFileQuery) throws -> AnyIAsyncOperation<AnyIVectorView<test_component.StorageFile?>?>! {
-            try _default.GetFilesAsyncOverloadDefaultStartAndCountImpl(query)
+            try _default.GetFilesAsyncOverloadDefaultStartAndCount(query)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.getfoldersasync)
         fileprivate func getFoldersAsync(_ query: CommonFolderQuery, _ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> AnyIAsyncOperation<AnyIVectorView<test_component.StorageFolder?>?>! {
-            try _default.GetFoldersAsyncImpl(query, startIndex, maxItemsToRetrieve)
+            try _default.GetFoldersAsync(query, startIndex, maxItemsToRetrieve)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.getfoldersasync)
         fileprivate func getFoldersAsync(_ query: CommonFolderQuery) throws -> AnyIAsyncOperation<AnyIVectorView<test_component.StorageFolder?>?>! {
-            try _default.GetFoldersAsyncOverloadDefaultStartAndCountImpl(query)
+            try _default.GetFoldersAsyncOverloadDefaultStartAndCount(query)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.getitemsasync)
         fileprivate func getItemsAsync(_ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> AnyIAsyncOperation<AnyIVectorView<test_component.AnyIStorageItem?>?>! {
-            try _default.GetItemsAsyncImpl(startIndex, maxItemsToRetrieve)
+            try _default.GetItemsAsync(startIndex, maxItemsToRetrieve)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.arequeryoptionssupported)
         fileprivate func areQueryOptionsSupported(_ queryOptions: QueryOptions!) throws -> Bool {
-            try _default.AreQueryOptionsSupportedImpl(queryOptions)
+            try _default.AreQueryOptionsSupported(queryOptions)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.iscommonfolderquerysupported)
         fileprivate func isCommonFolderQuerySupported(_ query: CommonFolderQuery) throws -> Bool {
-            try _default.IsCommonFolderQuerySupportedImpl(query)
+            try _default.IsCommonFolderQuerySupported(query)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations.iscommonfilequerysupported)
         fileprivate func isCommonFileQuerySupported(_ query: CommonFileQuery) throws -> Bool {
-            try _default.IsCommonFileQuerySupportedImpl(query)
+            try _default.IsCommonFileQuerySupported(query)
         }
 
     }
@@ -140,27 +140,27 @@ public enum __IMPL_Windows_Storage_Search {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragequeryresultbase.getitemcountasync)
         fileprivate func getItemCountAsync() throws -> AnyIAsyncOperation<UInt32>! {
-            try _default.GetItemCountAsyncImpl()
+            try _default.GetItemCountAsync()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragequeryresultbase.findstartindexasync)
         fileprivate func findStartIndexAsync(_ value: Any!) throws -> AnyIAsyncOperation<UInt32>! {
-            try _default.FindStartIndexAsyncImpl(value)
+            try _default.FindStartIndexAsync(value)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragequeryresultbase.getcurrentqueryoptions)
         fileprivate func getCurrentQueryOptions() throws -> QueryOptions! {
-            try _default.GetCurrentQueryOptionsImpl()
+            try _default.GetCurrentQueryOptions()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragequeryresultbase.applynewqueryoptions)
         fileprivate func applyNewQueryOptions(_ newQueryOptions: QueryOptions!) throws {
-            try _default.ApplyNewQueryOptionsImpl(newQueryOptions)
+            try _default.ApplyNewQueryOptions(newQueryOptions)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragequeryresultbase.folder)
         fileprivate var folder : test_component.StorageFolder! {
-            get { try! _default.get_FolderImpl() }
+            get { try! _default.get_Folder() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragequeryresultbase.contentschanged)
@@ -168,10 +168,10 @@ public enum __IMPL_Windows_Storage_Search {
           .init(
             add: { [weak self] in
               guard let this = self?._default else { return .init() }
-              return try! this.add_ContentsChangedImpl($0)
+              return try! this.add_ContentsChanged($0)
             },
             remove: { [weak self] in
-             try? self?._default.remove_ContentsChangedImpl($0)
+             try? self?._default.remove_ContentsChanged($0)
            }
           )
         }()
@@ -181,10 +181,10 @@ public enum __IMPL_Windows_Storage_Search {
           .init(
             add: { [weak self] in
               guard let this = self?._default else { return .init() }
-              return try! this.add_OptionsChangedImpl($0)
+              return try! this.add_OptionsChanged($0)
             },
             remove: { [weak self] in
-             try? self?._default.remove_OptionsChangedImpl($0)
+             try? self?._default.remove_OptionsChanged($0)
            }
           )
         }()

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
@@ -46,87 +46,87 @@ public final class QueryOptions : WinRTClass {
 
     private static let _IQueryOptionsFactory: __ABI_Windows_Storage_Search.IQueryOptionsFactory = try! RoGetActivationFactory("Windows.Storage.Search.QueryOptions")
     public init(_ query: CommonFileQuery, _ fileTypeFilter: AnyIIterable<String>!) {
-        super.init(try! Self._IQueryOptionsFactory.CreateCommonFileQueryImpl(query, fileTypeFilter))
+        super.init(try! Self._IQueryOptionsFactory.CreateCommonFileQuery(query, fileTypeFilter))
     }
 
     public init(_ query: CommonFolderQuery) {
-        super.init(try! Self._IQueryOptionsFactory.CreateCommonFolderQueryImpl(query))
+        super.init(try! Self._IQueryOptionsFactory.CreateCommonFolderQuery(query))
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.savetostring)
     public func saveToString() throws -> String {
-        try _default.SaveToStringImpl()
+        try _default.SaveToString()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.loadfromstring)
     public func loadFromString(_ value: String) throws {
-        try _default.LoadFromStringImpl(value)
+        try _default.LoadFromString(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.setthumbnailprefetch)
     public func setThumbnailPrefetch(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws {
-        try _default.SetThumbnailPrefetchImpl(mode, requestedSize, options)
+        try _default.SetThumbnailPrefetch(mode, requestedSize, options)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.setpropertyprefetch)
     public func setPropertyPrefetch(_ options: test_component.PropertyPrefetchOptions, _ propertiesToRetrieve: AnyIIterable<String>!) throws {
-        try _default.SetPropertyPrefetchImpl(options, propertiesToRetrieve)
+        try _default.SetPropertyPrefetch(options, propertiesToRetrieve)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.applicationsearchfilter)
     public var applicationSearchFilter : String {
-        get { try! _default.get_ApplicationSearchFilterImpl() }
-        set { try! _default.put_ApplicationSearchFilterImpl(newValue) }
+        get { try! _default.get_ApplicationSearchFilter() }
+        set { try! _default.put_ApplicationSearchFilter(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.datestackoption)
     public var dateStackOption : DateStackOption {
-        get { try! _default.get_DateStackOptionImpl() }
+        get { try! _default.get_DateStackOption() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.filetypefilter)
     public var fileTypeFilter : AnyIVector<String>! {
-        get { try! _default.get_FileTypeFilterImpl() }
+        get { try! _default.get_FileTypeFilter() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.folderdepth)
     public var folderDepth : FolderDepth {
-        get { try! _default.get_FolderDepthImpl() }
-        set { try! _default.put_FolderDepthImpl(newValue) }
+        get { try! _default.get_FolderDepth() }
+        set { try! _default.put_FolderDepth(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.grouppropertyname)
     public var groupPropertyName : String {
-        get { try! _default.get_GroupPropertyNameImpl() }
+        get { try! _default.get_GroupPropertyName() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.indexeroption)
     public var indexerOption : IndexerOption {
-        get { try! _default.get_IndexerOptionImpl() }
-        set { try! _default.put_IndexerOptionImpl(newValue) }
+        get { try! _default.get_IndexerOption() }
+        set { try! _default.put_IndexerOption(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.language)
     public var language : String {
-        get { try! _default.get_LanguageImpl() }
-        set { try! _default.put_LanguageImpl(newValue) }
+        get { try! _default.get_Language() }
+        set { try! _default.put_Language(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.sortorder)
     public var sortOrder : AnyIVector<SortEntry>! {
-        get { try! _default.get_SortOrderImpl() }
+        get { try! _default.get_SortOrder() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.usersearchfilter)
     public var userSearchFilter : String {
-        get { try! _default.get_UserSearchFilterImpl() }
-        set { try! _default.put_UserSearchFilterImpl(newValue) }
+        get { try! _default.get_UserSearchFilter() }
+        set { try! _default.put_UserSearchFilter(newValue) }
     }
 
     private lazy var _IQueryOptionsWithProviderFilter: __ABI_Windows_Storage_Search.IQueryOptionsWithProviderFilter! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.queryoptions.storageprovideridfilter)
     public var storageProviderIdFilter : AnyIVector<String>! {
-        get { try! _IQueryOptionsWithProviderFilter.get_StorageProviderIdFilterImpl() }
+        get { try! _IQueryOptionsWithProviderFilter.get_StorageProviderIdFilter() }
     }
 
     deinit {
@@ -165,27 +165,27 @@ public final class StorageFileQueryResult : WinRTClass, IStorageQueryResultBase 
     private lazy var _IStorageQueryResultBase: __ABI_Windows_Storage_Search.IStorageQueryResultBase! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefilequeryresult.getitemcountasync)
     public func getItemCountAsync() throws -> AnyIAsyncOperation<UInt32>! {
-        try _IStorageQueryResultBase.GetItemCountAsyncImpl()
+        try _IStorageQueryResultBase.GetItemCountAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefilequeryresult.findstartindexasync)
     public func findStartIndexAsync(_ value: Any!) throws -> AnyIAsyncOperation<UInt32>! {
-        try _IStorageQueryResultBase.FindStartIndexAsyncImpl(value)
+        try _IStorageQueryResultBase.FindStartIndexAsync(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefilequeryresult.getcurrentqueryoptions)
     public func getCurrentQueryOptions() throws -> QueryOptions! {
-        try _IStorageQueryResultBase.GetCurrentQueryOptionsImpl()
+        try _IStorageQueryResultBase.GetCurrentQueryOptions()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefilequeryresult.applynewqueryoptions)
     public func applyNewQueryOptions(_ newQueryOptions: QueryOptions!) throws {
-        try _IStorageQueryResultBase.ApplyNewQueryOptionsImpl(newQueryOptions)
+        try _IStorageQueryResultBase.ApplyNewQueryOptions(newQueryOptions)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefilequeryresult.folder)
     public var folder : test_component.StorageFolder! {
-        get { try! _IStorageQueryResultBase.get_FolderImpl() }
+        get { try! _IStorageQueryResultBase.get_Folder() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefilequeryresult.contentschanged)
@@ -193,10 +193,10 @@ public final class StorageFileQueryResult : WinRTClass, IStorageQueryResultBase 
       .init(
         add: { [weak self] in
           guard let this = self?._IStorageQueryResultBase else { return .init() }
-          return try! this.add_ContentsChangedImpl($0)
+          return try! this.add_ContentsChanged($0)
         },
         remove: { [weak self] in
-         try? self?._IStorageQueryResultBase.remove_ContentsChangedImpl($0)
+         try? self?._IStorageQueryResultBase.remove_ContentsChanged($0)
        }
       )
     }()
@@ -206,28 +206,28 @@ public final class StorageFileQueryResult : WinRTClass, IStorageQueryResultBase 
       .init(
         add: { [weak self] in
           guard let this = self?._IStorageQueryResultBase else { return .init() }
-          return try! this.add_OptionsChangedImpl($0)
+          return try! this.add_OptionsChanged($0)
         },
         remove: { [weak self] in
-         try? self?._IStorageQueryResultBase.remove_OptionsChangedImpl($0)
+         try? self?._IStorageQueryResultBase.remove_OptionsChanged($0)
        }
       )
     }()
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefilequeryresult.getfilesasync)
     public func getFilesAsync(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> AnyIAsyncOperation<AnyIVectorView<test_component.StorageFile?>?>! {
-        try _default.GetFilesAsyncImpl(startIndex, maxNumberOfItems)
+        try _default.GetFilesAsync(startIndex, maxNumberOfItems)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefilequeryresult.getfilesasync)
     public func getFilesAsync() throws -> AnyIAsyncOperation<AnyIVectorView<test_component.StorageFile?>?>! {
-        try _default.GetFilesAsyncDefaultStartAndCountImpl()
+        try _default.GetFilesAsyncDefaultStartAndCount()
     }
 
     private lazy var _IStorageFileQueryResult2: __ABI_Windows_Storage_Search.IStorageFileQueryResult2! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefilequeryresult.getmatchingpropertieswithranges)
     public func getMatchingPropertiesWithRanges(_ file: test_component.StorageFile!) throws -> AnyIMap<String, AnyIVectorView<test_component.TextSegment>?>! {
-        try _IStorageFileQueryResult2.GetMatchingPropertiesWithRangesImpl(file)
+        try _IStorageFileQueryResult2.GetMatchingPropertiesWithRanges(file)
     }
 
     deinit {
@@ -267,27 +267,27 @@ public final class StorageFolderQueryResult : WinRTClass, IStorageQueryResultBas
     private lazy var _IStorageQueryResultBase: __ABI_Windows_Storage_Search.IStorageQueryResultBase! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefolderqueryresult.getitemcountasync)
     public func getItemCountAsync() throws -> AnyIAsyncOperation<UInt32>! {
-        try _IStorageQueryResultBase.GetItemCountAsyncImpl()
+        try _IStorageQueryResultBase.GetItemCountAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefolderqueryresult.findstartindexasync)
     public func findStartIndexAsync(_ value: Any!) throws -> AnyIAsyncOperation<UInt32>! {
-        try _IStorageQueryResultBase.FindStartIndexAsyncImpl(value)
+        try _IStorageQueryResultBase.FindStartIndexAsync(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefolderqueryresult.getcurrentqueryoptions)
     public func getCurrentQueryOptions() throws -> QueryOptions! {
-        try _IStorageQueryResultBase.GetCurrentQueryOptionsImpl()
+        try _IStorageQueryResultBase.GetCurrentQueryOptions()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefolderqueryresult.applynewqueryoptions)
     public func applyNewQueryOptions(_ newQueryOptions: QueryOptions!) throws {
-        try _IStorageQueryResultBase.ApplyNewQueryOptionsImpl(newQueryOptions)
+        try _IStorageQueryResultBase.ApplyNewQueryOptions(newQueryOptions)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefolderqueryresult.folder)
     public var folder : test_component.StorageFolder! {
-        get { try! _IStorageQueryResultBase.get_FolderImpl() }
+        get { try! _IStorageQueryResultBase.get_Folder() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefolderqueryresult.contentschanged)
@@ -295,10 +295,10 @@ public final class StorageFolderQueryResult : WinRTClass, IStorageQueryResultBas
       .init(
         add: { [weak self] in
           guard let this = self?._IStorageQueryResultBase else { return .init() }
-          return try! this.add_ContentsChangedImpl($0)
+          return try! this.add_ContentsChanged($0)
         },
         remove: { [weak self] in
-         try? self?._IStorageQueryResultBase.remove_ContentsChangedImpl($0)
+         try? self?._IStorageQueryResultBase.remove_ContentsChanged($0)
        }
       )
     }()
@@ -308,22 +308,22 @@ public final class StorageFolderQueryResult : WinRTClass, IStorageQueryResultBas
       .init(
         add: { [weak self] in
           guard let this = self?._IStorageQueryResultBase else { return .init() }
-          return try! this.add_OptionsChangedImpl($0)
+          return try! this.add_OptionsChanged($0)
         },
         remove: { [weak self] in
-         try? self?._IStorageQueryResultBase.remove_OptionsChangedImpl($0)
+         try? self?._IStorageQueryResultBase.remove_OptionsChanged($0)
        }
       )
     }()
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefolderqueryresult.getfoldersasync)
     public func getFoldersAsync(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> AnyIAsyncOperation<AnyIVectorView<test_component.StorageFolder?>?>! {
-        try _default.GetFoldersAsyncImpl(startIndex, maxNumberOfItems)
+        try _default.GetFoldersAsync(startIndex, maxNumberOfItems)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storagefolderqueryresult.getfoldersasync)
     public func getFoldersAsync() throws -> AnyIAsyncOperation<AnyIVectorView<test_component.StorageFolder?>?>! {
-        try _default.GetFoldersAsyncDefaultStartAndCountImpl()
+        try _default.GetFoldersAsyncDefaultStartAndCount()
     }
 
     deinit {
@@ -362,27 +362,27 @@ public final class StorageItemQueryResult : WinRTClass, IStorageQueryResultBase 
     private lazy var _IStorageQueryResultBase: __ABI_Windows_Storage_Search.IStorageQueryResultBase! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storageitemqueryresult.getitemcountasync)
     public func getItemCountAsync() throws -> AnyIAsyncOperation<UInt32>! {
-        try _IStorageQueryResultBase.GetItemCountAsyncImpl()
+        try _IStorageQueryResultBase.GetItemCountAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storageitemqueryresult.findstartindexasync)
     public func findStartIndexAsync(_ value: Any!) throws -> AnyIAsyncOperation<UInt32>! {
-        try _IStorageQueryResultBase.FindStartIndexAsyncImpl(value)
+        try _IStorageQueryResultBase.FindStartIndexAsync(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storageitemqueryresult.getcurrentqueryoptions)
     public func getCurrentQueryOptions() throws -> QueryOptions! {
-        try _IStorageQueryResultBase.GetCurrentQueryOptionsImpl()
+        try _IStorageQueryResultBase.GetCurrentQueryOptions()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storageitemqueryresult.applynewqueryoptions)
     public func applyNewQueryOptions(_ newQueryOptions: QueryOptions!) throws {
-        try _IStorageQueryResultBase.ApplyNewQueryOptionsImpl(newQueryOptions)
+        try _IStorageQueryResultBase.ApplyNewQueryOptions(newQueryOptions)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storageitemqueryresult.folder)
     public var folder : test_component.StorageFolder! {
-        get { try! _IStorageQueryResultBase.get_FolderImpl() }
+        get { try! _IStorageQueryResultBase.get_Folder() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storageitemqueryresult.contentschanged)
@@ -390,10 +390,10 @@ public final class StorageItemQueryResult : WinRTClass, IStorageQueryResultBase 
       .init(
         add: { [weak self] in
           guard let this = self?._IStorageQueryResultBase else { return .init() }
-          return try! this.add_ContentsChangedImpl($0)
+          return try! this.add_ContentsChanged($0)
         },
         remove: { [weak self] in
-         try? self?._IStorageQueryResultBase.remove_ContentsChangedImpl($0)
+         try? self?._IStorageQueryResultBase.remove_ContentsChanged($0)
        }
       )
     }()
@@ -403,22 +403,22 @@ public final class StorageItemQueryResult : WinRTClass, IStorageQueryResultBase 
       .init(
         add: { [weak self] in
           guard let this = self?._IStorageQueryResultBase else { return .init() }
-          return try! this.add_OptionsChangedImpl($0)
+          return try! this.add_OptionsChanged($0)
         },
         remove: { [weak self] in
-         try? self?._IStorageQueryResultBase.remove_OptionsChangedImpl($0)
+         try? self?._IStorageQueryResultBase.remove_OptionsChanged($0)
        }
       )
     }()
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storageitemqueryresult.getitemsasync)
     public func getItemsAsync(_ startIndex: UInt32, _ maxNumberOfItems: UInt32) throws -> AnyIAsyncOperation<AnyIVectorView<test_component.AnyIStorageItem?>?>! {
-        try _default.GetItemsAsyncImpl(startIndex, maxNumberOfItems)
+        try _default.GetItemsAsync(startIndex, maxNumberOfItems)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.storageitemqueryresult.getitemsasync)
     public func getItemsAsync() throws -> AnyIAsyncOperation<AnyIVectorView<test_component.AnyIStorageItem?>?>! {
-        try _default.GetItemsAsyncDefaultStartAndCountImpl()
+        try _default.GetItemsAsyncDefaultStartAndCount()
     }
 
     deinit {

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams+ABI.swift
@@ -48,7 +48,7 @@ public enum __ABI_Windows_Storage_Streams {
     public class IBuffer: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIBuffer }
 
-        open func get_CapacityImpl() throws -> UInt32 {
+        open func get_Capacity() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIBuffer.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Capacity(pThis, &value))
@@ -56,7 +56,7 @@ public enum __ABI_Windows_Storage_Streams {
             return value
         }
 
-        open func get_LengthImpl() throws -> UInt32 {
+        open func get_Length() throws -> UInt32 {
             var value: UINT32 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIBuffer.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Length(pThis, &value))
@@ -64,7 +64,7 @@ public enum __ABI_Windows_Storage_Streams {
             return value
         }
 
-        open func put_LengthImpl(_ value: UInt32) throws {
+        open func put_Length(_ value: UInt32) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIBuffer.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Length(pThis, value))
             }
@@ -127,7 +127,7 @@ public enum __ABI_Windows_Storage_Streams {
     public class IBufferFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIBufferFactory }
 
-        public func CreateImpl(_ capacity: UInt32) throws -> IBuffer {
+        public func Create(_ capacity: UInt32) throws -> IBuffer {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIBufferFactory.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Create(pThis, capacity, &valueAbi))
@@ -141,7 +141,7 @@ public enum __ABI_Windows_Storage_Streams {
     public class IBufferStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIBufferStatics }
 
-        public func CreateCopyFromMemoryBufferImpl(_ input: test_component.AnyIMemoryBuffer?) throws -> test_component.Buffer? {
+        public func CreateCopyFromMemoryBuffer(_ input: test_component.AnyIMemoryBuffer?) throws -> test_component.Buffer? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let inputWrapper = __ABI_Windows_Foundation.IMemoryBufferWrapper(input)
                 let _input = try! inputWrapper?.toABI { $0 }
@@ -152,7 +152,7 @@ public enum __ABI_Windows_Storage_Streams {
             return .from(abi: value)
         }
 
-        public func CreateMemoryBufferOverIBufferImpl(_ input: test_component.AnyIBuffer?) throws -> test_component.MemoryBuffer? {
+        public func CreateMemoryBufferOverIBuffer(_ input: test_component.AnyIBuffer?) throws -> test_component.MemoryBuffer? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let inputWrapper = __ABI_Windows_Storage_Streams.IBufferWrapper(input)
                 let _input = try! inputWrapper?.toABI { $0 }
@@ -168,7 +168,7 @@ public enum __ABI_Windows_Storage_Streams {
     public class IContentTypeProvider: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIContentTypeProvider }
 
-        open func get_ContentTypeImpl() throws -> String {
+        open func get_ContentType() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIContentTypeProvider.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ContentType(pThis, &value))
@@ -218,7 +218,7 @@ public enum __ABI_Windows_Storage_Streams {
     public class IInputStream: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIInputStream }
 
-        open func ReadAsyncImpl(_ buffer: test_component.AnyIBuffer?, _ count: UInt32, _ options: test_component.InputStreamOptions) throws -> test_component.AnyIAsyncOperationWithProgress<test_component.AnyIBuffer?, UInt32>? {
+        open func ReadAsync(_ buffer: test_component.AnyIBuffer?, _ count: UInt32, _ options: test_component.InputStreamOptions) throws -> test_component.AnyIAsyncOperationWithProgress<test_component.AnyIBuffer?, UInt32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let bufferWrapper = __ABI_Windows_Storage_Streams.IBufferWrapper(buffer)
                 let _buffer = try! bufferWrapper?.toABI { $0 }
@@ -278,7 +278,7 @@ public enum __ABI_Windows_Storage_Streams {
     public class IInputStreamReference: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIInputStreamReference }
 
-        open func OpenSequentialReadAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIInputStream?>? {
+        open func OpenSequentialReadAsync() throws -> test_component.AnyIAsyncOperation<test_component.AnyIInputStream?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIInputStreamReference.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OpenSequentialReadAsync(pThis, &operationAbi))
@@ -332,7 +332,7 @@ public enum __ABI_Windows_Storage_Streams {
     public class IOutputStream: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIOutputStream }
 
-        open func WriteAsyncImpl(_ buffer: test_component.AnyIBuffer?) throws -> test_component.AnyIAsyncOperationWithProgress<UInt32, UInt32>? {
+        open func WriteAsync(_ buffer: test_component.AnyIBuffer?) throws -> test_component.AnyIAsyncOperationWithProgress<UInt32, UInt32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 let bufferWrapper = __ABI_Windows_Storage_Streams.IBufferWrapper(buffer)
                 let _buffer = try! bufferWrapper?.toABI { $0 }
@@ -343,7 +343,7 @@ public enum __ABI_Windows_Storage_Streams {
             return test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Wrapper.unwrapFrom(abi: operation)
         }
 
-        open func FlushAsyncImpl() throws -> test_component.AnyIAsyncOperation<Bool>? {
+        open func FlushAsync() throws -> test_component.AnyIAsyncOperation<Bool>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIOutputStream.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.FlushAsync(pThis, &operationAbi))
@@ -409,7 +409,7 @@ public enum __ABI_Windows_Storage_Streams {
     public class IRandomAccessStream: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStream }
 
-        open func get_SizeImpl() throws -> UInt64 {
+        open func get_Size() throws -> UInt64 {
             var value: UINT64 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &value))
@@ -417,13 +417,13 @@ public enum __ABI_Windows_Storage_Streams {
             return value
         }
 
-        open func put_SizeImpl(_ value: UInt64) throws {
+        open func put_Size(_ value: UInt64) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Size(pThis, value))
             }
         }
 
-        open func GetInputStreamAtImpl(_ position: UInt64) throws -> test_component.AnyIInputStream? {
+        open func GetInputStreamAt(_ position: UInt64) throws -> test_component.AnyIInputStream? {
             let (stream) = try ComPtrs.initialize { streamAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStream.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetInputStreamAt(pThis, position, &streamAbi))
@@ -432,7 +432,7 @@ public enum __ABI_Windows_Storage_Streams {
             return __ABI_Windows_Storage_Streams.IInputStreamWrapper.unwrapFrom(abi: stream)
         }
 
-        open func GetOutputStreamAtImpl(_ position: UInt64) throws -> test_component.AnyIOutputStream? {
+        open func GetOutputStreamAt(_ position: UInt64) throws -> test_component.AnyIOutputStream? {
             let (stream) = try ComPtrs.initialize { streamAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStream.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetOutputStreamAt(pThis, position, &streamAbi))
@@ -441,7 +441,7 @@ public enum __ABI_Windows_Storage_Streams {
             return __ABI_Windows_Storage_Streams.IOutputStreamWrapper.unwrapFrom(abi: stream)
         }
 
-        open func get_PositionImpl() throws -> UInt64 {
+        open func get_Position() throws -> UInt64 {
             var value: UINT64 = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Position(pThis, &value))
@@ -449,13 +449,13 @@ public enum __ABI_Windows_Storage_Streams {
             return value
         }
 
-        open func SeekImpl(_ position: UInt64) throws {
+        open func Seek(_ position: UInt64) throws {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Seek(pThis, position))
             }
         }
 
-        open func CloneStreamImpl() throws -> test_component.AnyIRandomAccessStream? {
+        open func CloneStream() throws -> test_component.AnyIRandomAccessStream? {
             let (stream) = try ComPtrs.initialize { streamAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStream.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CloneStream(pThis, &streamAbi))
@@ -464,7 +464,7 @@ public enum __ABI_Windows_Storage_Streams {
             return __ABI_Windows_Storage_Streams.IRandomAccessStreamWrapper.unwrapFrom(abi: stream)
         }
 
-        open func get_CanReadImpl() throws -> Bool {
+        open func get_CanRead() throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_CanRead(pThis, &value))
@@ -472,7 +472,7 @@ public enum __ABI_Windows_Storage_Streams {
             return .init(from: value)
         }
 
-        open func get_CanWriteImpl() throws -> Bool {
+        open func get_CanWrite() throws -> Bool {
             var value: boolean = 0
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_CanWrite(pThis, &value))
@@ -594,7 +594,7 @@ public enum __ABI_Windows_Storage_Streams {
     public class IRandomAccessStreamReference: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamReference }
 
-        open func OpenReadAsyncImpl() throws -> test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStreamWithContentType?>? {
+        open func OpenReadAsync() throws -> test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStreamWithContentType?>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamReference.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OpenReadAsync(pThis, &operationAbi))

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams+Impl.swift
@@ -30,13 +30,13 @@ public enum __IMPL_Windows_Storage_Streams {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.ibuffer.capacity)
         fileprivate var capacity : UInt32 {
-            get { try! _default.get_CapacityImpl() }
+            get { try! _default.get_Capacity() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.ibuffer.length)
         fileprivate var length : UInt32 {
-            get { try! _default.get_LengthImpl() }
-            set { try! _default.put_LengthImpl(newValue) }
+            get { try! _default.get_Length() }
+            set { try! _default.put_Length(newValue) }
         }
 
         private lazy var _IBufferByteAccess: __ABI_.IBufferByteAccess! = getInterfaceForCaching()
@@ -73,7 +73,7 @@ public enum __IMPL_Windows_Storage_Streams {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.icontenttypeprovider.contenttype)
         fileprivate var contentType : String {
-            get { try! _default.get_ContentTypeImpl() }
+            get { try! _default.get_ContentType() }
         }
 
     }
@@ -103,13 +103,13 @@ public enum __IMPL_Windows_Storage_Streams {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.iinputstream.readasync)
         fileprivate func readAsync(_ buffer: AnyIBuffer!, _ count: UInt32, _ options: InputStreamOptions) throws -> AnyIAsyncOperationWithProgress<AnyIBuffer?, UInt32>! {
-            try _default.ReadAsyncImpl(buffer, count, options)
+            try _default.ReadAsync(buffer, count, options)
         }
 
         private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.iinputstream.close)
         fileprivate func close() throws {
-            try _IClosable.CloseImpl()
+            try _IClosable.Close()
         }
 
     }
@@ -139,7 +139,7 @@ public enum __IMPL_Windows_Storage_Streams {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.iinputstreamreference.opensequentialreadasync)
         fileprivate func openSequentialReadAsync() throws -> AnyIAsyncOperation<AnyIInputStream?>! {
-            try _default.OpenSequentialReadAsyncImpl()
+            try _default.OpenSequentialReadAsync()
         }
 
     }
@@ -169,18 +169,18 @@ public enum __IMPL_Windows_Storage_Streams {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.ioutputstream.writeasync)
         fileprivate func writeAsync(_ buffer: AnyIBuffer!) throws -> AnyIAsyncOperationWithProgress<UInt32, UInt32>! {
-            try _default.WriteAsyncImpl(buffer)
+            try _default.WriteAsync(buffer)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.ioutputstream.flushasync)
         fileprivate func flushAsync() throws -> AnyIAsyncOperation<Bool>! {
-            try _default.FlushAsyncImpl()
+            try _default.FlushAsync()
         }
 
         private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.ioutputstream.close)
         fileprivate func close() throws {
-            try _IClosable.CloseImpl()
+            try _IClosable.Close()
         }
 
     }
@@ -210,66 +210,66 @@ public enum __IMPL_Windows_Storage_Streams {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.getinputstreamat)
         fileprivate func getInputStreamAt(_ position: UInt64) throws -> AnyIInputStream! {
-            try _default.GetInputStreamAtImpl(position)
+            try _default.GetInputStreamAt(position)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.getoutputstreamat)
         fileprivate func getOutputStreamAt(_ position: UInt64) throws -> AnyIOutputStream! {
-            try _default.GetOutputStreamAtImpl(position)
+            try _default.GetOutputStreamAt(position)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.seek)
         fileprivate func seek(_ position: UInt64) throws {
-            try _default.SeekImpl(position)
+            try _default.Seek(position)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.clonestream)
         fileprivate func cloneStream() throws -> AnyIRandomAccessStream! {
-            try _default.CloneStreamImpl()
+            try _default.CloneStream()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.canread)
         fileprivate var canRead : Bool {
-            get { try! _default.get_CanReadImpl() }
+            get { try! _default.get_CanRead() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.canwrite)
         fileprivate var canWrite : Bool {
-            get { try! _default.get_CanWriteImpl() }
+            get { try! _default.get_CanWrite() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.position)
         fileprivate var position : UInt64 {
-            get { try! _default.get_PositionImpl() }
+            get { try! _default.get_Position() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.size)
         fileprivate var size : UInt64 {
-            get { try! _default.get_SizeImpl() }
-            set { try! _default.put_SizeImpl(newValue) }
+            get { try! _default.get_Size() }
+            set { try! _default.put_Size(newValue) }
         }
 
         private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.close)
         fileprivate func close() throws {
-            try _IClosable.CloseImpl()
+            try _IClosable.Close()
         }
 
         private lazy var _IInputStream: __ABI_Windows_Storage_Streams.IInputStream! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.readasync)
         fileprivate func readAsync(_ buffer: AnyIBuffer!, _ count: UInt32, _ options: InputStreamOptions) throws -> AnyIAsyncOperationWithProgress<AnyIBuffer?, UInt32>! {
-            try _IInputStream.ReadAsyncImpl(buffer, count, options)
+            try _IInputStream.ReadAsync(buffer, count, options)
         }
 
         private lazy var _IOutputStream: __ABI_Windows_Storage_Streams.IOutputStream! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.writeasync)
         fileprivate func writeAsync(_ buffer: AnyIBuffer!) throws -> AnyIAsyncOperationWithProgress<UInt32, UInt32>! {
-            try _IOutputStream.WriteAsyncImpl(buffer)
+            try _IOutputStream.WriteAsync(buffer)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstream.flushasync)
         fileprivate func flushAsync() throws -> AnyIAsyncOperation<Bool>! {
-            try _IOutputStream.FlushAsyncImpl()
+            try _IOutputStream.FlushAsync()
         }
 
     }
@@ -299,7 +299,7 @@ public enum __IMPL_Windows_Storage_Streams {
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamreference.openreadasync)
         fileprivate func openReadAsync() throws -> AnyIAsyncOperation<AnyIRandomAccessStreamWithContentType?>! {
-            try _default.OpenReadAsyncImpl()
+            try _default.OpenReadAsync()
         }
 
     }
@@ -330,72 +330,72 @@ public enum __IMPL_Windows_Storage_Streams {
         private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.close)
         fileprivate func close() throws {
-            try _IClosable.CloseImpl()
+            try _IClosable.Close()
         }
 
         private lazy var _IInputStream: __ABI_Windows_Storage_Streams.IInputStream! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.readasync)
         fileprivate func readAsync(_ buffer: AnyIBuffer!, _ count: UInt32, _ options: InputStreamOptions) throws -> AnyIAsyncOperationWithProgress<AnyIBuffer?, UInt32>! {
-            try _IInputStream.ReadAsyncImpl(buffer, count, options)
+            try _IInputStream.ReadAsync(buffer, count, options)
         }
 
         private lazy var _IOutputStream: __ABI_Windows_Storage_Streams.IOutputStream! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.writeasync)
         fileprivate func writeAsync(_ buffer: AnyIBuffer!) throws -> AnyIAsyncOperationWithProgress<UInt32, UInt32>! {
-            try _IOutputStream.WriteAsyncImpl(buffer)
+            try _IOutputStream.WriteAsync(buffer)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.flushasync)
         fileprivate func flushAsync() throws -> AnyIAsyncOperation<Bool>! {
-            try _IOutputStream.FlushAsyncImpl()
+            try _IOutputStream.FlushAsync()
         }
 
         private lazy var _IRandomAccessStream: __ABI_Windows_Storage_Streams.IRandomAccessStream! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.getinputstreamat)
         fileprivate func getInputStreamAt(_ position: UInt64) throws -> AnyIInputStream! {
-            try _IRandomAccessStream.GetInputStreamAtImpl(position)
+            try _IRandomAccessStream.GetInputStreamAt(position)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.getoutputstreamat)
         fileprivate func getOutputStreamAt(_ position: UInt64) throws -> AnyIOutputStream! {
-            try _IRandomAccessStream.GetOutputStreamAtImpl(position)
+            try _IRandomAccessStream.GetOutputStreamAt(position)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.seek)
         fileprivate func seek(_ position: UInt64) throws {
-            try _IRandomAccessStream.SeekImpl(position)
+            try _IRandomAccessStream.Seek(position)
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.clonestream)
         fileprivate func cloneStream() throws -> AnyIRandomAccessStream! {
-            try _IRandomAccessStream.CloneStreamImpl()
+            try _IRandomAccessStream.CloneStream()
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.canread)
         fileprivate var canRead : Bool {
-            get { try! _IRandomAccessStream.get_CanReadImpl() }
+            get { try! _IRandomAccessStream.get_CanRead() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.canwrite)
         fileprivate var canWrite : Bool {
-            get { try! _IRandomAccessStream.get_CanWriteImpl() }
+            get { try! _IRandomAccessStream.get_CanWrite() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.position)
         fileprivate var position : UInt64 {
-            get { try! _IRandomAccessStream.get_PositionImpl() }
+            get { try! _IRandomAccessStream.get_Position() }
         }
 
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.size)
         fileprivate var size : UInt64 {
-            get { try! _IRandomAccessStream.get_SizeImpl() }
-            set { try! _IRandomAccessStream.put_SizeImpl(newValue) }
+            get { try! _IRandomAccessStream.get_Size() }
+            set { try! _IRandomAccessStream.put_Size(newValue) }
         }
 
         private lazy var _IContentTypeProvider: __ABI_Windows_Storage_Streams.IContentTypeProvider! = getInterfaceForCaching()
         /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.irandomaccessstreamwithcontenttype.contenttype)
         fileprivate var contentType : String {
-            get { try! _IContentTypeProvider.get_ContentTypeImpl() }
+            get { try! _IContentTypeProvider.get_ContentType() }
         }
 
     }

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams.swift
@@ -36,18 +36,18 @@ public final class Buffer : WinRTClass, IBufferByteAccess, IBuffer {
     }
     private static let _IBufferFactory: __ABI_Windows_Storage_Streams.IBufferFactory = try! RoGetActivationFactory("Windows.Storage.Streams.Buffer")
     public init(_ capacity: UInt32) {
-        super.init(try! Self._IBufferFactory.CreateImpl(capacity))
+        super.init(try! Self._IBufferFactory.Create(capacity))
     }
 
     private static let _IBufferStatics: __ABI_Windows_Storage_Streams.IBufferStatics = try! RoGetActivationFactory("Windows.Storage.Streams.Buffer")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.buffer.createcopyfrommemorybuffer)
     public static func createCopyFromMemoryBuffer(_ input: test_component.AnyIMemoryBuffer!) throws -> Buffer! {
-        return try _IBufferStatics.CreateCopyFromMemoryBufferImpl(input)
+        return try _IBufferStatics.CreateCopyFromMemoryBuffer(input)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.buffer.creatememorybufferoveribuffer)
     public static func createMemoryBufferOverIBuffer(_ input: AnyIBuffer!) throws -> test_component.MemoryBuffer! {
-        return try _IBufferStatics.CreateMemoryBufferOverIBufferImpl(input)
+        return try _IBufferStatics.CreateMemoryBufferOverIBuffer(input)
     }
 
     private lazy var _IBufferByteAccess: __ABI_.IBufferByteAccess! = getInterfaceForCaching()
@@ -59,13 +59,13 @@ public final class Buffer : WinRTClass, IBufferByteAccess, IBuffer {
     }
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.buffer.capacity)
     public var capacity : UInt32 {
-        get { try! _default.get_CapacityImpl() }
+        get { try! _default.get_Capacity() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streams.buffer.length)
     public var length : UInt32 {
-        get { try! _default.get_LengthImpl() }
-        set { try! _default.put_LengthImpl(newValue) }
+        get { try! _default.get_Length() }
+        set { try! _default.put_Length(newValue) }
     }
 
     deinit {

--- a/tests/test_component/Sources/test_component/Windows.Storage.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.swift
@@ -26,72 +26,72 @@ public final class PathIO {
     private static let _IPathIOStatics: __ABI_Windows_Storage.IPathIOStatics = try! RoGetActivationFactory("Windows.Storage.PathIO")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readtextasync)
     public static func readTextAsync(_ absolutePath: String) throws -> AnyIAsyncOperation<String>! {
-        return try _IPathIOStatics.ReadTextAsyncImpl(absolutePath)
+        return try _IPathIOStatics.ReadTextAsync(absolutePath)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readtextasync)
     public static func readTextAsync(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> AnyIAsyncOperation<String>! {
-        return try _IPathIOStatics.ReadTextWithEncodingAsyncImpl(absolutePath, encoding)
+        return try _IPathIOStatics.ReadTextWithEncodingAsync(absolutePath, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writetextasync)
     public static func writeTextAsync(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction! {
-        return try _IPathIOStatics.WriteTextAsyncImpl(absolutePath, contents)
+        return try _IPathIOStatics.WriteTextAsync(absolutePath, contents)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writetextasync)
     public static func writeTextAsync(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction! {
-        return try _IPathIOStatics.WriteTextWithEncodingAsyncImpl(absolutePath, contents, encoding)
+        return try _IPathIOStatics.WriteTextWithEncodingAsync(absolutePath, contents, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendtextasync)
     public static func appendTextAsync(_ absolutePath: String, _ contents: String) throws -> test_component.AnyIAsyncAction! {
-        return try _IPathIOStatics.AppendTextAsyncImpl(absolutePath, contents)
+        return try _IPathIOStatics.AppendTextAsync(absolutePath, contents)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendtextasync)
     public static func appendTextAsync(_ absolutePath: String, _ contents: String, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction! {
-        return try _IPathIOStatics.AppendTextWithEncodingAsyncImpl(absolutePath, contents, encoding)
+        return try _IPathIOStatics.AppendTextWithEncodingAsync(absolutePath, contents, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readlinesasync)
     public static func readLinesAsync(_ absolutePath: String) throws -> AnyIAsyncOperation<AnyIVector<String>?>! {
-        return try _IPathIOStatics.ReadLinesAsyncImpl(absolutePath)
+        return try _IPathIOStatics.ReadLinesAsync(absolutePath)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readlinesasync)
     public static func readLinesAsync(_ absolutePath: String, _ encoding: test_component.UnicodeEncoding) throws -> AnyIAsyncOperation<AnyIVector<String>?>! {
-        return try _IPathIOStatics.ReadLinesWithEncodingAsyncImpl(absolutePath, encoding)
+        return try _IPathIOStatics.ReadLinesWithEncodingAsync(absolutePath, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writelinesasync)
     public static func writeLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!) throws -> test_component.AnyIAsyncAction! {
-        return try _IPathIOStatics.WriteLinesAsyncImpl(absolutePath, lines)
+        return try _IPathIOStatics.WriteLinesAsync(absolutePath, lines)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writelinesasync)
     public static func writeLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction! {
-        return try _IPathIOStatics.WriteLinesWithEncodingAsyncImpl(absolutePath, lines, encoding)
+        return try _IPathIOStatics.WriteLinesWithEncodingAsync(absolutePath, lines, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendlinesasync)
     public static func appendLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!) throws -> test_component.AnyIAsyncAction! {
-        return try _IPathIOStatics.AppendLinesAsyncImpl(absolutePath, lines)
+        return try _IPathIOStatics.AppendLinesAsync(absolutePath, lines)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.appendlinesasync)
     public static func appendLinesAsync(_ absolutePath: String, _ lines: AnyIIterable<String>!, _ encoding: test_component.UnicodeEncoding) throws -> test_component.AnyIAsyncAction! {
-        return try _IPathIOStatics.AppendLinesWithEncodingAsyncImpl(absolutePath, lines, encoding)
+        return try _IPathIOStatics.AppendLinesWithEncodingAsync(absolutePath, lines, encoding)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.readbufferasync)
     public static func readBufferAsync(_ absolutePath: String) throws -> AnyIAsyncOperation<test_component.AnyIBuffer?>! {
-        return try _IPathIOStatics.ReadBufferAsyncImpl(absolutePath)
+        return try _IPathIOStatics.ReadBufferAsync(absolutePath)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.pathio.writebufferasync)
     public static func writeBufferAsync(_ absolutePath: String, _ buffer: test_component.AnyIBuffer!) throws -> test_component.AnyIAsyncAction! {
-        return try _IPathIOStatics.WriteBufferAsyncImpl(absolutePath, buffer)
+        return try _IPathIOStatics.WriteBufferAsync(absolutePath, buffer)
     }
 
 }
@@ -126,241 +126,241 @@ public final class StorageFile : WinRTClass, IStorageItem, test_component.IRando
     private static let _IStorageFileStatics: __ABI_Windows_Storage.IStorageFileStatics = try! RoGetActivationFactory("Windows.Storage.StorageFile")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getfilefrompathasync)
     public static func getFileFromPathAsync(_ path: String) throws -> AnyIAsyncOperation<StorageFile?>! {
-        return try _IStorageFileStatics.GetFileFromPathAsyncImpl(path)
+        return try _IStorageFileStatics.GetFileFromPathAsync(path)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getfilefromapplicationuriasync)
     public static func getFileFromApplicationUriAsync(_ uri: test_component.Uri!) throws -> AnyIAsyncOperation<StorageFile?>! {
-        return try _IStorageFileStatics.GetFileFromApplicationUriAsyncImpl(uri)
+        return try _IStorageFileStatics.GetFileFromApplicationUriAsync(uri)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.createstreamedfileasync)
     public static func createStreamedFileAsync(_ displayNameWithExtension: String, _ dataRequested: StreamedFileDataRequestedHandler!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) throws -> AnyIAsyncOperation<StorageFile?>! {
-        return try _IStorageFileStatics.CreateStreamedFileAsyncImpl(displayNameWithExtension, dataRequested, thumbnail)
+        return try _IStorageFileStatics.CreateStreamedFileAsync(displayNameWithExtension, dataRequested, thumbnail)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.replacewithstreamedfileasync)
     public static func replaceWithStreamedFileAsync(_ fileToReplace: AnyIStorageFile!, _ dataRequested: StreamedFileDataRequestedHandler!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) throws -> AnyIAsyncOperation<StorageFile?>! {
-        return try _IStorageFileStatics.ReplaceWithStreamedFileAsyncImpl(fileToReplace, dataRequested, thumbnail)
+        return try _IStorageFileStatics.ReplaceWithStreamedFileAsync(fileToReplace, dataRequested, thumbnail)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.createstreamedfilefromuriasync)
     public static func createStreamedFileFromUriAsync(_ displayNameWithExtension: String, _ uri: test_component.Uri!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) throws -> AnyIAsyncOperation<StorageFile?>! {
-        return try _IStorageFileStatics.CreateStreamedFileFromUriAsyncImpl(displayNameWithExtension, uri, thumbnail)
+        return try _IStorageFileStatics.CreateStreamedFileFromUriAsync(displayNameWithExtension, uri, thumbnail)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.replacewithstreamedfilefromuriasync)
     public static func replaceWithStreamedFileFromUriAsync(_ fileToReplace: AnyIStorageFile!, _ uri: test_component.Uri!, _ thumbnail: test_component.AnyIRandomAccessStreamReference!) throws -> AnyIAsyncOperation<StorageFile?>! {
-        return try _IStorageFileStatics.ReplaceWithStreamedFileFromUriAsyncImpl(fileToReplace, uri, thumbnail)
+        return try _IStorageFileStatics.ReplaceWithStreamedFileFromUriAsync(fileToReplace, uri, thumbnail)
     }
 
     private lazy var _IStorageItem: __ABI_Windows_Storage.IStorageItem! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.renameasync)
     public func renameAsync(_ desiredName: String) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItem.RenameAsyncOverloadDefaultOptionsImpl(desiredName)
+        try _IStorageItem.RenameAsyncOverloadDefaultOptions(desiredName)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.renameasync)
     public func renameAsync(_ desiredName: String, _ option: NameCollisionOption) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItem.RenameAsyncImpl(desiredName, option)
+        try _IStorageItem.RenameAsync(desiredName, option)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.deleteasync)
     public func deleteAsync() throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItem.DeleteAsyncOverloadDefaultOptionsImpl()
+        try _IStorageItem.DeleteAsyncOverloadDefaultOptions()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.deleteasync)
     public func deleteAsync(_ option: StorageDeleteOption) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItem.DeleteAsyncImpl(option)
+        try _IStorageItem.DeleteAsync(option)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getbasicpropertiesasync)
     public func getBasicPropertiesAsync() throws -> AnyIAsyncOperation<test_component.BasicProperties?>! {
-        try _IStorageItem.GetBasicPropertiesAsyncImpl()
+        try _IStorageItem.GetBasicPropertiesAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.isoftype)
     public func isOfType(_ type: StorageItemTypes) throws -> Bool {
-        try _IStorageItem.IsOfTypeImpl(type)
+        try _IStorageItem.IsOfType(type)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.attributes)
     public var attributes : FileAttributes {
-        get { try! _IStorageItem.get_AttributesImpl() }
+        get { try! _IStorageItem.get_Attributes() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.datecreated)
     public var dateCreated : test_component.DateTime {
-        get { try! _IStorageItem.get_DateCreatedImpl() }
+        get { try! _IStorageItem.get_DateCreated() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.name)
     public var name : String {
-        get { try! _IStorageItem.get_NameImpl() }
+        get { try! _IStorageItem.get_Name() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.path)
     public var path : String {
-        get { try! _IStorageItem.get_PathImpl() }
+        get { try! _IStorageItem.get_Path() }
     }
 
     private lazy var _IRandomAccessStreamReference: __ABI_Windows_Storage_Streams.IRandomAccessStreamReference! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.openreadasync)
     public func openReadAsync() throws -> AnyIAsyncOperation<test_component.AnyIRandomAccessStreamWithContentType?>! {
-        try _IRandomAccessStreamReference.OpenReadAsyncImpl()
+        try _IRandomAccessStreamReference.OpenReadAsync()
     }
 
     private lazy var _IInputStreamReference: __ABI_Windows_Storage_Streams.IInputStreamReference! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.opensequentialreadasync)
     public func openSequentialReadAsync() throws -> AnyIAsyncOperation<test_component.AnyIInputStream?>! {
-        try _IInputStreamReference.OpenSequentialReadAsyncImpl()
+        try _IInputStreamReference.OpenSequentialReadAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.openasync)
     public func openAsync(_ accessMode: FileAccessMode) throws -> AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>! {
-        try _default.OpenAsyncImpl(accessMode)
+        try _default.OpenAsync(accessMode)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.opentransactedwriteasync)
     public func openTransactedWriteAsync() throws -> AnyIAsyncOperation<StorageStreamTransaction?>! {
-        try _default.OpenTransactedWriteAsyncImpl()
+        try _default.OpenTransactedWriteAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.copyasync)
     public func copyAsync(_ destinationFolder: AnyIStorageFolder!) throws -> AnyIAsyncOperation<StorageFile?>! {
-        try _default.CopyOverloadDefaultNameAndOptionsImpl(destinationFolder)
+        try _default.CopyOverloadDefaultNameAndOptions(destinationFolder)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.copyasync)
     public func copyAsync(_ destinationFolder: AnyIStorageFolder!, _ desiredNewName: String) throws -> AnyIAsyncOperation<StorageFile?>! {
-        try _default.CopyOverloadDefaultOptionsImpl(destinationFolder, desiredNewName)
+        try _default.CopyOverloadDefaultOptions(destinationFolder, desiredNewName)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.copyasync)
     public func copyAsync(_ destinationFolder: AnyIStorageFolder!, _ desiredNewName: String, _ option: NameCollisionOption) throws -> AnyIAsyncOperation<StorageFile?>! {
-        try _default.CopyOverloadImpl(destinationFolder, desiredNewName, option)
+        try _default.CopyOverload(destinationFolder, desiredNewName, option)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.copyandreplaceasync)
     public func copyAndReplaceAsync(_ fileToReplace: AnyIStorageFile!) throws -> test_component.AnyIAsyncAction! {
-        try _default.CopyAndReplaceAsyncImpl(fileToReplace)
+        try _default.CopyAndReplaceAsync(fileToReplace)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.moveasync)
     public func moveAsync(_ destinationFolder: AnyIStorageFolder!) throws -> test_component.AnyIAsyncAction! {
-        try _default.MoveOverloadDefaultNameAndOptionsImpl(destinationFolder)
+        try _default.MoveOverloadDefaultNameAndOptions(destinationFolder)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.moveasync)
     public func moveAsync(_ destinationFolder: AnyIStorageFolder!, _ desiredNewName: String) throws -> test_component.AnyIAsyncAction! {
-        try _default.MoveOverloadDefaultOptionsImpl(destinationFolder, desiredNewName)
+        try _default.MoveOverloadDefaultOptions(destinationFolder, desiredNewName)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.moveasync)
     public func moveAsync(_ destinationFolder: AnyIStorageFolder!, _ desiredNewName: String, _ option: NameCollisionOption) throws -> test_component.AnyIAsyncAction! {
-        try _default.MoveOverloadImpl(destinationFolder, desiredNewName, option)
+        try _default.MoveOverload(destinationFolder, desiredNewName, option)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.moveandreplaceasync)
     public func moveAndReplaceAsync(_ fileToReplace: AnyIStorageFile!) throws -> test_component.AnyIAsyncAction! {
-        try _default.MoveAndReplaceAsyncImpl(fileToReplace)
+        try _default.MoveAndReplaceAsync(fileToReplace)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.contenttype)
     public var contentType : String {
-        get { try! _default.get_ContentTypeImpl() }
+        get { try! _default.get_ContentType() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.filetype)
     public var fileType : String {
-        get { try! _default.get_FileTypeImpl() }
+        get { try! _default.get_FileType() }
     }
 
     private lazy var _IStorageItemProperties: __ABI_Windows_Storage.IStorageItemProperties! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getthumbnailasync)
     public func getThumbnailAsync(_ mode: test_component.ThumbnailMode) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultSizeDefaultOptionsImpl(mode)
+        try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultSizeDefaultOptions(mode)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getthumbnailasync)
     public func getThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultOptionsImpl(mode, requestedSize)
+        try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultOptions(mode, requestedSize)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getthumbnailasync)
     public func getThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties.GetThumbnailAsyncImpl(mode, requestedSize, options)
+        try _IStorageItemProperties.GetThumbnailAsync(mode, requestedSize, options)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.displayname)
     public var displayName : String {
-        get { try! _IStorageItemProperties.get_DisplayNameImpl() }
+        get { try! _IStorageItemProperties.get_DisplayName() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.displaytype)
     public var displayType : String {
-        get { try! _IStorageItemProperties.get_DisplayTypeImpl() }
+        get { try! _IStorageItemProperties.get_DisplayType() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.folderrelativeid)
     public var folderRelativeId : String {
-        get { try! _IStorageItemProperties.get_FolderRelativeIdImpl() }
+        get { try! _IStorageItemProperties.get_FolderRelativeId() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.properties)
     public var properties : test_component.StorageItemContentProperties! {
-        get { try! _IStorageItemProperties.get_PropertiesImpl() }
+        get { try! _IStorageItemProperties.get_Properties() }
     }
 
     private lazy var _IStorageItemProperties2: __ABI_Windows_Storage.IStorageItemProperties2! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getscaledimageasthumbnailasync)
     public func getScaledImageAsThumbnailAsync(_ mode: test_component.ThumbnailMode) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsyncOverloadDefaultSizeDefaultOptionsImpl(mode)
+        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsyncOverloadDefaultSizeDefaultOptions(mode)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getscaledimageasthumbnailasync)
     public func getScaledImageAsThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsyncOverloadDefaultOptionsImpl(mode, requestedSize)
+        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsyncOverloadDefaultOptions(mode, requestedSize)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getscaledimageasthumbnailasync)
     public func getScaledImageAsThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsyncImpl(mode, requestedSize, options)
+        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsync(mode, requestedSize, options)
     }
 
     private lazy var _IStorageItem2: __ABI_Windows_Storage.IStorageItem2! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.getparentasync)
     public func getParentAsync() throws -> AnyIAsyncOperation<StorageFolder?>! {
-        try _IStorageItem2.GetParentAsyncImpl()
+        try _IStorageItem2.GetParentAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.isequal)
     public func isEqual(_ item: AnyIStorageItem!) throws -> Bool {
-        try _IStorageItem2.IsEqualImpl(item)
+        try _IStorageItem2.IsEqual(item)
     }
 
     private lazy var _IStorageItemPropertiesWithProvider: __ABI_Windows_Storage.IStorageItemPropertiesWithProvider! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.provider)
     public var provider : StorageProvider! {
-        get { try! _IStorageItemPropertiesWithProvider.get_ProviderImpl() }
+        get { try! _IStorageItemPropertiesWithProvider.get_Provider() }
     }
 
     private lazy var _IStorageFilePropertiesWithAvailability: __ABI_Windows_Storage.IStorageFilePropertiesWithAvailability! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.isavailable)
     public var isAvailable : Bool {
-        get { try! _IStorageFilePropertiesWithAvailability.get_IsAvailableImpl() }
+        get { try! _IStorageFilePropertiesWithAvailability.get_IsAvailable() }
     }
 
     private lazy var _IStorageFile2: __ABI_Windows_Storage.IStorageFile2! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.openasync)
     public func openAsync(_ accessMode: FileAccessMode, _ options: StorageOpenOptions) throws -> AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>! {
-        try _IStorageFile2.OpenWithOptionsAsyncImpl(accessMode, options)
+        try _IStorageFile2.OpenWithOptionsAsync(accessMode, options)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefile.opentransactedwriteasync)
     public func openTransactedWriteAsync(_ options: StorageOpenOptions) throws -> AnyIAsyncOperation<StorageStreamTransaction?>! {
-        try _IStorageFile2.OpenTransactedWriteWithOptionsAsyncImpl(options)
+        try _IStorageFile2.OpenTransactedWriteWithOptionsAsync(options)
     }
 
     deinit {
@@ -407,275 +407,275 @@ public final class StorageFolder : WinRTClass, IStorageItem, IStorageFolder, tes
     private static let _IStorageFolderStatics: __ABI_Windows_Storage.IStorageFolderStatics = try! RoGetActivationFactory("Windows.Storage.StorageFolder")
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfolderfrompathasync)
     public static func getFolderFromPathAsync(_ path: String) throws -> AnyIAsyncOperation<StorageFolder?>! {
-        return try _IStorageFolderStatics.GetFolderFromPathAsyncImpl(path)
+        return try _IStorageFolderStatics.GetFolderFromPathAsync(path)
     }
 
     private lazy var _IStorageItem: __ABI_Windows_Storage.IStorageItem! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.renameasync)
     public func renameAsync(_ desiredName: String) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItem.RenameAsyncOverloadDefaultOptionsImpl(desiredName)
+        try _IStorageItem.RenameAsyncOverloadDefaultOptions(desiredName)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.renameasync)
     public func renameAsync(_ desiredName: String, _ option: NameCollisionOption) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItem.RenameAsyncImpl(desiredName, option)
+        try _IStorageItem.RenameAsync(desiredName, option)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.deleteasync)
     public func deleteAsync() throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItem.DeleteAsyncOverloadDefaultOptionsImpl()
+        try _IStorageItem.DeleteAsyncOverloadDefaultOptions()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.deleteasync)
     public func deleteAsync(_ option: StorageDeleteOption) throws -> test_component.AnyIAsyncAction! {
-        try _IStorageItem.DeleteAsyncImpl(option)
+        try _IStorageItem.DeleteAsync(option)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getbasicpropertiesasync)
     public func getBasicPropertiesAsync() throws -> AnyIAsyncOperation<test_component.BasicProperties?>! {
-        try _IStorageItem.GetBasicPropertiesAsyncImpl()
+        try _IStorageItem.GetBasicPropertiesAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.isoftype)
     public func isOfType(_ type: StorageItemTypes) throws -> Bool {
-        try _IStorageItem.IsOfTypeImpl(type)
+        try _IStorageItem.IsOfType(type)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.attributes)
     public var attributes : FileAttributes {
-        get { try! _IStorageItem.get_AttributesImpl() }
+        get { try! _IStorageItem.get_Attributes() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.datecreated)
     public var dateCreated : test_component.DateTime {
-        get { try! _IStorageItem.get_DateCreatedImpl() }
+        get { try! _IStorageItem.get_DateCreated() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.name)
     public var name : String {
-        get { try! _IStorageItem.get_NameImpl() }
+        get { try! _IStorageItem.get_Name() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.path)
     public var path : String {
-        get { try! _IStorageItem.get_PathImpl() }
+        get { try! _IStorageItem.get_Path() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createfileasync)
     public func createFileAsync(_ desiredName: String) throws -> AnyIAsyncOperation<StorageFile?>! {
-        try _default.CreateFileAsyncOverloadDefaultOptionsImpl(desiredName)
+        try _default.CreateFileAsyncOverloadDefaultOptions(desiredName)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createfileasync)
     public func createFileAsync(_ desiredName: String, _ options: CreationCollisionOption) throws -> AnyIAsyncOperation<StorageFile?>! {
-        try _default.CreateFileAsyncImpl(desiredName, options)
+        try _default.CreateFileAsync(desiredName, options)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createfolderasync)
     public func createFolderAsync(_ desiredName: String) throws -> AnyIAsyncOperation<StorageFolder?>! {
-        try _default.CreateFolderAsyncOverloadDefaultOptionsImpl(desiredName)
+        try _default.CreateFolderAsyncOverloadDefaultOptions(desiredName)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createfolderasync)
     public func createFolderAsync(_ desiredName: String, _ options: CreationCollisionOption) throws -> AnyIAsyncOperation<StorageFolder?>! {
-        try _default.CreateFolderAsyncImpl(desiredName, options)
+        try _default.CreateFolderAsync(desiredName, options)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfileasync)
     public func getFileAsync(_ name: String) throws -> AnyIAsyncOperation<StorageFile?>! {
-        try _default.GetFileAsyncImpl(name)
+        try _default.GetFileAsync(name)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfolderasync)
     public func getFolderAsync(_ name: String) throws -> AnyIAsyncOperation<StorageFolder?>! {
-        try _default.GetFolderAsyncImpl(name)
+        try _default.GetFolderAsync(name)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getitemasync)
     public func getItemAsync(_ name: String) throws -> AnyIAsyncOperation<AnyIStorageItem?>! {
-        try _default.GetItemAsyncImpl(name)
+        try _default.GetItemAsync(name)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfilesasync)
     public func getFilesAsync() throws -> AnyIAsyncOperation<AnyIVectorView<StorageFile?>?>! {
-        try _default.GetFilesAsyncOverloadDefaultOptionsStartAndCountImpl()
+        try _default.GetFilesAsyncOverloadDefaultOptionsStartAndCount()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfoldersasync)
     public func getFoldersAsync() throws -> AnyIAsyncOperation<AnyIVectorView<StorageFolder?>?>! {
-        try _default.GetFoldersAsyncOverloadDefaultOptionsStartAndCountImpl()
+        try _default.GetFoldersAsyncOverloadDefaultOptionsStartAndCount()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getitemsasync)
     public func getItemsAsync() throws -> AnyIAsyncOperation<AnyIVectorView<AnyIStorageItem?>?>! {
-        try _default.GetItemsAsyncOverloadDefaultStartAndCountImpl()
+        try _default.GetItemsAsyncOverloadDefaultStartAndCount()
     }
 
     private lazy var _IStorageFolderQueryOperations: __ABI_Windows_Storage_Search.IStorageFolderQueryOperations! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getindexedstateasync)
     public func getIndexedStateAsync() throws -> AnyIAsyncOperation<test_component.IndexedState>! {
-        try _IStorageFolderQueryOperations.GetIndexedStateAsyncImpl()
+        try _IStorageFolderQueryOperations.GetIndexedStateAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createfilequery)
     public func createFileQuery() throws -> test_component.StorageFileQueryResult! {
-        try _IStorageFolderQueryOperations.CreateFileQueryOverloadDefaultImpl()
+        try _IStorageFolderQueryOperations.CreateFileQueryOverloadDefault()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createfilequery)
     public func createFileQuery(_ query: test_component.CommonFileQuery) throws -> test_component.StorageFileQueryResult! {
-        try _IStorageFolderQueryOperations.CreateFileQueryImpl(query)
+        try _IStorageFolderQueryOperations.CreateFileQuery(query)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createfilequerywithoptions)
     public func createFileQueryWithOptions(_ queryOptions: test_component.QueryOptions!) throws -> test_component.StorageFileQueryResult! {
-        try _IStorageFolderQueryOperations.CreateFileQueryWithOptionsImpl(queryOptions)
+        try _IStorageFolderQueryOperations.CreateFileQueryWithOptions(queryOptions)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createfolderquery)
     public func createFolderQuery() throws -> test_component.StorageFolderQueryResult! {
-        try _IStorageFolderQueryOperations.CreateFolderQueryOverloadDefaultImpl()
+        try _IStorageFolderQueryOperations.CreateFolderQueryOverloadDefault()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createfolderquery)
     public func createFolderQuery(_ query: test_component.CommonFolderQuery) throws -> test_component.StorageFolderQueryResult! {
-        try _IStorageFolderQueryOperations.CreateFolderQueryImpl(query)
+        try _IStorageFolderQueryOperations.CreateFolderQuery(query)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createfolderquerywithoptions)
     public func createFolderQueryWithOptions(_ queryOptions: test_component.QueryOptions!) throws -> test_component.StorageFolderQueryResult! {
-        try _IStorageFolderQueryOperations.CreateFolderQueryWithOptionsImpl(queryOptions)
+        try _IStorageFolderQueryOperations.CreateFolderQueryWithOptions(queryOptions)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createitemquery)
     public func createItemQuery() throws -> test_component.StorageItemQueryResult! {
-        try _IStorageFolderQueryOperations.CreateItemQueryImpl()
+        try _IStorageFolderQueryOperations.CreateItemQuery()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.createitemquerywithoptions)
     public func createItemQueryWithOptions(_ queryOptions: test_component.QueryOptions!) throws -> test_component.StorageItemQueryResult! {
-        try _IStorageFolderQueryOperations.CreateItemQueryWithOptionsImpl(queryOptions)
+        try _IStorageFolderQueryOperations.CreateItemQueryWithOptions(queryOptions)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfilesasync)
     public func getFilesAsync(_ query: test_component.CommonFileQuery, _ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> AnyIAsyncOperation<AnyIVectorView<StorageFile?>?>! {
-        try _IStorageFolderQueryOperations.GetFilesAsyncImpl(query, startIndex, maxItemsToRetrieve)
+        try _IStorageFolderQueryOperations.GetFilesAsync(query, startIndex, maxItemsToRetrieve)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfilesasync)
     public func getFilesAsync(_ query: test_component.CommonFileQuery) throws -> AnyIAsyncOperation<AnyIVectorView<StorageFile?>?>! {
-        try _IStorageFolderQueryOperations.GetFilesAsyncOverloadDefaultStartAndCountImpl(query)
+        try _IStorageFolderQueryOperations.GetFilesAsyncOverloadDefaultStartAndCount(query)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfoldersasync)
     public func getFoldersAsync(_ query: test_component.CommonFolderQuery, _ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> AnyIAsyncOperation<AnyIVectorView<StorageFolder?>?>! {
-        try _IStorageFolderQueryOperations.GetFoldersAsyncImpl(query, startIndex, maxItemsToRetrieve)
+        try _IStorageFolderQueryOperations.GetFoldersAsync(query, startIndex, maxItemsToRetrieve)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getfoldersasync)
     public func getFoldersAsync(_ query: test_component.CommonFolderQuery) throws -> AnyIAsyncOperation<AnyIVectorView<StorageFolder?>?>! {
-        try _IStorageFolderQueryOperations.GetFoldersAsyncOverloadDefaultStartAndCountImpl(query)
+        try _IStorageFolderQueryOperations.GetFoldersAsyncOverloadDefaultStartAndCount(query)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getitemsasync)
     public func getItemsAsync(_ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> AnyIAsyncOperation<AnyIVectorView<AnyIStorageItem?>?>! {
-        try _IStorageFolderQueryOperations.GetItemsAsyncImpl(startIndex, maxItemsToRetrieve)
+        try _IStorageFolderQueryOperations.GetItemsAsync(startIndex, maxItemsToRetrieve)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.arequeryoptionssupported)
     public func areQueryOptionsSupported(_ queryOptions: test_component.QueryOptions!) throws -> Bool {
-        try _IStorageFolderQueryOperations.AreQueryOptionsSupportedImpl(queryOptions)
+        try _IStorageFolderQueryOperations.AreQueryOptionsSupported(queryOptions)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.iscommonfolderquerysupported)
     public func isCommonFolderQuerySupported(_ query: test_component.CommonFolderQuery) throws -> Bool {
-        try _IStorageFolderQueryOperations.IsCommonFolderQuerySupportedImpl(query)
+        try _IStorageFolderQueryOperations.IsCommonFolderQuerySupported(query)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.iscommonfilequerysupported)
     public func isCommonFileQuerySupported(_ query: test_component.CommonFileQuery) throws -> Bool {
-        try _IStorageFolderQueryOperations.IsCommonFileQuerySupportedImpl(query)
+        try _IStorageFolderQueryOperations.IsCommonFileQuerySupported(query)
     }
 
     private lazy var _IStorageItemProperties: __ABI_Windows_Storage.IStorageItemProperties! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getthumbnailasync)
     public func getThumbnailAsync(_ mode: test_component.ThumbnailMode) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultSizeDefaultOptionsImpl(mode)
+        try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultSizeDefaultOptions(mode)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getthumbnailasync)
     public func getThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultOptionsImpl(mode, requestedSize)
+        try _IStorageItemProperties.GetThumbnailAsyncOverloadDefaultOptions(mode, requestedSize)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getthumbnailasync)
     public func getThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties.GetThumbnailAsyncImpl(mode, requestedSize, options)
+        try _IStorageItemProperties.GetThumbnailAsync(mode, requestedSize, options)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.displayname)
     public var displayName : String {
-        get { try! _IStorageItemProperties.get_DisplayNameImpl() }
+        get { try! _IStorageItemProperties.get_DisplayName() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.displaytype)
     public var displayType : String {
-        get { try! _IStorageItemProperties.get_DisplayTypeImpl() }
+        get { try! _IStorageItemProperties.get_DisplayType() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.folderrelativeid)
     public var folderRelativeId : String {
-        get { try! _IStorageItemProperties.get_FolderRelativeIdImpl() }
+        get { try! _IStorageItemProperties.get_FolderRelativeId() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.properties)
     public var properties : test_component.StorageItemContentProperties! {
-        get { try! _IStorageItemProperties.get_PropertiesImpl() }
+        get { try! _IStorageItemProperties.get_Properties() }
     }
 
     private lazy var _IStorageItemProperties2: __ABI_Windows_Storage.IStorageItemProperties2! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getscaledimageasthumbnailasync)
     public func getScaledImageAsThumbnailAsync(_ mode: test_component.ThumbnailMode) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsyncOverloadDefaultSizeDefaultOptionsImpl(mode)
+        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsyncOverloadDefaultSizeDefaultOptions(mode)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getscaledimageasthumbnailasync)
     public func getScaledImageAsThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsyncOverloadDefaultOptionsImpl(mode, requestedSize)
+        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsyncOverloadDefaultOptions(mode, requestedSize)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getscaledimageasthumbnailasync)
     public func getScaledImageAsThumbnailAsync(_ mode: test_component.ThumbnailMode, _ requestedSize: UInt32, _ options: test_component.ThumbnailOptions) throws -> AnyIAsyncOperation<test_component.StorageItemThumbnail?>! {
-        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsyncImpl(mode, requestedSize, options)
+        try _IStorageItemProperties2.GetScaledImageAsThumbnailAsync(mode, requestedSize, options)
     }
 
     private lazy var _IStorageItem2: __ABI_Windows_Storage.IStorageItem2! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.getparentasync)
     public func getParentAsync() throws -> AnyIAsyncOperation<StorageFolder?>! {
-        try _IStorageItem2.GetParentAsyncImpl()
+        try _IStorageItem2.GetParentAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.isequal)
     public func isEqual(_ item: AnyIStorageItem!) throws -> Bool {
-        try _IStorageItem2.IsEqualImpl(item)
+        try _IStorageItem2.IsEqual(item)
     }
 
     private lazy var _IStorageFolder2: __ABI_Windows_Storage.IStorageFolder2! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.trygetitemasync)
     public func tryGetItemAsync(_ name: String) throws -> AnyIAsyncOperation<AnyIStorageItem?>! {
-        try _IStorageFolder2.TryGetItemAsyncImpl(name)
+        try _IStorageFolder2.TryGetItemAsync(name)
     }
 
     private lazy var _IStorageItemPropertiesWithProvider: __ABI_Windows_Storage.IStorageItemPropertiesWithProvider! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.provider)
     public var provider : StorageProvider! {
-        get { try! _IStorageItemPropertiesWithProvider.get_ProviderImpl() }
+        get { try! _IStorageItemPropertiesWithProvider.get_Provider() }
     }
 
     private lazy var _IStorageFolder3: __ABI_Windows_Storage.IStorageFolder3! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagefolder.trygetchangetracker)
     public func tryGetChangeTracker() throws -> StorageLibraryChangeTracker! {
-        try _IStorageFolder3.TryGetChangeTrackerImpl()
+        try _IStorageFolder3.TryGetChangeTracker()
     }
 
     deinit {
@@ -717,27 +717,27 @@ public final class StorageLibraryChange : WinRTClass {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychange.isoftype)
     public func isOfType(_ type: StorageItemTypes) throws -> Bool {
-        try _default.IsOfTypeImpl(type)
+        try _default.IsOfType(type)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychange.getstorageitemasync)
     public func getStorageItemAsync() throws -> AnyIAsyncOperation<AnyIStorageItem?>! {
-        try _default.GetStorageItemAsyncImpl()
+        try _default.GetStorageItemAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychange.changetype)
     public var changeType : StorageLibraryChangeType {
-        get { try! _default.get_ChangeTypeImpl() }
+        get { try! _default.get_ChangeType() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychange.path)
     public var path : String {
-        get { try! _default.get_PathImpl() }
+        get { try! _default.get_Path() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychange.previouspath)
     public var previousPath : String {
-        get { try! _default.get_PreviousPathImpl() }
+        get { try! _default.get_PreviousPath() }
     }
 
     deinit {
@@ -771,12 +771,12 @@ public final class StorageLibraryChangeReader : WinRTClass {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychangereader.readbatchasync)
     public func readBatchAsync() throws -> AnyIAsyncOperation<AnyIVectorView<StorageLibraryChange?>?>! {
-        try _default.ReadBatchAsyncImpl()
+        try _default.ReadBatchAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychangereader.acceptchangesasync)
     public func acceptChangesAsync() throws -> test_component.AnyIAsyncAction! {
-        try _default.AcceptChangesAsyncImpl()
+        try _default.AcceptChangesAsync()
     }
 
     deinit {
@@ -810,17 +810,17 @@ public final class StorageLibraryChangeTracker : WinRTClass {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychangetracker.getchangereader)
     public func getChangeReader() throws -> StorageLibraryChangeReader! {
-        try _default.GetChangeReaderImpl()
+        try _default.GetChangeReader()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychangetracker.enable)
     public func enable() throws {
-        try _default.EnableImpl()
+        try _default.Enable()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagelibrarychangetracker.reset)
     public func reset() throws {
-        try _default.ResetImpl()
+        try _default.Reset()
     }
 
     deinit {
@@ -854,18 +854,18 @@ public final class StorageProvider : WinRTClass {
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storageprovider.displayname)
     public var displayName : String {
-        get { try! _default.get_DisplayNameImpl() }
+        get { try! _default.get_DisplayName() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storageprovider.id)
     public var id : String {
-        get { try! _default.get_IdImpl() }
+        get { try! _default.get_Id() }
     }
 
     private lazy var _IStorageProvider2: __ABI_Windows_Storage.IStorageProvider2! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storageprovider.ispropertysupportedforpartialfileasync)
     public func isPropertySupportedForPartialFileAsync(_ propertyCanonicalName: String) throws -> AnyIAsyncOperation<Bool>! {
-        try _IStorageProvider2.IsPropertySupportedForPartialFileAsyncImpl(propertyCanonicalName)
+        try _IStorageProvider2.IsPropertySupportedForPartialFileAsync(propertyCanonicalName)
     }
 
     deinit {
@@ -904,17 +904,17 @@ public final class StorageStreamTransaction : WinRTClass, test_component.IClosab
     private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagestreamtransaction.close)
     public func close() throws {
-        try _IClosable.CloseImpl()
+        try _IClosable.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagestreamtransaction.commitasync)
     public func commitAsync() throws -> test_component.AnyIAsyncAction! {
-        try _default.CommitAsyncImpl()
+        try _default.CommitAsync()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.storagestreamtransaction.stream)
     public var stream : test_component.AnyIRandomAccessStream! {
-        get { try! _default.get_StreamImpl() }
+        get { try! _default.get_Stream() }
     }
 
     deinit {
@@ -953,23 +953,23 @@ public final class StreamedFileDataRequest : WinRTClass, test_component.IClosabl
     private lazy var _IClosable: __ABI_Windows_Foundation.IClosable! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streamedfiledatarequest.close)
     public func close() throws {
-        try _IClosable.CloseImpl()
+        try _IClosable.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streamedfiledatarequest.writeasync)
     public func writeAsync(_ buffer: test_component.AnyIBuffer!) throws -> AnyIAsyncOperationWithProgress<UInt32, UInt32>! {
-        try _default.WriteAsyncImpl(buffer)
+        try _default.WriteAsync(buffer)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streamedfiledatarequest.flushasync)
     public func flushAsync() throws -> AnyIAsyncOperation<Bool>! {
-        try _default.FlushAsyncImpl()
+        try _default.FlushAsync()
     }
 
     private lazy var _IStreamedFileDataRequest: __ABI_Windows_Storage.IStreamedFileDataRequest! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.streamedfiledatarequest.failandclose)
     public func failAndClose(_ failureMode: StreamedFileFailureMode) throws {
-        try _IStreamedFileDataRequest.FailAndCloseImpl(failureMode)
+        try _IStreamedFileDataRequest.FailAndClose(failureMode)
     }
 
     deinit {

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -228,7 +228,7 @@ public enum __ABI_test_component {
     public class IAsyncMethodsStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIAsyncMethodsStatics }
 
-        public func GetCompletedAsyncImpl(_ result: Int32) throws -> test_component.AnyIAsyncOperation<Int32>? {
+        public func GetCompletedAsync(_ result: Int32) throws -> test_component.AnyIAsyncOperation<Int32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethodsStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetCompletedAsync(pThis, result, &operationAbi))
@@ -237,7 +237,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
         }
 
-        public func GetCompletedWithErrorAsyncImpl(_ errorCode: HRESULT) throws -> test_component.AnyIAsyncOperation<Int32>? {
+        public func GetCompletedWithErrorAsync(_ errorCode: HRESULT) throws -> test_component.AnyIAsyncOperation<Int32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethodsStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetCompletedWithErrorAsync(pThis, errorCode, &operationAbi))
@@ -246,7 +246,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
         }
 
-        public func GetPendingAsyncImpl() throws -> test_component.AsyncOperationInt? {
+        public func GetPendingAsync() throws -> test_component.AsyncOperationInt? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethodsStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetPendingAsync(pThis, &resultAbi))
@@ -260,7 +260,7 @@ public enum __ABI_test_component {
     public class IAsyncMethodsWithProgress: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIAsyncMethodsWithProgress }
 
-        open func OperationWithProgressImpl(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncOperationWithProgress<Int32, Double>? {
+        open func OperationWithProgress(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncOperationWithProgress<Int32, Double>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIAsyncMethodsWithProgress.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OperationWithProgress(pThis, .from(swift: value), &operationAbi))
@@ -315,13 +315,13 @@ public enum __ABI_test_component {
     public class IAsyncOperationInt: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIAsyncOperationInt }
 
-        open func CompleteImpl(_ result: Int32) throws {
+        open func Complete(_ result: Int32) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIAsyncOperationInt.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Complete(pThis, result))
             }
         }
 
-        open func CompleteWithErrorImpl(_ errorCode: HRESULT) throws {
+        open func CompleteWithError(_ errorCode: HRESULT) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIAsyncOperationInt.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.CompleteWithError(pThis, errorCode))
             }
@@ -380,7 +380,7 @@ public enum __ABI_test_component {
     public class IBase: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBase }
 
-        public func DoTheThingImpl() throws {
+        public func DoTheThing() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.DoTheThing(pThis))
             }
@@ -391,7 +391,7 @@ public enum __ABI_test_component {
     public class IBaseCollectionProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseCollectionProtectedFactory }
 
-        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.BaseCollection.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IVectorBase {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.BaseCollection.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IVectorBase {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -414,7 +414,7 @@ public enum __ABI_test_component {
     public class IBaseNoOverridesProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseNoOverridesProtectedFactory }
 
-        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.BaseNoOverrides.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBaseNoOverrides {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.BaseNoOverrides.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBaseNoOverrides {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -432,7 +432,7 @@ public enum __ABI_test_component {
     public class IBaseNoOverridesStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseNoOverridesStatics }
 
-        public func CreateFromStringImpl(_ value: String) throws -> test_component.BaseNoOverrides? {
+        public func CreateFromString(_ value: String) throws -> test_component.BaseNoOverrides? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 let _value = try! HString(value)
                 _ = try perform(as: __x_ABI_Ctest__component_CIBaseNoOverridesStatics.self) { pThis in
@@ -447,7 +447,7 @@ public enum __ABI_test_component {
     public class IBaseOverrides: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseOverrides }
 
-        public func OnDoTheThingImpl() throws {
+        public func OnDoTheThing() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIBaseOverrides.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OnDoTheThing(pThis))
             }
@@ -458,7 +458,7 @@ public enum __ABI_test_component {
     public class IBaseProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseProtectedFactory }
 
-        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.Base.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBase {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.Base.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBase {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -476,7 +476,7 @@ public enum __ABI_test_component {
     public class IBaseStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseStatics }
 
-        public func CreateFromStringImpl(_ value: String) throws -> test_component.Base? {
+        public func CreateFromString(_ value: String) throws -> test_component.Base? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 let _value = try! HString(value)
                 _ = try perform(as: __x_ABI_Ctest__component_CIBaseStatics.self) { pThis in
@@ -491,7 +491,7 @@ public enum __ABI_test_component {
     public class IBasic: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBasic }
 
-        open func MethodImpl() throws {
+        open func Method() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIBasic.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Method(pThis))
             }
@@ -540,7 +540,7 @@ public enum __ABI_test_component {
     public class IBufferTesterStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBufferTesterStatics }
 
-        public func GetDataFromImpl(_ buffer: test_component.AnyIBuffer?, _ index: UInt32) throws -> UInt8 {
+        public func GetDataFrom(_ buffer: test_component.AnyIBuffer?, _ index: UInt32) throws -> UInt8 {
             var result: UINT8 = 0
             let bufferWrapper = __ABI_Windows_Storage_Streams.IBufferWrapper(buffer)
             let _buffer = try! bufferWrapper?.toABI { $0 }
@@ -555,7 +555,7 @@ public enum __ABI_test_component {
     public class IClass: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIClass }
 
-        public func get_ImplementationImpl() throws -> test_component.AnyIBasic? {
+        public func get_Implementation() throws -> test_component.AnyIBasic? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Implementation(pThis, &valueAbi))
@@ -564,7 +564,7 @@ public enum __ABI_test_component {
             return __ABI_test_component.IBasicWrapper.unwrapFrom(abi: value)
         }
 
-        public func put_ImplementationImpl(_ value: test_component.AnyIBasic?) throws {
+        public func put_Implementation(_ value: test_component.AnyIBasic?) throws {
             let valueWrapper = __ABI_test_component.IBasicWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
@@ -572,7 +572,7 @@ public enum __ABI_test_component {
             }
         }
 
-        public func SetDelegateImpl(_ value: test_component.AnyISimpleDelegate?) throws {
+        public func SetDelegate(_ value: test_component.AnyISimpleDelegate?) throws {
             let valueWrapper = __ABI_test_component.ISimpleDelegateWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
@@ -580,7 +580,7 @@ public enum __ABI_test_component {
             }
         }
 
-        public func GetDelegateImpl() throws -> test_component.AnyISimpleDelegate? {
+        public func GetDelegate() throws -> test_component.AnyISimpleDelegate? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetDelegate(pThis, &resultAbi))
@@ -589,14 +589,14 @@ public enum __ABI_test_component {
             return __ABI_test_component.ISimpleDelegateWrapper.unwrapFrom(abi: result)
         }
 
-        public func FailImpl(_ message: String) throws {
+        public func Fail(_ message: String) throws {
             let _message = try! HString(message)
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Fail(pThis, _message.get()))
             }
         }
 
-        public func InInt32Impl(_ value: Int32) throws -> String {
+        public func InInt32(_ value: Int32) throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InInt32(pThis, value, &result))
@@ -604,7 +604,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func InStringImpl(_ value: String) throws -> String {
+        public func InString(_ value: String) throws -> String {
             var result: HSTRING?
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
@@ -613,7 +613,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func InObjectImpl(_ value: Any?) throws -> String {
+        public func InObject(_ value: Any?) throws -> String {
             var result: HSTRING?
             let valueWrapper = __ABI_.AnyWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -623,7 +623,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func InEnumImpl(_ value: test_component.Signed) throws -> String {
+        public func InEnum(_ value: test_component.Signed) throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InEnum(pThis, value, &result))
@@ -631,13 +631,13 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func OutInt32Impl(_ value: inout Int32) throws {
+        public func OutInt32(_ value: inout Int32) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutInt32(pThis, &value))
             }
         }
 
-        public func OutStringImpl(_ value: inout String) throws {
+        public func OutString(_ value: inout String) throws {
             var _value: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutString(pThis, &_value))
@@ -646,7 +646,7 @@ public enum __ABI_test_component {
             WindowsDeleteString(_value)
         }
 
-        public func OutObjectImpl(_ value: inout Any?) throws {
+        public func OutObject(_ value: inout Any?) throws {
             let (_value) = try ComPtrs.initialize { (_valueAbi) in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OutObject(pThis, &_valueAbi))
@@ -655,7 +655,7 @@ public enum __ABI_test_component {
             value = __ABI_.AnyWrapper.unwrapFrom(abi: _value)
         }
 
-        public func OutStringableImpl(_ value: inout test_component.AnyIStringable?) throws {
+        public func OutStringable(_ value: inout test_component.AnyIStringable?) throws {
             let (_value) = try ComPtrs.initialize { (_valueAbi) in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OutStringable(pThis, &_valueAbi))
@@ -664,7 +664,7 @@ public enum __ABI_test_component {
             value = __ABI_Windows_Foundation.IStringableWrapper.unwrapFrom(abi: _value)
         }
 
-        public func OutBlittableStructImpl(_ value: inout test_component.BlittableStruct) throws {
+        public func OutBlittableStruct(_ value: inout test_component.BlittableStruct) throws {
             var _value: __x_ABI_Ctest__component_CBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutBlittableStruct(pThis, &_value))
@@ -672,7 +672,7 @@ public enum __ABI_test_component {
             value = .from(abi: _value)
         }
 
-        public func OutNonBlittableStructImpl(_ value: inout test_component.NonBlittableStruct) throws {
+        public func OutNonBlittableStruct(_ value: inout test_component.NonBlittableStruct) throws {
             let _value: __ABI_test_component._ABI_NonBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutNonBlittableStruct(pThis, &_value.val))
@@ -680,13 +680,13 @@ public enum __ABI_test_component {
             value = .from(abi: _value.val)
         }
 
-        public func OutEnumImpl(_ value: inout test_component.Signed) throws {
+        public func OutEnum(_ value: inout test_component.Signed) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutEnum(pThis, &value))
             }
         }
 
-        public func ReturnObjectImpl() throws -> Any? {
+        public func ReturnObject() throws -> Any? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnObject(pThis, &resultAbi))
@@ -695,7 +695,7 @@ public enum __ABI_test_component {
             return __ABI_.AnyWrapper.unwrapFrom(abi: result)
         }
 
-        public func ReturnEnumImpl() throws -> test_component.Signed {
+        public func ReturnEnum() throws -> test_component.Signed {
             var result: __x_ABI_Ctest__component_CSigned = .init(0)
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnEnum(pThis, &result))
@@ -703,7 +703,7 @@ public enum __ABI_test_component {
             return result
         }
 
-        public func ReturnReferenceEnumImpl() throws -> test_component.Signed? {
+        public func ReturnReferenceEnum() throws -> test_component.Signed? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnReferenceEnum(pThis, &resultAbi))
@@ -712,7 +712,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedWrapper.unwrapFrom(abi: result)
         }
 
-        public func get_EnumPropertyImpl() throws -> test_component.Fruit {
+        public func get_EnumProperty() throws -> test_component.Fruit {
             var value: __x_ABI_Ctest__component_CFruit = .init(0)
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_EnumProperty(pThis, &value))
@@ -720,19 +720,19 @@ public enum __ABI_test_component {
             return value
         }
 
-        public func put_EnumPropertyImpl(_ value: test_component.Fruit) throws {
+        public func put_EnumProperty(_ value: test_component.Fruit) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_EnumProperty(pThis, value))
             }
         }
 
-        public func NoexceptVoidImpl() throws {
+        public func NoexceptVoid() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.NoexceptVoid(pThis))
             }
         }
 
-        public func NoexceptInt32Impl() throws -> Int32 {
+        public func NoexceptInt32() throws -> Int32 {
             var result: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.NoexceptInt32(pThis, &result))
@@ -740,7 +740,7 @@ public enum __ABI_test_component {
             return result
         }
 
-        public func NoexceptStringImpl() throws -> String {
+        public func NoexceptString() throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.NoexceptString(pThis, &result))
@@ -748,7 +748,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func add_DeferrableEventImpl(_ handler: TypedEventHandler<test_component.Class?, test_component.DeferrableEventArgs?>?) throws -> EventRegistrationToken {
+        public func add_DeferrableEvent(_ handler: TypedEventHandler<test_component.Class?, test_component.DeferrableEventArgs?>?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -758,13 +758,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        public func remove_DeferrableEventImpl(_ token: EventRegistrationToken) throws {
+        public func remove_DeferrableEvent(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_DeferrableEvent(pThis, token))
             }
         }
 
-        public func RaiseDeferrableEventAsyncImpl() throws -> test_component.AnyIAsyncOperation<Int32>? {
+        public func RaiseDeferrableEventAsync() throws -> test_component.AnyIAsyncOperation<Int32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.RaiseDeferrableEventAsync(pThis, &operationAbi))
@@ -773,7 +773,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
         }
 
-        public func ReturnCharImpl() throws -> Character {
+        public func ReturnChar() throws -> Character {
             var result: WCHAR = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnChar(pThis, &result))
@@ -781,7 +781,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func InCharImpl(_ value: Character) throws -> String {
+        public func InChar(_ value: Character) throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InChar(pThis, .init(from: value), &result))
@@ -789,7 +789,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func OutCharImpl(_ value: inout Character) throws {
+        public func OutChar(_ value: inout Character) throws {
             var _value: WCHAR = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutChar(pThis, &_value))
@@ -797,7 +797,7 @@ public enum __ABI_test_component {
             value = .init(from: _value)
         }
 
-        public func get_StartValueImpl() throws -> Int32? {
+        public func get_StartValue() throws -> Int32? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_StartValue(pThis, &valueAbi))
@@ -806,7 +806,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIReference_1_intWrapper.unwrapFrom(abi: value)
         }
 
-        public func put_StartValueImpl(_ value: Int32?) throws {
+        public func put_StartValue(_ value: Int32?) throws {
             let valueWrapper = test_component.__x_ABI_C__FIReference_1_intWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
@@ -814,7 +814,7 @@ public enum __ABI_test_component {
             }
         }
 
-        public func get_IdImpl() throws -> Foundation.UUID? {
+        public func get_Id() throws -> Foundation.UUID? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Id(pThis, &valueAbi))
@@ -823,7 +823,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIReference_1_GUIDWrapper.unwrapFrom(abi: value)
         }
 
-        public func put_IdImpl(_ value: Foundation.UUID?) throws {
+        public func put_Id(_ value: Foundation.UUID?) throws {
             let valueWrapper = test_component.__x_ABI_C__FIReference_1_GUIDWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
@@ -831,7 +831,7 @@ public enum __ABI_test_component {
             }
         }
 
-        public func get_BasePropertyImpl() throws -> test_component.Base? {
+        public func get_BaseProperty() throws -> test_component.Base? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_BaseProperty(pThis, &valueAbi))
@@ -840,13 +840,13 @@ public enum __ABI_test_component {
             return .from(abi: value)
         }
 
-        public func put_BasePropertyImpl(_ value: test_component.Base?) throws {
+        public func put_BaseProperty(_ value: test_component.Base?) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_BaseProperty(pThis, RawPointer(value)))
             }
         }
 
-        public func get_BaseNoOverridesPropertyImpl() throws -> test_component.BaseNoOverrides? {
+        public func get_BaseNoOverridesProperty() throws -> test_component.BaseNoOverrides? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_BaseNoOverridesProperty(pThis, &valueAbi))
@@ -855,7 +855,7 @@ public enum __ABI_test_component {
             return .from(abi: value)
         }
 
-        public func put_BaseNoOverridesPropertyImpl(_ value: test_component.BaseNoOverrides?) throws {
+        public func put_BaseNoOverridesProperty(_ value: test_component.BaseNoOverrides?) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_BaseNoOverridesProperty(pThis, RawPointer(value)))
             }
@@ -866,7 +866,7 @@ public enum __ABI_test_component {
     public class IClassFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIClassFactory }
 
-        public func CreateInstanceImpl(_ name: String) throws -> IClass {
+        public func CreateInstance(_ name: String) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _name = try! HString(name)
                 _ = try perform(as: __x_ABI_Ctest__component_CIClassFactory.self) { pThis in
@@ -876,7 +876,7 @@ public enum __ABI_test_component {
             return IClass(value!)
         }
 
-        public func CreateInstance2Impl(_ name: String, _ fruit: test_component.Fruit) throws -> IClass {
+        public func CreateInstance2(_ name: String, _ fruit: test_component.Fruit) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _name = try! HString(name)
                 _ = try perform(as: __x_ABI_Ctest__component_CIClassFactory.self) { pThis in
@@ -886,7 +886,7 @@ public enum __ABI_test_component {
             return IClass(value!)
         }
 
-        public func CreateInstance3Impl(_ arg: test_component.AnyIMap<String, String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32) throws -> IClass {
+        public func CreateInstance3(_ arg: test_component.AnyIMap<String, String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let argWrapper = test_component.__x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper(arg)
                 let _arg = try! argWrapper?.toABI { $0 }
@@ -897,7 +897,7 @@ public enum __ABI_test_component {
             return IClass(value!)
         }
 
-        public func CreateInstance4Impl(_ arg: test_component.AnyIMapView<String, String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32) throws -> IClass {
+        public func CreateInstance4(_ arg: test_component.AnyIMapView<String, String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let argWrapper = test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper(arg)
                 let _arg = try! argWrapper?.toABI { $0 }
@@ -908,7 +908,7 @@ public enum __ABI_test_component {
             return IClass(value!)
         }
 
-        public func CreateInstance5Impl(_ arg: test_component.AnyIVector<String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32, _ dummy5: Int32) throws -> IClass {
+        public func CreateInstance5(_ arg: test_component.AnyIVector<String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32, _ dummy5: Int32) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let argWrapper = test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper(arg)
                 let _arg = try! argWrapper?.toABI { $0 }
@@ -919,7 +919,7 @@ public enum __ABI_test_component {
             return IClass(value!)
         }
 
-        public func CreateInstance6Impl(_ arg: test_component.AnyIVectorView<String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32, _ dummy5: Int32, _ dummy6: Int32) throws -> IClass {
+        public func CreateInstance6(_ arg: test_component.AnyIVectorView<String>?, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32, _ dummy5: Int32, _ dummy6: Int32) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let argWrapper = test_component.__x_ABI_C__FIVectorView_1_HSTRINGWrapper(arg)
                 let _arg = try! argWrapper?.toABI { $0 }
@@ -935,7 +935,7 @@ public enum __ABI_test_component {
     public class IClassFactory2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIClassFactory2 }
 
-        public func CreateInstanceImpl(_ name: String, _ fruit: test_component.Fruit, _ implementation: test_component.AnyIIAmImplementable?) throws -> IClass {
+        public func CreateInstance(_ name: String, _ fruit: test_component.Fruit, _ implementation: test_component.AnyIIAmImplementable?) throws -> IClass {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _name = try! HString(name)
                 let implementationWrapper = __ABI_test_component.IIAmImplementableWrapper(implementation)
@@ -952,13 +952,13 @@ public enum __ABI_test_component {
     public class IClassStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIClassStatics }
 
-        public func StaticTestImpl() throws {
+        public func StaticTest() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.StaticTest(pThis))
             }
         }
 
-        public func StaticTestReturnImpl() throws -> Int32 {
+        public func StaticTestReturn() throws -> Int32 {
             var result: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.StaticTestReturn(pThis, &result))
@@ -966,7 +966,7 @@ public enum __ABI_test_component {
             return result
         }
 
-        public func get_StaticPropertyImpl() throws -> Int32 {
+        public func get_StaticProperty() throws -> Int32 {
             var value: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StaticProperty(pThis, &value))
@@ -974,7 +974,7 @@ public enum __ABI_test_component {
             return value
         }
 
-        public func TakeBaseAndGiveToCallbackAsObjectImpl(_ base: test_component.Base?, _ callback: test_component.InObjectDelegate?) throws {
+        public func TakeBaseAndGiveToCallbackAsObject(_ base: test_component.Base?, _ callback: test_component.InObjectDelegate?) throws {
             let callbackWrapper = __ABI_test_component_Delegates.InObjectDelegateWrapper(callback)
             let _callback = try! callbackWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics.self) { pThis in
@@ -987,7 +987,7 @@ public enum __ABI_test_component {
     public class IClassStatics2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIClassStatics2 }
 
-        public func StaticTestReturnFloatImpl() throws -> Float {
+        public func StaticTestReturnFloat() throws -> Float {
             var result: FLOAT = 0.0
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics2.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.StaticTestReturnFloat(pThis, &result))
@@ -995,7 +995,7 @@ public enum __ABI_test_component {
             return result
         }
 
-        public func get_StaticPropertyFloatImpl() throws -> Float {
+        public func get_StaticPropertyFloat() throws -> Float {
             var value: FLOAT = 0.0
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics2.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StaticPropertyFloat(pThis, &value))
@@ -1003,7 +1003,7 @@ public enum __ABI_test_component {
             return value
         }
 
-        public func put_StaticPropertyFloatImpl(_ value: Float) throws {
+        public func put_StaticPropertyFloat(_ value: Float) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIClassStatics2.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_StaticPropertyFloat(pThis, value))
             }
@@ -1014,7 +1014,7 @@ public enum __ABI_test_component {
     public class ICollectionTester: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CICollectionTester }
 
-        public func ReturnStoredStringVectorImpl() throws -> test_component.AnyIVector<String>? {
+        public func ReturnStoredStringVector() throws -> test_component.AnyIVector<String>? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CICollectionTester.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnStoredStringVector(pThis, &resultAbi))
@@ -1023,7 +1023,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: result)
         }
 
-        public func ReturnMapFromStringToStringImpl() throws -> test_component.AnyIMap<String, String>? {
+        public func ReturnMapFromStringToString() throws -> test_component.AnyIMap<String, String>? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CICollectionTester.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnMapFromStringToString(pThis, &resultAbi))
@@ -1037,7 +1037,7 @@ public enum __ABI_test_component {
     public class ICollectionTesterStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CICollectionTesterStatics }
 
-        public func InMapImpl(_ value: test_component.AnyIMap<String, String>?) throws -> String {
+        public func InMap(_ value: test_component.AnyIMap<String, String>?) throws -> String {
             var result: HSTRING?
             let valueWrapper = test_component.__x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1047,7 +1047,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func InMapViewImpl(_ value: test_component.AnyIMapView<String, String>?) throws -> String {
+        public func InMapView(_ value: test_component.AnyIMapView<String, String>?) throws -> String {
             var result: HSTRING?
             let valueWrapper = test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1057,7 +1057,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func InVectorImpl(_ value: test_component.AnyIVector<String>?) throws -> String {
+        public func InVector(_ value: test_component.AnyIVector<String>?) throws -> String {
             var result: HSTRING?
             let valueWrapper = test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1067,7 +1067,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func InVectorViewImpl(_ value: test_component.AnyIVectorView<String>?) throws -> String {
+        public func InVectorView(_ value: test_component.AnyIVectorView<String>?) throws -> String {
             var result: HSTRING?
             let valueWrapper = test_component.__x_ABI_C__FIVectorView_1_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1077,7 +1077,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func GetObjectAtImpl(_ value: test_component.AnyIVector<Any?>?, _ index: UInt32, _ callback: test_component.ObjectHandler?) throws {
+        public func GetObjectAt(_ value: test_component.AnyIVector<Any?>?, _ index: UInt32, _ callback: test_component.ObjectHandler?) throws {
             let valueWrapper = test_component.__x_ABI_C__FIVector_1_IInspectableWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             let callbackWrapper = __ABI_test_component.ObjectHandlerWrapper(callback)
@@ -1087,7 +1087,7 @@ public enum __ABI_test_component {
             }
         }
 
-        public func VectorAsIterableImpl(_ value: test_component.AnyIVector<String>?) throws -> test_component.AnyIIterable<String>? {
+        public func VectorAsIterable(_ value: test_component.AnyIVector<String>?) throws -> test_component.AnyIIterable<String>? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 let valueWrapper = test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper(value)
                 let _value = try! valueWrapper?.toABI { $0 }
@@ -1103,7 +1103,7 @@ public enum __ABI_test_component {
     public class IDeferrableEventArgs: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIDeferrableEventArgs }
 
-        public func GetDeferralImpl() throws -> test_component.Deferral? {
+        public func GetDeferral() throws -> test_component.Deferral? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIDeferrableEventArgs.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetDeferral(pThis, &resultAbi))
@@ -1112,7 +1112,7 @@ public enum __ABI_test_component {
             return .from(abi: result)
         }
 
-        public func IncrementCounterImpl() throws {
+        public func IncrementCounter() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIDeferrableEventArgs.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.IncrementCounter(pThis))
             }
@@ -1123,7 +1123,7 @@ public enum __ABI_test_component {
     public class IDerived: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIDerived }
 
-        public func get_PropImpl() throws -> Int32 {
+        public func get_Prop() throws -> Int32 {
             var value: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIDerived.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Prop(pThis, &value))
@@ -1131,7 +1131,7 @@ public enum __ABI_test_component {
             return value
         }
 
-        public func put_PropImpl(_ value: Int32) throws {
+        public func put_Prop(_ value: Int32) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIDerived.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Prop(pThis, value))
             }
@@ -1142,7 +1142,7 @@ public enum __ABI_test_component {
     public class IDerivedFromNoConstructor: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIDerivedFromNoConstructor }
 
-        public func MethodImpl() throws {
+        public func Method() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIDerivedFromNoConstructor.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Method(pThis))
             }
@@ -1153,7 +1153,7 @@ public enum __ABI_test_component {
     public class IDerivedStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIDerivedStatics }
 
-        public func CreateFromStringImpl(_ value: String) throws -> test_component.Derived? {
+        public func CreateFromString(_ value: String) throws -> test_component.Derived? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 let _value = try! HString(value)
                 _ = try perform(as: __x_ABI_Ctest__component_CIDerivedStatics.self) { pThis in
@@ -1168,19 +1168,19 @@ public enum __ABI_test_component {
     public class IEventTester: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIEventTester }
 
-        public func SubscribeImpl() throws {
+        public func Subscribe() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIEventTester.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Subscribe(pThis))
             }
         }
 
-        public func UnsubscribeImpl() throws {
+        public func Unsubscribe() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIEventTester.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Unsubscribe(pThis))
             }
         }
 
-        public func GetResultImpl() throws -> String {
+        public func GetResult() throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIEventTester.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResult(pThis, &result))
@@ -1188,7 +1188,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func get_CountImpl() throws -> Int32 {
+        public func get_Count() throws -> Int32 {
             var value: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIEventTester.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Count(pThis, &value))
@@ -1201,7 +1201,7 @@ public enum __ABI_test_component {
     public class IEventTesterFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIEventTesterFactory }
 
-        public func CreateInstanceImpl(_ impl: test_component.AnyIIAmImplementable?) throws -> IEventTester {
+        public func CreateInstance(_ impl: test_component.AnyIIAmImplementable?) throws -> IEventTester {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let implWrapper = __ABI_test_component.IIAmImplementableWrapper(impl)
                 let _impl = try! implWrapper?.toABI { $0 }
@@ -1217,7 +1217,7 @@ public enum __ABI_test_component {
     public class IIAmImplementable: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIIAmImplementable }
 
-        open func InInt32Impl(_ value: Int32) throws -> String {
+        open func InInt32(_ value: Int32) throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InInt32(pThis, value, &result))
@@ -1225,7 +1225,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        open func InStringImpl(_ value: String) throws -> String {
+        open func InString(_ value: String) throws -> String {
             var result: HSTRING?
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
@@ -1234,7 +1234,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        open func InObjectImpl(_ value: Any?) throws -> String {
+        open func InObject(_ value: Any?) throws -> String {
             var result: HSTRING?
             let valueWrapper = __ABI_.AnyWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1244,7 +1244,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        open func InEnumImpl(_ value: test_component.Signed) throws -> String {
+        open func InEnum(_ value: test_component.Signed) throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InEnum(pThis, value, &result))
@@ -1252,13 +1252,13 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        open func OutInt32Impl(_ value: inout Int32) throws {
+        open func OutInt32(_ value: inout Int32) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutInt32(pThis, &value))
             }
         }
 
-        open func OutStringImpl(_ value: inout String) throws {
+        open func OutString(_ value: inout String) throws {
             var _value: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutString(pThis, &_value))
@@ -1267,7 +1267,7 @@ public enum __ABI_test_component {
             WindowsDeleteString(_value)
         }
 
-        open func OutObjectImpl(_ value: inout Any?) throws {
+        open func OutObject(_ value: inout Any?) throws {
             let (_value) = try ComPtrs.initialize { (_valueAbi) in
                 _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.OutObject(pThis, &_valueAbi))
@@ -1276,7 +1276,7 @@ public enum __ABI_test_component {
             value = __ABI_.AnyWrapper.unwrapFrom(abi: _value)
         }
 
-        open func OutBlittableStructImpl(_ value: inout test_component.BlittableStruct) throws {
+        open func OutBlittableStruct(_ value: inout test_component.BlittableStruct) throws {
             var _value: __x_ABI_Ctest__component_CBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutBlittableStruct(pThis, &_value))
@@ -1284,7 +1284,7 @@ public enum __ABI_test_component {
             value = .from(abi: _value)
         }
 
-        open func OutNonBlittableStructImpl(_ value: inout test_component.NonBlittableStruct) throws {
+        open func OutNonBlittableStruct(_ value: inout test_component.NonBlittableStruct) throws {
             let _value: __ABI_test_component._ABI_NonBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutNonBlittableStruct(pThis, &_value.val))
@@ -1292,13 +1292,13 @@ public enum __ABI_test_component {
             value = .from(abi: _value.val)
         }
 
-        open func OutEnumImpl(_ value: inout test_component.Signed) throws {
+        open func OutEnum(_ value: inout test_component.Signed) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OutEnum(pThis, &value))
             }
         }
 
-        open func ReturnObjectImpl() throws -> Any? {
+        open func ReturnObject() throws -> Any? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnObject(pThis, &resultAbi))
@@ -1307,7 +1307,7 @@ public enum __ABI_test_component {
             return __ABI_.AnyWrapper.unwrapFrom(abi: result)
         }
 
-        open func ReturnEnumImpl() throws -> test_component.Signed {
+        open func ReturnEnum() throws -> test_component.Signed {
             var result: __x_ABI_Ctest__component_CSigned = .init(0)
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnEnum(pThis, &result))
@@ -1315,7 +1315,7 @@ public enum __ABI_test_component {
             return result
         }
 
-        open func get_EnumPropertyImpl() throws -> test_component.Fruit {
+        open func get_EnumProperty() throws -> test_component.Fruit {
             var value: __x_ABI_Ctest__component_CFruit = .init(0)
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_EnumProperty(pThis, &value))
@@ -1323,13 +1323,13 @@ public enum __ABI_test_component {
             return value
         }
 
-        open func put_EnumPropertyImpl(_ value: test_component.Fruit) throws {
+        open func put_EnumProperty(_ value: test_component.Fruit) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_EnumProperty(pThis, value))
             }
         }
 
-        open func get_IdImpl() throws -> Foundation.UUID? {
+        open func get_Id() throws -> Foundation.UUID? {
             let (value) = try ComPtrs.initialize { valueAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Id(pThis, &valueAbi))
@@ -1338,7 +1338,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIReference_1_GUIDWrapper.unwrapFrom(abi: value)
         }
 
-        open func put_IdImpl(_ value: Foundation.UUID?) throws {
+        open func put_Id(_ value: Foundation.UUID?) throws {
             let valueWrapper = test_component.__x_ABI_C__FIReference_1_GUIDWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
@@ -1346,7 +1346,7 @@ public enum __ABI_test_component {
             }
         }
 
-        open func add_ImplementableEventImpl(_ handler: test_component.InDelegate?) throws -> EventRegistrationToken {
+        open func add_ImplementableEvent(_ handler: test_component.InDelegate?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = __ABI_test_component_Delegates.InDelegateWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -1356,13 +1356,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        open func remove_ImplementableEventImpl(_ token: EventRegistrationToken) throws {
+        open func remove_ImplementableEvent(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_ImplementableEvent(pThis, token))
             }
         }
 
-        open func FireEventImpl(_ data: String) throws {
+        open func FireEvent(_ data: String) throws {
             let _data = try! HString(data)
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.FireEvent(pThis, _data.get()))
@@ -1578,7 +1578,7 @@ public enum __ABI_test_component {
     public class IInterfaceWithObservableVector: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIInterfaceWithObservableVector }
 
-        open func TakeObservableImpl(_ basics: test_component.AnyIObservableVector<test_component.AnyIBasic?>?) throws {
+        open func TakeObservable(_ basics: test_component.AnyIObservableVector<test_component.AnyIBasic?>?) throws {
             let basicsWrapper = test_component.__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper(basics)
             let _basics = try! basicsWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIInterfaceWithObservableVector.self) { pThis in
@@ -1630,7 +1630,7 @@ public enum __ABI_test_component {
     public class INullValuesStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CINullValuesStatics }
 
-        public func IsObjectNullImpl(_ value: Any?) throws -> Bool {
+        public func IsObjectNull(_ value: Any?) throws -> Bool {
             var result: boolean = 0
             let valueWrapper = __ABI_.AnyWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1640,7 +1640,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func IsInterfaceNullImpl(_ value: test_component.AnyIClosable?) throws -> Bool {
+        public func IsInterfaceNull(_ value: test_component.AnyIClosable?) throws -> Bool {
             var result: boolean = 0
             let valueWrapper = __ABI_Windows_Foundation.IClosableWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1650,7 +1650,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func IsGenericInterfaceNullImpl(_ value: test_component.AnyIVector<String>?) throws -> Bool {
+        public func IsGenericInterfaceNull(_ value: test_component.AnyIVector<String>?) throws -> Bool {
             var result: boolean = 0
             let valueWrapper = test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1660,7 +1660,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func IsClassNullImpl(_ value: test_component.NoopClosable?) throws -> Bool {
+        public func IsClassNull(_ value: test_component.NoopClosable?) throws -> Bool {
             var result: boolean = 0
             _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.IsClassNull(pThis, RawPointer(value), &result))
@@ -1668,7 +1668,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func IsDelegateNullImpl(_ value: test_component.VoidToVoidDelegate?) throws -> Bool {
+        public func IsDelegateNull(_ value: test_component.VoidToVoidDelegate?) throws -> Bool {
             var result: boolean = 0
             let valueWrapper = __ABI_test_component.VoidToVoidDelegateWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
@@ -1678,7 +1678,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func GetNullObjectImpl() throws -> Any? {
+        public func GetNullObject() throws -> Any? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetNullObject(pThis, &resultAbi))
@@ -1687,7 +1687,7 @@ public enum __ABI_test_component {
             return __ABI_.AnyWrapper.unwrapFrom(abi: result)
         }
 
-        public func GetNullInterfaceImpl() throws -> test_component.AnyIClosable? {
+        public func GetNullInterface() throws -> test_component.AnyIClosable? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetNullInterface(pThis, &resultAbi))
@@ -1696,7 +1696,7 @@ public enum __ABI_test_component {
             return __ABI_Windows_Foundation.IClosableWrapper.unwrapFrom(abi: result)
         }
 
-        public func GetNullGenericInterfaceImpl() throws -> test_component.AnyIVector<String>? {
+        public func GetNullGenericInterface() throws -> test_component.AnyIVector<String>? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetNullGenericInterface(pThis, &resultAbi))
@@ -1705,7 +1705,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: result)
         }
 
-        public func GetNullClassImpl() throws -> test_component.NoopClosable? {
+        public func GetNullClass() throws -> test_component.NoopClosable? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetNullClass(pThis, &resultAbi))
@@ -1714,7 +1714,7 @@ public enum __ABI_test_component {
             return .from(abi: result)
         }
 
-        public func GetNullDelegateImpl() throws -> test_component.VoidToVoidDelegate? {
+        public func GetNullDelegate() throws -> test_component.VoidToVoidDelegate? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CINullValuesStatics.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetNullDelegate(pThis, &resultAbi))
@@ -1728,7 +1728,7 @@ public enum __ABI_test_component {
     public class IReferenceTarget: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIReferenceTarget }
 
-        open func MethodImpl() throws {
+        open func Method() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIReferenceTarget.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Method(pThis))
             }
@@ -1777,13 +1777,13 @@ public enum __ABI_test_component {
     public class ISimple: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CISimple }
 
-        public func MethodImpl() throws {
+        public func Method() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Method(pThis))
             }
         }
 
-        public func OperationImpl(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncOperation<Int32>? {
+        public func Operation(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncOperation<Int32>? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Operation(pThis, .from(swift: value), &operationAbi))
@@ -1792,7 +1792,7 @@ public enum __ABI_test_component {
             return test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper.unwrapFrom(abi: operation)
         }
 
-        public func ActionImpl(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncAction? {
+        public func Action(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncAction? {
             let (operation) = try ComPtrs.initialize { operationAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Action(pThis, .from(swift: value), &operationAbi))
@@ -1801,7 +1801,7 @@ public enum __ABI_test_component {
             return __ABI_Windows_Foundation.IAsyncActionWrapper.unwrapFrom(abi: operation)
         }
 
-        public func ObjectImpl(_ value: test_component.DateTime) throws -> Any? {
+        public func Object(_ value: test_component.DateTime) throws -> Any? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Object(pThis, .from(swift: value), &resultAbi))
@@ -1810,7 +1810,7 @@ public enum __ABI_test_component {
             return __ABI_.AnyWrapper.unwrapFrom(abi: result)
         }
 
-        public func ReturnBlittableStructImpl() throws -> test_component.BlittableStruct {
+        public func ReturnBlittableStruct() throws -> test_component.BlittableStruct {
             var result: __x_ABI_Ctest__component_CBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnBlittableStruct(pThis, &result))
@@ -1818,13 +1818,13 @@ public enum __ABI_test_component {
             return .from(abi: result)
         }
 
-        public func TakeBlittableStructImpl(_ value: test_component.BlittableStruct) throws {
+        public func TakeBlittableStruct(_ value: test_component.BlittableStruct) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.TakeBlittableStruct(pThis, .from(swift: value)))
             }
         }
 
-        public func get_BlittableStructPropertyImpl() throws -> test_component.BlittableStruct {
+        public func get_BlittableStructProperty() throws -> test_component.BlittableStruct {
             var value: __x_ABI_Ctest__component_CBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_BlittableStructProperty(pThis, &value))
@@ -1832,13 +1832,13 @@ public enum __ABI_test_component {
             return .from(abi: value)
         }
 
-        public func put_BlittableStructPropertyImpl(_ value: test_component.BlittableStruct) throws {
+        public func put_BlittableStructProperty(_ value: test_component.BlittableStruct) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_BlittableStructProperty(pThis, .from(swift: value)))
             }
         }
 
-        public func ReturnStructWithReferenceImpl() throws -> test_component.StructWithIReference {
+        public func ReturnStructWithReference() throws -> test_component.StructWithIReference {
             var result: __x_ABI_Ctest__component_CStructWithIReference = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnStructWithReference(pThis, &result))
@@ -1846,14 +1846,14 @@ public enum __ABI_test_component {
             return .from(abi: result)
         }
 
-        public func TakeStructWithReferenceImpl(_ value: test_component.StructWithIReference) throws {
+        public func TakeStructWithReference(_ value: test_component.StructWithIReference) throws {
             let _value = __ABI_test_component._ABI_StructWithIReference(from: value)
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.TakeStructWithReference(pThis, _value.val))
             }
         }
 
-        public func get_StructWithReferencePropertyImpl() throws -> test_component.StructWithIReference {
+        public func get_StructWithReferenceProperty() throws -> test_component.StructWithIReference {
             var value: __x_ABI_Ctest__component_CStructWithIReference = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StructWithReferenceProperty(pThis, &value))
@@ -1861,14 +1861,14 @@ public enum __ABI_test_component {
             return .from(abi: value)
         }
 
-        public func put_StructWithReferencePropertyImpl(_ value: test_component.StructWithIReference) throws {
+        public func put_StructWithReferenceProperty(_ value: test_component.StructWithIReference) throws {
             let _value = __ABI_test_component._ABI_StructWithIReference(from: value)
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_StructWithReferenceProperty(pThis, _value.val))
             }
         }
 
-        public func ReturnNonBlittableStructImpl() throws -> test_component.NonBlittableStruct {
+        public func ReturnNonBlittableStruct() throws -> test_component.NonBlittableStruct {
             var result: __x_ABI_Ctest__component_CNonBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ReturnNonBlittableStruct(pThis, &result))
@@ -1876,14 +1876,14 @@ public enum __ABI_test_component {
             return .from(abi: result)
         }
 
-        public func TakeNonBlittableStructImpl(_ value: test_component.NonBlittableStruct) throws {
+        public func TakeNonBlittableStruct(_ value: test_component.NonBlittableStruct) throws {
             let _value = __ABI_test_component._ABI_NonBlittableStruct(from: value)
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.TakeNonBlittableStruct(pThis, _value.val))
             }
         }
 
-        public func get_NonBlittableStructPropertyImpl() throws -> test_component.NonBlittableStruct {
+        public func get_NonBlittableStructProperty() throws -> test_component.NonBlittableStruct {
             var value: __x_ABI_Ctest__component_CNonBlittableStruct = .init()
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_NonBlittableStructProperty(pThis, &value))
@@ -1891,14 +1891,14 @@ public enum __ABI_test_component {
             return .from(abi: value)
         }
 
-        public func put_NonBlittableStructPropertyImpl(_ value: test_component.NonBlittableStruct) throws {
+        public func put_NonBlittableStructProperty(_ value: test_component.NonBlittableStruct) throws {
             let _value = __ABI_test_component._ABI_NonBlittableStruct(from: value)
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_NonBlittableStructProperty(pThis, _value.val))
             }
         }
 
-        public func get_StringPropertyImpl() throws -> String {
+        public func get_StringProperty() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StringProperty(pThis, &value))
@@ -1906,14 +1906,14 @@ public enum __ABI_test_component {
             return .init(from: value)
         }
 
-        public func put_StringPropertyImpl(_ value: String) throws {
+        public func put_StringProperty(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_StringProperty(pThis, _value.get()))
             }
         }
 
-        public func add_SignalEventImpl(_ handler: test_component.SignalDelegate?) throws -> EventRegistrationToken {
+        public func add_SignalEvent(_ handler: test_component.SignalDelegate?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = __ABI_test_component_Delegates.SignalDelegateWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -1923,13 +1923,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        public func remove_SignalEventImpl(_ token: EventRegistrationToken) throws {
+        public func remove_SignalEvent(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_SignalEvent(pThis, token))
             }
         }
 
-        public func add_InEventImpl(_ handler: test_component.InDelegate?) throws -> EventRegistrationToken {
+        public func add_InEvent(_ handler: test_component.InDelegate?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = __ABI_test_component_Delegates.InDelegateWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -1939,13 +1939,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        public func remove_InEventImpl(_ token: EventRegistrationToken) throws {
+        public func remove_InEvent(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_InEvent(pThis, token))
             }
         }
 
-        public func add_SimpleEventImpl(_ handler: TypedEventHandler<test_component.Simple?, test_component.SimpleEventArgs>?) throws -> EventRegistrationToken {
+        public func add_SimpleEvent(_ handler: TypedEventHandler<test_component.Simple?, test_component.SimpleEventArgs>?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = test_component.__x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -1955,13 +1955,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        public func remove_SimpleEventImpl(_ token: EventRegistrationToken) throws {
+        public func remove_SimpleEvent(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_SimpleEvent(pThis, token))
             }
         }
 
-        public func FireEventImpl() throws {
+        public func FireEvent() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.FireEvent(pThis))
             }
@@ -1972,13 +1972,13 @@ public enum __ABI_test_component {
     public class ISimpleDelegate: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CISimpleDelegate }
 
-        open func DoThisImpl() throws {
+        open func DoThis() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimpleDelegate.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.DoThis(pThis))
             }
         }
 
-        open func DoThatImpl(_ val: Int32) throws {
+        open func DoThat(_ val: Int32) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimpleDelegate.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.DoThat(pThis, val))
             }
@@ -2036,7 +2036,7 @@ public enum __ABI_test_component {
     public class ISimpleOverrides: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CISimpleOverrides }
 
-        public func CantActuallyOverrideBecauseNotComposableImpl() throws {
+        public func CantActuallyOverrideBecauseNotComposable() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimpleOverrides.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.CantActuallyOverrideBecauseNotComposable(pThis))
             }
@@ -2047,7 +2047,7 @@ public enum __ABI_test_component {
     public class ISimpleStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CISimpleStatics }
 
-        public func add_StaticEventImpl(_ handler: EventHandler<Any?>?) throws -> EventRegistrationToken {
+        public func add_StaticEvent(_ handler: EventHandler<Any?>?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = test_component.__x_ABI_C__FIEventHandler_1_IInspectableWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -2057,13 +2057,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        public func remove_StaticEventImpl(_ token: EventRegistrationToken) throws {
+        public func remove_StaticEvent(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimpleStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_StaticEvent(pThis, token))
             }
         }
 
-        public func FireStaticEventImpl() throws {
+        public func FireStaticEvent() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CISimpleStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.FireStaticEvent(pThis))
             }
@@ -2074,7 +2074,7 @@ public enum __ABI_test_component {
     public class IStaticClassStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIStaticClassStatics }
 
-        public func get_EnumPropertyImpl() throws -> test_component.Fruit {
+        public func get_EnumProperty() throws -> test_component.Fruit {
             var value: __x_ABI_Ctest__component_CFruit = .init(0)
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_EnumProperty(pThis, &value))
@@ -2082,13 +2082,13 @@ public enum __ABI_test_component {
             return value
         }
 
-        public func put_EnumPropertyImpl(_ value: test_component.Fruit) throws {
+        public func put_EnumProperty(_ value: test_component.Fruit) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_EnumProperty(pThis, value))
             }
         }
 
-        public func InEnumImpl(_ value: test_component.Signed) throws -> String {
+        public func InEnum(_ value: test_component.Signed) throws -> String {
             var result: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InEnum(pThis, value, &result))
@@ -2096,7 +2096,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func InNonBlittableStructImpl(_ value: test_component.NonBlittableStruct) throws -> String {
+        public func InNonBlittableStruct(_ value: test_component.NonBlittableStruct) throws -> String {
             var result: HSTRING?
             let _value = __ABI_test_component._ABI_NonBlittableStruct(from: value)
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
@@ -2105,7 +2105,7 @@ public enum __ABI_test_component {
             return .init(from: result)
         }
 
-        public func TakeBaseImpl(_ base: test_component.Base?) throws {
+        public func TakeBase(_ base: test_component.Base?) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.TakeBase(pThis, RawPointer(base)))
             }
@@ -2116,7 +2116,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerived: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerived }
 
-        public func get_PropImpl() throws -> Int32 {
+        public func get_Prop() throws -> Int32 {
             var value: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CIUnsealedDerived.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Prop(pThis, &value))
@@ -2124,7 +2124,7 @@ public enum __ABI_test_component {
             return value
         }
 
-        public func put_PropImpl(_ value: Int32) throws {
+        public func put_Prop(_ value: Int32) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIUnsealedDerived.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Prop(pThis, value))
             }
@@ -2135,7 +2135,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerived2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerived2 }
 
-        public func MethodImpl() throws {
+        public func Method() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIUnsealedDerived2.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Method(pThis))
             }
@@ -2146,7 +2146,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerived2Factory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerived2Factory }
 
-        public func CreateInstanceImpl(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived2.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
+        public func CreateInstance(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived2.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2164,7 +2164,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerived2ProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerived2ProtectedFactory }
 
-        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived2.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived2.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2182,7 +2182,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedFactory }
 
-        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2195,7 +2195,7 @@ public enum __ABI_test_component {
             return IUnsealedDerived(value!)
         }
 
-        public func CreateInstance2Impl(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
+        public func CreateInstance2(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2208,7 +2208,7 @@ public enum __ABI_test_component {
             return IUnsealedDerived(value!)
         }
 
-        public func CreateInstance3Impl(_ prop1: String, _ prop2: test_component.Base?, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
+        public func CreateInstance3(_ prop1: String, _ prop2: test_component.Base?, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _prop1 = try! HString(prop1)
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
@@ -2232,7 +2232,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedFromNoConstructorFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructorFactory }
 
-        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerivedFromNoConstructor.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedFromNoConstructor {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerivedFromNoConstructor.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedFromNoConstructor {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2265,7 +2265,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedNoOverridesProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedNoOverridesProtectedFactory }
 
-        public func CreateInstanceImpl(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerivedNoOverrides.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedNoOverrides {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerivedNoOverrides.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedNoOverrides {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2283,7 +2283,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedOverloads2: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedOverloads2 }
 
-        public func OnAfterDoTheThingImpl() throws {
+        public func OnAfterDoTheThing() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OnAfterDoTheThing(pThis))
             }
@@ -2294,7 +2294,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedOverrides: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedOverrides }
 
-        public func OnBeforeDoTheThingImpl() throws {
+        public func OnBeforeDoTheThing() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIUnsealedDerivedOverrides.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.OnBeforeDoTheThing(pThis))
             }
@@ -2305,7 +2305,7 @@ public enum __ABI_test_component {
     public class IWeakReferencer: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIWeakReferencer }
 
-        public func ResolveImpl() throws -> test_component.AnyIReferenceTarget? {
+        public func Resolve() throws -> test_component.AnyIReferenceTarget? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CIWeakReferencer.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.Resolve(pThis, &resultAbi))
@@ -2319,7 +2319,7 @@ public enum __ABI_test_component {
     public class IWeakReferencerFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIWeakReferencerFactory }
 
-        public func CreateInstanceImpl(_ object: test_component.AnyIReferenceTarget?) throws -> IWeakReferencer {
+        public func CreateInstance(_ object: test_component.AnyIReferenceTarget?) throws -> IWeakReferencer {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let objectWrapper = __ABI_test_component.IReferenceTargetWrapper(object)
                 let _object = try! objectWrapper?.toABI { $0 }
@@ -2335,7 +2335,7 @@ public enum __ABI_test_component {
     public class InterfaceWithReturnDelegate: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CInterfaceWithReturnDelegate }
 
-        open func add_EventWithReturnImpl(_ handler: test_component.ReturnInt32Delegate?) throws -> EventRegistrationToken {
+        open func add_EventWithReturn(_ handler: test_component.ReturnInt32Delegate?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = __ABI_test_component_Delegates.ReturnInt32DelegateWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -2345,7 +2345,7 @@ public enum __ABI_test_component {
             return token
         }
 
-        open func remove_EventWithReturnImpl(_ token: EventRegistrationToken) throws {
+        open func remove_EventWithReturn(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CInterfaceWithReturnDelegate.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_EventWithReturn(pThis, token))
             }
@@ -2401,7 +2401,7 @@ public enum __ABI_test_component {
     public class WithIterableGuids: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CWithIterableGuids }
 
-        open func IDsImpl() throws -> test_component.AnyIVector<Foundation.UUID>? {
+        open func IDs() throws -> test_component.AnyIVector<Foundation.UUID>? {
             let (result) = try ComPtrs.initialize { resultAbi in
                 _ = try perform(as: __x_ABI_Ctest__component_CWithIterableGuids.self) { pThis in
                     try CHECKED(pThis.pointee.lpVtbl.pointee.IDs(pThis, &resultAbi))
@@ -2455,14 +2455,14 @@ public enum __ABI_test_component {
     public class WithKeyword: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CWithKeyword }
 
-        open func EnumImpl(_ `extension`: String) throws {
+        open func Enum(_ `extension`: String) throws {
             let _extension = try! HString(`extension`)
             _ = try perform(as: __x_ABI_Ctest__component_CWithKeyword.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Enum(pThis, _extension.get()))
             }
         }
 
-        open func get_StructImpl() throws -> String {
+        open func get_Struct() throws -> String {
             var value: HSTRING?
             _ = try perform(as: __x_ABI_Ctest__component_CWithKeyword.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Struct(pThis, &value))
@@ -2470,14 +2470,14 @@ public enum __ABI_test_component {
             return .init(from: value)
         }
 
-        open func put_StructImpl(_ value: String) throws {
+        open func put_Struct(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_Ctest__component_CWithKeyword.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.put_Struct(pThis, _value.get()))
             }
         }
 
-        open func add_RepeatImpl(_ handler: EventHandler<Any?>?) throws -> EventRegistrationToken {
+        open func add_Repeat(_ handler: EventHandler<Any?>?) throws -> EventRegistrationToken {
             var token: EventRegistrationToken = .init()
             let handlerWrapper = test_component.__x_ABI_C__FIEventHandler_1_IInspectableWrapper(handler)
             let _handler = try! handlerWrapper?.toABI { $0 }
@@ -2487,13 +2487,13 @@ public enum __ABI_test_component {
             return token
         }
 
-        open func remove_RepeatImpl(_ token: EventRegistrationToken) throws {
+        open func remove_Repeat(_ token: EventRegistrationToken) throws {
             _ = try perform(as: __x_ABI_Ctest__component_CWithKeyword.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.remove_Repeat(pThis, token))
             }
         }
 
-        open func SubscriptImpl() throws {
+        open func Subscript() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CWithKeyword.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Subscript(pThis))
             }
@@ -2794,7 +2794,7 @@ extension __ABI_test_component {
     public class ObjectHandler: test_component.IUnknown {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIObjectHandler }
 
-        open func InvokeImpl(_ item: Any?) throws {
+        open func Invoke(_ item: Any?) throws {
             let itemWrapper = __ABI_.AnyWrapper(item)
             let _item = try! itemWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CIObjectHandler.self) { pThis in
@@ -2832,7 +2832,7 @@ extension __ABI_test_component {
     public class VoidToVoidDelegate: test_component.IUnknown {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIVoidToVoidDelegate }
 
-        open func InvokeImpl() throws {
+        open func Invoke() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CIVoidToVoidDelegate.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis))
             }

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -32,7 +32,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanWrapper = Interfa
 public class AsyncOperationCompletedHandlerBool: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1_boolean }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<Bool>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<Bool>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1_booleanWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1_boolean.self) { pThis in
@@ -51,7 +51,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanBridge : Win
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -85,7 +85,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper = InterfaceWr
 public class AsyncOperationCompletedHandlerInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1_int }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<Int32>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<Int32>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1_intWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1_int.self) { pThis in
@@ -104,7 +104,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1_intBridge : WinRTDe
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -138,7 +138,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGWrapper = Interfa
 public class AsyncOperationCompletedHandlerString: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRING }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<String>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<String>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1_HSTRINGWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRING.self) { pThis in
@@ -157,7 +157,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGBridge : Win
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -191,7 +191,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32Wrapper = Interfac
 public class AsyncOperationCompletedHandlerUInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32 }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1_UINT32Wrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32.self) { pThis in
@@ -210,7 +210,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32Bridge : WinR
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -244,7 +244,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRI
 public class AsyncOperationCompletedHandlerIMapString_Any: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectable }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIMap<String, Any?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIMap<String, Any?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
@@ -263,7 +263,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -297,7 +297,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_
 public class AsyncOperationCompletedHandlerIVectorViewIStorageItem: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
@@ -316,7 +316,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -350,7 +350,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_
 public class AsyncOperationCompletedHandlerIVectorViewStorageFile: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
@@ -369,7 +369,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -403,7 +403,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_
 public class AsyncOperationCompletedHandlerIVectorViewStorageFolder: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFolder?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
@@ -422,7 +422,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -456,7 +456,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_
 public class AsyncOperationCompletedHandlerIVectorViewStorageLibraryChange: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
@@ -475,7 +475,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -509,7 +509,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HS
 public class AsyncOperationCompletedHandlerIVectorString: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRING }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIVector<String>?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRING.self) { pThis in
@@ -528,7 +528,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -562,7 +562,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerBasicProperties: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.BasicProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.BasicProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties.self) { pThis in
@@ -581,7 +581,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -615,7 +615,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerDocumentProperties: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.DocumentProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.DocumentProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties.self) { pThis in
@@ -634,7 +634,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -668,7 +668,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerImageProperties: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.ImageProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.ImageProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties.self) { pThis in
@@ -687,7 +687,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -721,7 +721,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerMusicProperties: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.MusicProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.MusicProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties.self) { pThis in
@@ -740,7 +740,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -774,7 +774,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerStorageItemThumbnail: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageItemThumbnail?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail.self) { pThis in
@@ -793,7 +793,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -827,7 +827,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerVideoProperties: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.VideoProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.VideoProperties?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties.self) { pThis in
@@ -846,7 +846,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -880,7 +880,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerIStorageItem: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIStorageItem?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
@@ -899,7 +899,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -933,7 +933,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerIndexedState: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.IndexedState>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.IndexedState>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState.self) { pThis in
@@ -952,7 +952,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -986,7 +986,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerStorageFile: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageFile?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageFile?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
@@ -1005,7 +1005,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -1039,7 +1039,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerStorageFolder: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageFolder?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageFolder?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
@@ -1058,7 +1058,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -1092,7 +1092,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerStorageStreamTransaction: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageStreamTransaction?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.StorageStreamTransaction?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction.self) { pThis in
@@ -1111,7 +1111,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -1145,7 +1145,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerIBuffer: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIBuffer?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIBuffer?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer.self) { pThis in
@@ -1164,7 +1164,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -1198,7 +1198,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerIInputStream: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIInputStream?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIInputStream?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream.self) { pThis in
@@ -1217,7 +1217,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -1251,7 +1251,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerIRandomAccessStream: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStream?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream.self) { pThis in
@@ -1270,7 +1270,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -1304,7 +1304,7 @@ typealias __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStora
 public class AsyncOperationCompletedHandlerIRandomAccessStreamWithContentType: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStreamWithContentType?>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperation<test_component.AnyIRandomAccessStreamWithContentType?>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType.self) { pThis in
@@ -1323,7 +1323,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -1357,7 +1357,7 @@ typealias __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleWrapper = Inter
 public class AsyncOperationProgressHandlerInt32_Double: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationProgressHandler_2_int_double }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<Int32, Double>?, _ progressInfo: Double) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<Int32, Double>?, _ progressInfo: Double) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationProgressHandler_2_int_double.self) { pThis in
@@ -1376,7 +1376,7 @@ internal class __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleBridge : W
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, progressInfo) in
-            try _default.InvokeImpl(asyncInfo, progressInfo)
+            try _default.Invoke(asyncInfo, progressInfo)
         }
         return handler
     }
@@ -1410,7 +1410,7 @@ typealias __x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32Wrapper = In
 public class AsyncOperationProgressHandlerUInt32_UInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32 }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<UInt32, UInt32>?, _ progressInfo: UInt32) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<UInt32, UInt32>?, _ progressInfo: UInt32) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Wrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32.self) { pThis in
@@ -1429,7 +1429,7 @@ internal class __x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32Bridge 
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, progressInfo) in
-            try _default.InvokeImpl(asyncInfo, progressInfo)
+            try _default.Invoke(asyncInfo, progressInfo)
         }
         return handler
     }
@@ -1463,7 +1463,7 @@ typealias __x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorag
 public class AsyncOperationProgressHandlerIBuffer_UInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32 }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<test_component.AnyIBuffer?, UInt32>?, _ progressInfo: UInt32) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<test_component.AnyIBuffer?, UInt32>?, _ progressInfo: UInt32) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
@@ -1482,7 +1482,7 @@ internal class __x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CS
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, progressInfo) in
-            try _default.InvokeImpl(asyncInfo, progressInfo)
+            try _default.Invoke(asyncInfo, progressInfo)
         }
         return handler
     }
@@ -1516,7 +1516,7 @@ typealias __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleWr
 public class AsyncOperationWithProgressCompletedHandlerInt32_Double: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_double }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<Int32, Double>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<Int32, Double>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_double.self) { pThis in
@@ -1535,7 +1535,7 @@ internal class __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_dou
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -1569,7 +1569,7 @@ typealias __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT3
 public class AsyncOperationWithProgressCompletedHandlerUInt32_UInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32 }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<UInt32, UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<UInt32, UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Wrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32.self) { pThis in
@@ -1588,7 +1588,7 @@ internal class __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -1622,7 +1622,7 @@ typealias __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWin
 public class AsyncOperationWithProgressCompletedHandlerIBuffer_UInt32: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32 }
 
-    open func InvokeImpl(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<test_component.AnyIBuffer?, UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
+    open func Invoke(_ asyncInfo: test_component.AnyIAsyncOperationWithProgress<test_component.AnyIBuffer?, UInt32>?, _ asyncStatus: test_component.AsyncStatus) throws {
         let asyncInfoWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper(asyncInfo)
         let _asyncInfo = try! asyncInfoWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
@@ -1641,7 +1641,7 @@ internal class __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
-            try _default.InvokeImpl(asyncInfo, asyncStatus)
+            try _default.Invoke(asyncInfo, asyncStatus)
         }
         return handler
     }
@@ -1690,7 +1690,7 @@ typealias __x_ABI_C__FIIterable_1_IInspectableWrapper = InterfaceWrapperBase<tes
 public class IIterableAny: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1_IInspectable }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<Any?>? {
+    open func First() throws -> test_component.AnyIIterator<Any?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -1727,7 +1727,7 @@ fileprivate class __x_ABI_C__FIIterable_1_IInspectableImpl : IIterable, AbiInter
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<Any?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -1777,7 +1777,7 @@ typealias __x_ABI_C__FIIterable_1_GUIDWrapper = InterfaceWrapperBase<test_compon
 public class IIterableUUID: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1_GUID }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<Foundation.UUID>? {
+    open func First() throws -> test_component.AnyIIterator<Foundation.UUID>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1_GUID.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -1814,7 +1814,7 @@ fileprivate class __x_ABI_C__FIIterable_1_GUIDImpl : IIterable, AbiInterfaceImpl
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<Foundation.UUID>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -1864,7 +1864,7 @@ typealias __x_ABI_C__FIIterable_1_HSTRINGWrapper = InterfaceWrapperBase<test_com
 public class IIterableString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1_HSTRING }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<String>? {
+    open func First() throws -> test_component.AnyIIterator<String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -1901,7 +1901,7 @@ fileprivate class __x_ABI_C__FIIterable_1_HSTRINGImpl : IIterable, AbiInterfaceI
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<String>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -1951,7 +1951,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegmentWr
 public class IIterableTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.TextSegment>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.TextSegment>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -1988,7 +1988,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextS
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<test_component.TextSegment>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2038,7 +2038,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectab
 public class IIterableIKeyValuePairString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, Any?>?>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, Any?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2075,7 +2075,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_II
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, Any?>?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2125,7 +2125,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWra
 public class IIterableIKeyValuePairString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, String>?>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, String>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2162,7 +2162,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HS
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, String>?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2212,7 +2212,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C_
 public class IIterableIKeyValuePairString_IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, test_component.AnyIVectorView<test_component.TextSegment>?>?>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, test_component.AnyIVectorView<test_component.TextSegment>?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2249,7 +2249,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, AnyIVectorView<test_component.TextSegment>?>?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2299,7 +2299,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ct
 public class IIterableIKeyValuePairString_Base: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, test_component.Base?>?>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.AnyIKeyValuePair<String, test_component.Base?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2336,7 +2336,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, Base?>?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2386,7 +2386,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDec
 public class IIterableIWwwFormUrlDecoderEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIWwwFormUrlDecoderEntry?>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.AnyIWwwFormUrlDecoderEntry?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2423,7 +2423,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFo
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<test_component.AnyIWwwFormUrlDecoderEntry?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2473,7 +2473,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItemWrapp
 public class IIterableIStorageItem: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIStorageItem?>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.AnyIStorageItem?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2510,7 +2510,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageI
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<test_component.AnyIStorageItem?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2560,7 +2560,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSortEntr
 public class IIterableSortEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.SortEntry>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.SortEntry>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2597,7 +2597,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__C
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<test_component.SortEntry>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2647,7 +2647,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFileWrappe
 public class IIterableStorageFile: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.StorageFile?>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.StorageFile?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2684,7 +2684,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFi
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<test_component.StorageFile?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2734,7 +2734,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolderWrap
 public class IIterableStorageFolder: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.StorageFolder?>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.StorageFolder?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2771,7 +2771,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFo
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<test_component.StorageFolder?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2821,7 +2821,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibraryCha
 public class IIterableStorageLibraryChange: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibraryChange }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.StorageLibraryChange?>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.StorageLibraryChange?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2858,7 +2858,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLi
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<test_component.StorageLibraryChange?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2908,7 +2908,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseWrapper = Inte
 public class IIterableBase: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBase }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.Base?>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.Base?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -2945,7 +2945,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseImpl :
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<Base?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -2995,7 +2995,7 @@ typealias __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = In
 public class IIterableIBasic: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    open func FirstImpl() throws -> test_component.AnyIIterator<test_component.AnyIBasic?>? {
+    open func First() throws -> test_component.AnyIIterator<test_component.AnyIBasic?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.First(pThis, &resultAbi))
@@ -3032,7 +3032,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicImpl
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterable-1.first)
     fileprivate func first() -> AnyIIterator<AnyIBasic?>? {
-        try! _default.FirstImpl()
+        try! _default.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3098,7 +3098,7 @@ typealias __x_ABI_C__FIIterator_1_IInspectableWrapper = InterfaceWrapperBase<tes
 public class IIteratorAny: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1_IInspectable }
 
-    open func get_CurrentImpl() throws -> Any? {
+    open func get_Current() throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -3107,7 +3107,7 @@ public class IIteratorAny: test_component.IInspectable {
         return __ABI_.AnyWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3115,7 +3115,7 @@ public class IIteratorAny: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3151,17 +3151,17 @@ fileprivate class __x_ABI_C__FIIterator_1_IInspectableImpl : IIterator, AbiInter
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : Any? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3226,7 +3226,7 @@ typealias __x_ABI_C__FIIterator_1_GUIDWrapper = InterfaceWrapperBase<test_compon
 public class IIteratorUUID: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1_GUID }
 
-    open func get_CurrentImpl() throws -> Foundation.UUID {
+    open func get_Current() throws -> Foundation.UUID {
         var result: test_component.GUID = .init()
         _ = try perform(as: __x_ABI_C__FIIterator_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
@@ -3234,7 +3234,7 @@ public class IIteratorUUID: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3242,7 +3242,7 @@ public class IIteratorUUID: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3278,17 +3278,17 @@ fileprivate class __x_ABI_C__FIIterator_1_GUIDImpl : IIterator, AbiInterfaceImpl
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : Foundation.UUID {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3353,7 +3353,7 @@ typealias __x_ABI_C__FIIterator_1_HSTRINGWrapper = InterfaceWrapperBase<test_com
 public class IIteratorString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1_HSTRING }
 
-    open func get_CurrentImpl() throws -> String {
+    open func get_Current() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIIterator_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
@@ -3361,7 +3361,7 @@ public class IIteratorString: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3369,7 +3369,7 @@ public class IIteratorString: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3405,17 +3405,17 @@ fileprivate class __x_ABI_C__FIIterator_1_HSTRINGImpl : IIterator, AbiInterfaceI
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : String {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3480,7 +3480,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegmentWr
 public class IIteratorTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    open func get_CurrentImpl() throws -> test_component.TextSegment {
+    open func get_Current() throws -> test_component.TextSegment {
         var result: __x_ABI_CWindows_CData_CText_CTextSegment = .init()
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
@@ -3488,7 +3488,7 @@ public class IIteratorTextSegment: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3496,7 +3496,7 @@ public class IIteratorTextSegment: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3532,17 +3532,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextS
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.TextSegment {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3608,7 +3608,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectab
 public class IIteratorIKeyValuePairString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable }
 
-    open func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, Any?>? {
+    open func get_Current() throws -> test_component.AnyIKeyValuePair<String, Any?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -3617,7 +3617,7 @@ public class IIteratorIKeyValuePairString_Any: test_component.IInspectable {
         return test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3625,7 +3625,7 @@ public class IIteratorIKeyValuePairString_Any: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3661,17 +3661,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_II
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : AnyIKeyValuePair<String, Any?>? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3737,7 +3737,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWra
 public class IIteratorIKeyValuePairString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING }
 
-    open func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, String>? {
+    open func get_Current() throws -> test_component.AnyIKeyValuePair<String, String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -3746,7 +3746,7 @@ public class IIteratorIKeyValuePairString_String: test_component.IInspectable {
         return test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3754,7 +3754,7 @@ public class IIteratorIKeyValuePairString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3790,17 +3790,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HS
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : AnyIKeyValuePair<String, String>? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3866,7 +3866,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C_
 public class IIteratorIKeyValuePairString_IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    open func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
+    open func get_Current() throws -> test_component.AnyIKeyValuePair<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -3875,7 +3875,7 @@ public class IIteratorIKeyValuePairString_IVectorViewTextSegment: test_component
         return test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -3883,7 +3883,7 @@ public class IIteratorIKeyValuePairString_IVectorViewTextSegment: test_component
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -3919,17 +3919,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : AnyIKeyValuePair<String, AnyIVectorView<test_component.TextSegment>?>? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -3995,7 +3995,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ct
 public class IIteratorIKeyValuePairString_Base: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase }
 
-    open func get_CurrentImpl() throws -> test_component.AnyIKeyValuePair<String, test_component.Base?>? {
+    open func get_Current() throws -> test_component.AnyIKeyValuePair<String, test_component.Base?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4004,7 +4004,7 @@ public class IIteratorIKeyValuePairString_Base: test_component.IInspectable {
         return test_component.__x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4012,7 +4012,7 @@ public class IIteratorIKeyValuePairString_Base: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4048,17 +4048,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : AnyIKeyValuePair<String, Base?>? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4124,7 +4124,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDec
 public class IIteratorIWwwFormUrlDecoderEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry }
 
-    open func get_CurrentImpl() throws -> test_component.AnyIWwwFormUrlDecoderEntry? {
+    open func get_Current() throws -> test_component.AnyIWwwFormUrlDecoderEntry? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4133,7 +4133,7 @@ public class IIteratorIWwwFormUrlDecoderEntry: test_component.IInspectable {
         return __ABI_Windows_Foundation.IWwwFormUrlDecoderEntryWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4141,7 +4141,7 @@ public class IIteratorIWwwFormUrlDecoderEntry: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4177,17 +4177,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFo
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.AnyIWwwFormUrlDecoderEntry? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4253,7 +4253,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItemWrapp
 public class IIteratorIStorageItem: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    open func get_CurrentImpl() throws -> test_component.AnyIStorageItem? {
+    open func get_Current() throws -> test_component.AnyIStorageItem? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4262,7 +4262,7 @@ public class IIteratorIStorageItem: test_component.IInspectable {
         return __ABI_Windows_Storage.IStorageItemWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4270,7 +4270,7 @@ public class IIteratorIStorageItem: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4306,17 +4306,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageI
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.AnyIStorageItem? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4382,7 +4382,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntr
 public class IIteratorSortEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry }
 
-    open func get_CurrentImpl() throws -> test_component.SortEntry {
+    open func get_Current() throws -> test_component.SortEntry {
         var result: __x_ABI_CWindows_CStorage_CSearch_CSortEntry = .init()
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
@@ -4390,7 +4390,7 @@ public class IIteratorSortEntry: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4398,7 +4398,7 @@ public class IIteratorSortEntry: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4434,17 +4434,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__C
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.SortEntry {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4509,7 +4509,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFileWrappe
 public class IIteratorStorageFile: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    open func get_CurrentImpl() throws -> test_component.StorageFile? {
+    open func get_Current() throws -> test_component.StorageFile? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4518,7 +4518,7 @@ public class IIteratorStorageFile: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4526,7 +4526,7 @@ public class IIteratorStorageFile: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4562,17 +4562,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFi
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.StorageFile? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4637,7 +4637,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolderWrap
 public class IIteratorStorageFolder: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    open func get_CurrentImpl() throws -> test_component.StorageFolder? {
+    open func get_Current() throws -> test_component.StorageFolder? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4646,7 +4646,7 @@ public class IIteratorStorageFolder: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4654,7 +4654,7 @@ public class IIteratorStorageFolder: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4690,17 +4690,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFo
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.StorageFolder? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4765,7 +4765,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryCha
 public class IIteratorStorageLibraryChange: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChange }
 
-    open func get_CurrentImpl() throws -> test_component.StorageLibraryChange? {
+    open func get_Current() throws -> test_component.StorageLibraryChange? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4774,7 +4774,7 @@ public class IIteratorStorageLibraryChange: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4782,7 +4782,7 @@ public class IIteratorStorageLibraryChange: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4818,17 +4818,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLi
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : test_component.StorageLibraryChange? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -4893,7 +4893,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseWrapper = Inte
 public class IIteratorBase: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBase }
 
-    open func get_CurrentImpl() throws -> test_component.Base? {
+    open func get_Current() throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -4902,7 +4902,7 @@ public class IIteratorBase: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -4910,7 +4910,7 @@ public class IIteratorBase: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -4946,17 +4946,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseImpl :
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : Base? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5022,7 +5022,7 @@ typealias __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = In
 public class IIteratorIBasic: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    open func get_CurrentImpl() throws -> test_component.AnyIBasic? {
+    open func get_Current() throws -> test_component.AnyIBasic? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
@@ -5031,7 +5031,7 @@ public class IIteratorIBasic: test_component.IInspectable {
         return __ABI_test_component.IBasicWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_HasCurrentImpl() throws -> Bool {
+    open func get_HasCurrent() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_HasCurrent(pThis, &result))
@@ -5039,7 +5039,7 @@ public class IIteratorIBasic: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func MoveNextImpl() throws -> Bool {
+    open func MoveNext() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.MoveNext(pThis, &result))
@@ -5075,17 +5075,17 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicImpl
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.movenext)
     fileprivate func moveNext() -> Bool {
-        try! _default.MoveNextImpl()
+        try! _default.MoveNext()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.current)
     fileprivate var current : AnyIBasic? {
-        get { try! _default.get_CurrentImpl() }
+        get { try! _default.get_Current() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iiterator-1.hascurrent)
     fileprivate var hasCurrent : Bool {
-        get { try! _default.get_HasCurrentImpl() }
+        get { try! _default.get_HasCurrent() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5142,7 +5142,7 @@ typealias __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableWrapper = InterfaceWra
 public class IKeyValuePairString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable }
 
-    open func get_KeyImpl() throws -> String {
+    open func get_Key() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
@@ -5150,7 +5150,7 @@ public class IKeyValuePairString_Any: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func get_ValueImpl() throws -> Any? {
+    open func get_Value() throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &resultAbi))
@@ -5188,12 +5188,12 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableImpl : IKeyVal
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.key)
     fileprivate var key : String {
-        get { try! _default.get_KeyImpl() }
+        get { try! _default.get_Key() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.value)
     fileprivate var value : Any? {
-        get { try! _default.get_ValueImpl() }
+        get { try! _default.get_Value() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5249,7 +5249,7 @@ typealias __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGWrapper = InterfaceWrapperB
 public class IKeyValuePairString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING }
 
-    open func get_KeyImpl() throws -> String {
+    open func get_Key() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
@@ -5257,7 +5257,7 @@ public class IKeyValuePairString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func get_ValueImpl() throws -> String {
+    open func get_Value() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &result))
@@ -5294,12 +5294,12 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGImpl : IKeyValuePai
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.key)
     fileprivate var key : String {
-        get { try! _default.get_KeyImpl() }
+        get { try! _default.get_Key() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.value)
     fileprivate var value : String {
-        get { try! _default.get_ValueImpl() }
+        get { try! _default.get_Value() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5356,7 +5356,7 @@ typealias __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_
 public class IKeyValuePairString_IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    open func get_KeyImpl() throws -> String {
+    open func get_Key() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
@@ -5364,7 +5364,7 @@ public class IKeyValuePairString_IVectorViewTextSegment: test_component.IInspect
         return .init(from: result)
     }
 
-    open func get_ValueImpl() throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
+    open func get_Value() throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &resultAbi))
@@ -5402,12 +5402,12 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1_
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.key)
     fileprivate var key : String {
-        get { try! _default.get_KeyImpl() }
+        get { try! _default.get_Key() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.value)
     fileprivate var value : AnyIVectorView<test_component.TextSegment>? {
-        get { try! _default.get_ValueImpl() }
+        get { try! _default.get_Value() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5463,7 +5463,7 @@ typealias __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWr
 public class IKeyValuePairString_Base: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase }
 
-    open func get_KeyImpl() throws -> String {
+    open func get_Key() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
@@ -5471,7 +5471,7 @@ public class IKeyValuePairString_Base: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func get_ValueImpl() throws -> test_component.Base? {
+    open func get_Value() throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &resultAbi))
@@ -5509,12 +5509,12 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent_
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.key)
     fileprivate var key : String {
-        get { try! _default.get_KeyImpl() }
+        get { try! _default.get_Key() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ikeyvaluepair-2.value)
     fileprivate var value : Base? {
-        get { try! _default.get_ValueImpl() }
+        get { try! _default.get_Value() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5570,7 +5570,7 @@ typealias __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper = InterfaceWrapperBa
 public class IMapChangedEventArgsString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMapChangedEventArgs_1_HSTRING }
 
-    open func get_CollectionChangeImpl() throws -> test_component.CollectionChange {
+    open func get_CollectionChange() throws -> test_component.CollectionChange {
         var result: __x_ABI_CWindows_CFoundation_CCollections_CCollectionChange = .init(0)
         _ = try perform(as: __x_ABI_C__FIMapChangedEventArgs_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_CollectionChange(pThis, &result))
@@ -5578,7 +5578,7 @@ public class IMapChangedEventArgsString: test_component.IInspectable {
         return result
     }
 
-    open func get_KeyImpl() throws -> String {
+    open func get_Key() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIMapChangedEventArgs_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
@@ -5614,12 +5614,12 @@ fileprivate class __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGImpl : IMapChangedEv
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapchangedeventargs-1.collectionchange)
     fileprivate var collectionChange : test_component.CollectionChange {
-        get { try! _default.get_CollectionChangeImpl() }
+        get { try! _default.get_CollectionChange() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapchangedeventargs-1.key)
     fileprivate var key : String {
-        get { try! _default.get_KeyImpl() }
+        get { try! _default.get_Key() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5698,7 +5698,7 @@ typealias __x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper = InterfaceWrapperB
 public class IMapViewString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMapView_2_HSTRING_IInspectable }
 
-    open func LookupImpl(_ key: String) throws -> Any? {
+    open func Lookup(_ key: String) throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
@@ -5708,7 +5708,7 @@ public class IMapViewString_Any: test_component.IInspectable {
         return __ABI_.AnyWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -5716,7 +5716,7 @@ public class IMapViewString_Any: test_component.IInspectable {
         return result
     }
 
-    open func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKey(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
@@ -5725,7 +5725,7 @@ public class IMapViewString_Any: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func SplitImpl(_ first: inout test_component.AnyIMapView<String, Any?>?, _ second: inout test_component.AnyIMapView<String, Any?>?) throws {
+    open func Split(_ first: inout test_component.AnyIMapView<String, Any?>?, _ second: inout test_component.AnyIMapView<String, Any?>?) throws {
         let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
@@ -5765,28 +5765,28 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING_IInspectableImpl : IMapView, Ab
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.lookup)
     fileprivate func lookup(_ key: String) -> Any? {
-        try! _default.LookupImpl(key)
+        try! _default.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.haskey)
     fileprivate func hasKey(_ key: String) -> Bool {
-        try! _default.HasKeyImpl(key)
+        try! _default.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.split)
     fileprivate func split(_ first: inout AnyIMapView<String, Any?>?, _ second: inout AnyIMapView<String, Any?>?) {
-        try! _default.SplitImpl(&first, &second)
+        try! _default.Split(&first, &second)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, Any?>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -5864,7 +5864,7 @@ typealias __x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper = InterfaceWrapperBase<t
 public class IMapViewString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMapView_2_HSTRING_HSTRING }
 
-    open func LookupImpl(_ key: String) throws -> String {
+    open func Lookup(_ key: String) throws -> String {
         var result: HSTRING?
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
@@ -5873,7 +5873,7 @@ public class IMapViewString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -5881,7 +5881,7 @@ public class IMapViewString_String: test_component.IInspectable {
         return result
     }
 
-    open func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKey(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
@@ -5890,7 +5890,7 @@ public class IMapViewString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func SplitImpl(_ first: inout test_component.AnyIMapView<String, String>?, _ second: inout test_component.AnyIMapView<String, String>?) throws {
+    open func Split(_ first: inout test_component.AnyIMapView<String, String>?, _ second: inout test_component.AnyIMapView<String, String>?) throws {
         let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
@@ -5930,28 +5930,28 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING_HSTRINGImpl : IMapView, AbiInte
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.lookup)
     fileprivate func lookup(_ key: String) -> String {
-        try! _default.LookupImpl(key)
+        try! _default.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.haskey)
     fileprivate func hasKey(_ key: String) -> Bool {
-        try! _default.HasKeyImpl(key)
+        try! _default.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.split)
     fileprivate func split(_ first: inout AnyIMapView<String, String>?, _ second: inout AnyIMapView<String, String>?) {
-        try! _default.SplitImpl(&first, &second)
+        try! _default.Split(&first, &second)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_String! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, String>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -6030,7 +6030,7 @@ typealias __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWind
 public class IMapViewString_IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    open func LookupImpl(_ key: String) throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
+    open func Lookup(_ key: String) throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
@@ -6040,7 +6040,7 @@ public class IMapViewString_IVectorViewTextSegment: test_component.IInspectable 
         return test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -6048,7 +6048,7 @@ public class IMapViewString_IVectorViewTextSegment: test_component.IInspectable 
         return result
     }
 
-    open func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKey(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
@@ -6057,7 +6057,7 @@ public class IMapViewString_IVectorViewTextSegment: test_component.IInspectable 
         return .init(from: result)
     }
 
-    open func SplitImpl(_ first: inout test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>?, _ second: inout test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>?) throws {
+    open func Split(_ first: inout test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>?, _ second: inout test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>?) throws {
         let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
@@ -6097,28 +6097,28 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_A
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.lookup)
     fileprivate func lookup(_ key: String) -> AnyIVectorView<test_component.TextSegment>? {
-        try! _default.LookupImpl(key)
+        try! _default.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.haskey)
     fileprivate func hasKey(_ key: String) -> Bool {
-        try! _default.HasKeyImpl(key)
+        try! _default.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.split)
     fileprivate func split(_ first: inout AnyIMapView<String, AnyIVectorView<test_component.TextSegment>?>?, _ second: inout AnyIMapView<String, AnyIVectorView<test_component.TextSegment>?>?) {
-        try! _default.SplitImpl(&first, &second)
+        try! _default.Split(&first, &second)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_IVectorViewTextSegment! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, AnyIVectorView<test_component.TextSegment>?>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -6196,7 +6196,7 @@ typealias __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper
 public class IMapViewString_Base: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase }
 
-    open func LookupImpl(_ key: String) throws -> test_component.Base? {
+    open func Lookup(_ key: String) throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
@@ -6206,7 +6206,7 @@ public class IMapViewString_Base: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -6214,7 +6214,7 @@ public class IMapViewString_Base: test_component.IInspectable {
         return result
     }
 
-    open func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKey(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
@@ -6223,7 +6223,7 @@ public class IMapViewString_Base: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func SplitImpl(_ first: inout test_component.AnyIMapView<String, test_component.Base?>?, _ second: inout test_component.AnyIMapView<String, test_component.Base?>?) throws {
+    open func Split(_ first: inout test_component.AnyIMapView<String, test_component.Base?>?, _ second: inout test_component.AnyIMapView<String, test_component.Base?>?) throws {
         let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
             _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
@@ -6263,28 +6263,28 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBas
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.lookup)
     fileprivate func lookup(_ key: String) -> Base? {
-        try! _default.LookupImpl(key)
+        try! _default.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.haskey)
     fileprivate func hasKey(_ key: String) -> Bool {
-        try! _default.HasKeyImpl(key)
+        try! _default.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.split)
     fileprivate func split(_ first: inout AnyIMapView<String, Base?>?, _ second: inout AnyIMapView<String, Base?>?) {
-        try! _default.SplitImpl(&first, &second)
+        try! _default.Split(&first, &second)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Base! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imapview-2.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, Base?>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -6381,7 +6381,7 @@ typealias __x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper = InterfaceWrapperBase<
 public class IMapString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMap_2_HSTRING_IInspectable }
 
-    open func LookupImpl(_ key: String) throws -> Any? {
+    open func Lookup(_ key: String) throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
@@ -6391,7 +6391,7 @@ public class IMapString_Any: test_component.IInspectable {
         return __ABI_.AnyWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -6399,7 +6399,7 @@ public class IMapString_Any: test_component.IInspectable {
         return result
     }
 
-    open func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKey(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
@@ -6408,7 +6408,7 @@ public class IMapString_Any: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func GetViewImpl() throws -> test_component.AnyIMapView<String, Any?>? {
+    open func GetView() throws -> test_component.AnyIMapView<String, Any?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -6417,7 +6417,7 @@ public class IMapString_Any: test_component.IInspectable {
         return test_component.__x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: result)
     }
 
-    open func InsertImpl(_ key: String, _ value: Any?) throws -> Bool {
+    open func Insert(_ key: String, _ value: Any?) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         let valueWrapper = __ABI_.AnyWrapper(value)
@@ -6428,14 +6428,14 @@ public class IMapString_Any: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func RemoveImpl(_ key: String) throws {
+    open func Remove(_ key: String) throws {
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Remove(pThis, _key.get()))
         }
     }
 
-    open func ClearImpl() throws {
+    open func Clear() throws {
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -6471,43 +6471,43 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING_IInspectableImpl : IMap, AbiInterfa
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.lookup)
     fileprivate func lookup(_ key: String) -> Any? {
-        try! _default.LookupImpl(key)
+        try! _default.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.haskey)
     fileprivate func hasKey(_ key: String) -> Bool {
-        try! _default.HasKeyImpl(key)
+        try! _default.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.getview)
     fileprivate func getView() -> AnyIMapView<String, Any?>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.insert)
     fileprivate func insert(_ key: String, _ value: Any?) -> Bool {
-        try! _default.InsertImpl(key, value)
+        try! _default.Insert(key, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.remove)
     fileprivate func remove(_ key: String) {
-        try! _default.RemoveImpl(key)
+        try! _default.Remove(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.clear)
     fileprivate func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, Any?>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -6603,7 +6603,7 @@ typealias __x_ABI_C__FIMap_2_HSTRING_HSTRINGWrapper = InterfaceWrapperBase<test_
 public class IMapString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMap_2_HSTRING_HSTRING }
 
-    open func LookupImpl(_ key: String) throws -> String {
+    open func Lookup(_ key: String) throws -> String {
         var result: HSTRING?
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
@@ -6612,7 +6612,7 @@ public class IMapString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -6620,7 +6620,7 @@ public class IMapString_String: test_component.IInspectable {
         return result
     }
 
-    open func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKey(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
@@ -6629,7 +6629,7 @@ public class IMapString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func GetViewImpl() throws -> test_component.AnyIMapView<String, String>? {
+    open func GetView() throws -> test_component.AnyIMapView<String, String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -6638,7 +6638,7 @@ public class IMapString_String: test_component.IInspectable {
         return test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: result)
     }
 
-    open func InsertImpl(_ key: String, _ value: String) throws -> Bool {
+    open func Insert(_ key: String, _ value: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         let _value = try! HString(value)
@@ -6648,14 +6648,14 @@ public class IMapString_String: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func RemoveImpl(_ key: String) throws {
+    open func Remove(_ key: String) throws {
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Remove(pThis, _key.get()))
         }
     }
 
-    open func ClearImpl() throws {
+    open func Clear() throws {
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -6691,43 +6691,43 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING_HSTRINGImpl : IMap, AbiInterfaceImp
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.lookup)
     fileprivate func lookup(_ key: String) -> String {
-        try! _default.LookupImpl(key)
+        try! _default.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.haskey)
     fileprivate func hasKey(_ key: String) -> Bool {
-        try! _default.HasKeyImpl(key)
+        try! _default.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.getview)
     fileprivate func getView() -> AnyIMapView<String, String>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.insert)
     fileprivate func insert(_ key: String, _ value: String) -> Bool {
-        try! _default.InsertImpl(key, value)
+        try! _default.Insert(key, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.remove)
     fileprivate func remove(_ key: String) {
-        try! _default.RemoveImpl(key)
+        try! _default.Remove(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.clear)
     fileprivate func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_String! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, String>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -6824,7 +6824,7 @@ typealias __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows_
 public class IMapString_IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    open func LookupImpl(_ key: String) throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
+    open func Lookup(_ key: String) throws -> test_component.AnyIVectorView<test_component.TextSegment>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
@@ -6834,7 +6834,7 @@ public class IMapString_IVectorViewTextSegment: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -6842,7 +6842,7 @@ public class IMapString_IVectorViewTextSegment: test_component.IInspectable {
         return result
     }
 
-    open func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKey(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
@@ -6851,7 +6851,7 @@ public class IMapString_IVectorViewTextSegment: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func GetViewImpl() throws -> test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
+    open func GetView() throws -> test_component.AnyIMapView<String, test_component.AnyIVectorView<test_component.TextSegment>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -6860,7 +6860,7 @@ public class IMapString_IVectorViewTextSegment: test_component.IInspectable {
         return test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: result)
     }
 
-    open func InsertImpl(_ key: String, _ value: test_component.AnyIVectorView<test_component.TextSegment>?) throws -> Bool {
+    open func Insert(_ key: String, _ value: test_component.AnyIVectorView<test_component.TextSegment>?) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         let valueWrapper = test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper(value)
@@ -6871,14 +6871,14 @@ public class IMapString_IVectorViewTextSegment: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func RemoveImpl(_ key: String) throws {
+    open func Remove(_ key: String) throws {
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Remove(pThis, _key.get()))
         }
     }
 
-    open func ClearImpl() throws {
+    open func Clear() throws {
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -6914,43 +6914,43 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_C
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.lookup)
     fileprivate func lookup(_ key: String) -> AnyIVectorView<test_component.TextSegment>? {
-        try! _default.LookupImpl(key)
+        try! _default.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.haskey)
     fileprivate func hasKey(_ key: String) -> Bool {
-        try! _default.HasKeyImpl(key)
+        try! _default.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.getview)
     fileprivate func getView() -> AnyIMapView<String, AnyIVectorView<test_component.TextSegment>?>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.insert)
     fileprivate func insert(_ key: String, _ value: AnyIVectorView<test_component.TextSegment>?) -> Bool {
-        try! _default.InsertImpl(key, value)
+        try! _default.Insert(key, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.remove)
     fileprivate func remove(_ key: String) {
-        try! _default.RemoveImpl(key)
+        try! _default.Remove(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.clear)
     fileprivate func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_IVectorViewTextSegment! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, AnyIVectorView<test_component.TextSegment>?>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -7046,7 +7046,7 @@ typealias __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper = I
 public class IMapString_Base: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase }
 
-    open func LookupImpl(_ key: String) throws -> test_component.Base? {
+    open func Lookup(_ key: String) throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             let _key = try! HString(key)
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
@@ -7056,7 +7056,7 @@ public class IMapString_Base: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -7064,7 +7064,7 @@ public class IMapString_Base: test_component.IInspectable {
         return result
     }
 
-    open func HasKeyImpl(_ key: String) throws -> Bool {
+    open func HasKey(_ key: String) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
@@ -7073,7 +7073,7 @@ public class IMapString_Base: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func GetViewImpl() throws -> test_component.AnyIMapView<String, test_component.Base?>? {
+    open func GetView() throws -> test_component.AnyIMapView<String, test_component.Base?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -7082,7 +7082,7 @@ public class IMapString_Base: test_component.IInspectable {
         return test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.unwrapFrom(abi: result)
     }
 
-    open func InsertImpl(_ key: String, _ value: test_component.Base?) throws -> Bool {
+    open func Insert(_ key: String, _ value: test_component.Base?) throws -> Bool {
         var result: boolean = 0
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
@@ -7091,14 +7091,14 @@ public class IMapString_Base: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func RemoveImpl(_ key: String) throws {
+    open func Remove(_ key: String) throws {
         let _key = try! HString(key)
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Remove(pThis, _key.get()))
         }
     }
 
-    open func ClearImpl() throws {
+    open func Clear() throws {
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -7134,43 +7134,43 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseImp
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.lookup)
     fileprivate func lookup(_ key: String) -> Base? {
-        try! _default.LookupImpl(key)
+        try! _default.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.haskey)
     fileprivate func hasKey(_ key: String) -> Bool {
-        try! _default.HasKeyImpl(key)
+        try! _default.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.getview)
     fileprivate func getView() -> AnyIMapView<String, Base?>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.insert)
     fileprivate func insert(_ key: String, _ value: Base?) -> Bool {
-        try! _default.InsertImpl(key, value)
+        try! _default.Insert(key, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.remove)
     fileprivate func remove(_ key: String) {
-        try! _default.RemoveImpl(key)
+        try! _default.Remove(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.clear)
     fileprivate func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Base! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.imap-2.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, Base?>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -7229,7 +7229,7 @@ typealias __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableWrapper = InterfaceWr
 public class IObservableMapString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIObservableMap_2_HSTRING_IInspectable }
 
-    open func add_MapChangedImpl(_ vhnd: MapChangedEventHandler<String, Any?>?) throws -> EventRegistrationToken {
+    open func add_MapChanged(_ vhnd: MapChangedEventHandler<String, Any?>?) throws -> EventRegistrationToken {
         var result: EventRegistrationToken = .init()
         let vhndWrapper = test_component.__x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableWrapper(vhnd)
         let _vhnd = try! vhndWrapper?.toABI { $0 }
@@ -7239,7 +7239,7 @@ public class IObservableMapString_Any: test_component.IInspectable {
         return result
     }
 
-    open func remove_MapChangedImpl(_ token: EventRegistrationToken) throws {
+    open func remove_MapChanged(_ token: EventRegistrationToken) throws {
         _ = try perform(as: __x_ABI_C__FIObservableMap_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.remove_MapChanged(pThis, token))
         }
@@ -7278,10 +7278,10 @@ fileprivate class __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableImpl : IObser
       .init(
         add: { [weak self] in
           guard let this = self?._default else { return .init() }
-          return try! this.add_MapChangedImpl($0)
+          return try! this.add_MapChanged($0)
         },
         remove: { [weak self] in
-         try? self?._default.remove_MapChangedImpl($0)
+         try? self?._default.remove_MapChanged($0)
        }
       )
     }()
@@ -7289,43 +7289,43 @@ fileprivate class __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableImpl : IObser
     private lazy var _IMap: IMapString_Any! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.lookup)
     fileprivate func lookup(_ key: String) -> Any? {
-        try! _IMap.LookupImpl(key)
+        try! _IMap.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.haskey)
     fileprivate func hasKey(_ key: String) -> Bool {
-        try! _IMap.HasKeyImpl(key)
+        try! _IMap.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.getview)
     fileprivate func getView() -> AnyIMapView<String, Any?>? {
-        try! _IMap.GetViewImpl()
+        try! _IMap.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.insert)
     fileprivate func insert(_ key: String, _ value: Any?) -> Bool {
-        try! _IMap.InsertImpl(key, value)
+        try! _IMap.Insert(key, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.remove)
     fileprivate func remove(_ key: String) {
-        try! _IMap.RemoveImpl(key)
+        try! _IMap.Remove(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.clear)
     fileprivate func clear() {
-        try! _IMap.ClearImpl()
+        try! _IMap.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _IMap.get_SizeImpl() }
+        get { try! _IMap.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Any! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, Any?>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -7384,7 +7384,7 @@ typealias __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGWrapper = InterfaceWrapper
 public class IObservableMapString_String: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIObservableMap_2_HSTRING_HSTRING }
 
-    open func add_MapChangedImpl(_ vhnd: MapChangedEventHandler<String, String>?) throws -> EventRegistrationToken {
+    open func add_MapChanged(_ vhnd: MapChangedEventHandler<String, String>?) throws -> EventRegistrationToken {
         var result: EventRegistrationToken = .init()
         let vhndWrapper = test_component.__x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGWrapper(vhnd)
         let _vhnd = try! vhndWrapper?.toABI { $0 }
@@ -7394,7 +7394,7 @@ public class IObservableMapString_String: test_component.IInspectable {
         return result
     }
 
-    open func remove_MapChangedImpl(_ token: EventRegistrationToken) throws {
+    open func remove_MapChanged(_ token: EventRegistrationToken) throws {
         _ = try perform(as: __x_ABI_C__FIObservableMap_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.remove_MapChanged(pThis, token))
         }
@@ -7433,10 +7433,10 @@ fileprivate class __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGImpl : IObservable
       .init(
         add: { [weak self] in
           guard let this = self?._default else { return .init() }
-          return try! this.add_MapChangedImpl($0)
+          return try! this.add_MapChanged($0)
         },
         remove: { [weak self] in
-         try? self?._default.remove_MapChangedImpl($0)
+         try? self?._default.remove_MapChanged($0)
        }
       )
     }()
@@ -7444,43 +7444,43 @@ fileprivate class __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGImpl : IObservable
     private lazy var _IMap: IMapString_String! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.lookup)
     fileprivate func lookup(_ key: String) -> String {
-        try! _IMap.LookupImpl(key)
+        try! _IMap.Lookup(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.haskey)
     fileprivate func hasKey(_ key: String) -> Bool {
-        try! _IMap.HasKeyImpl(key)
+        try! _IMap.HasKey(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.getview)
     fileprivate func getView() -> AnyIMapView<String, String>? {
-        try! _IMap.GetViewImpl()
+        try! _IMap.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.insert)
     fileprivate func insert(_ key: String, _ value: String) -> Bool {
-        try! _IMap.InsertImpl(key, value)
+        try! _IMap.Insert(key, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.remove)
     fileprivate func remove(_ key: String) {
-        try! _IMap.RemoveImpl(key)
+        try! _IMap.Remove(key)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.clear)
     fileprivate func clear() {
-        try! _IMap.ClearImpl()
+        try! _IMap.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.size)
     fileprivate var size : UInt32 {
-        get { try! _IMap.get_SizeImpl() }
+        get { try! _IMap.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_String! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablemap-2.first)
     fileprivate func first() -> AnyIIterator<AnyIKeyValuePair<String, String>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -7539,7 +7539,7 @@ typealias __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseWrappe
 public class IObservableVectorBase: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase }
 
-    open func add_VectorChangedImpl(_ vhnd: VectorChangedEventHandler<test_component.Base?>?) throws -> EventRegistrationToken {
+    open func add_VectorChanged(_ vhnd: VectorChangedEventHandler<test_component.Base?>?) throws -> EventRegistrationToken {
         var result: EventRegistrationToken = .init()
         let vhndWrapper = test_component.__x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBaseWrapper(vhnd)
         let _vhnd = try! vhndWrapper?.toABI { $0 }
@@ -7549,7 +7549,7 @@ public class IObservableVectorBase: test_component.IInspectable {
         return result
     }
 
-    open func remove_VectorChangedImpl(_ token: EventRegistrationToken) throws {
+    open func remove_VectorChanged(_ token: EventRegistrationToken) throws {
         _ = try perform(as: __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.remove_VectorChanged(pThis, token))
         }
@@ -7616,10 +7616,10 @@ fileprivate class __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBa
       .init(
         add: { [weak self] in
           guard let this = self?._default else { return .init() }
-          return try! this.add_VectorChangedImpl($0)
+          return try! this.add_VectorChanged($0)
         },
         remove: { [weak self] in
-         try? self?._default.remove_VectorChangedImpl($0)
+         try? self?._default.remove_VectorChanged($0)
        }
       )
     }()
@@ -7627,58 +7627,58 @@ fileprivate class __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBa
     private lazy var _IVector: IVectorBase! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.getat)
     fileprivate func getAt(_ index: UInt32) -> Base? {
-        try! _IVector.GetAtImpl(index)
+        try! _IVector.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.getview)
     fileprivate func getView() -> AnyIVectorView<Base?>? {
-        try! _IVector.GetViewImpl()
+        try! _IVector.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.indexof)
     fileprivate func indexOf(_ value: Base?, _ index: inout UInt32) -> Bool {
-        try! _IVector.IndexOfImpl(value, &index)
+        try! _IVector.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.setat)
     fileprivate func setAt(_ index: UInt32, _ value: Base?) {
-        try! _IVector.SetAtImpl(index, value)
+        try! _IVector.SetAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.insertat)
     fileprivate func insertAt(_ index: UInt32, _ value: Base?) {
-        try! _IVector.InsertAtImpl(index, value)
+        try! _IVector.InsertAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.removeat)
     fileprivate func removeAt(_ index: UInt32) {
-        try! _IVector.RemoveAtImpl(index)
+        try! _IVector.RemoveAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.append)
     fileprivate func append(_ value: Base?) {
-        try! _IVector.AppendImpl(value)
+        try! _IVector.Append(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.removeatend)
     fileprivate func removeAtEnd() {
-        try! _IVector.RemoveAtEndImpl()
+        try! _IVector.RemoveAtEnd()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.clear)
     fileprivate func clear() {
-        try! _IVector.ClearImpl()
+        try! _IVector.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _IVector.get_SizeImpl() }
+        get { try! _IVector.get_Size() }
     }
 
     private lazy var _IIterable: IIterableBase! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.first)
     fileprivate func first() -> AnyIIterator<Base?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -7737,7 +7737,7 @@ typealias __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrap
 public class IObservableVectorIBasic: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    open func add_VectorChangedImpl(_ vhnd: VectorChangedEventHandler<test_component.AnyIBasic?>?) throws -> EventRegistrationToken {
+    open func add_VectorChanged(_ vhnd: VectorChangedEventHandler<test_component.AnyIBasic?>?) throws -> EventRegistrationToken {
         var result: EventRegistrationToken = .init()
         let vhndWrapper = test_component.__x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasicWrapper(vhnd)
         let _vhnd = try! vhndWrapper?.toABI { $0 }
@@ -7747,7 +7747,7 @@ public class IObservableVectorIBasic: test_component.IInspectable {
         return result
     }
 
-    open func remove_VectorChangedImpl(_ token: EventRegistrationToken) throws {
+    open func remove_VectorChanged(_ token: EventRegistrationToken) throws {
         _ = try perform(as: __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.remove_VectorChanged(pThis, token))
         }
@@ -7814,10 +7814,10 @@ fileprivate class __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIB
       .init(
         add: { [weak self] in
           guard let this = self?._default else { return .init() }
-          return try! this.add_VectorChangedImpl($0)
+          return try! this.add_VectorChanged($0)
         },
         remove: { [weak self] in
-         try? self?._default.remove_VectorChangedImpl($0)
+         try? self?._default.remove_VectorChanged($0)
        }
       )
     }()
@@ -7825,58 +7825,58 @@ fileprivate class __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIB
     private lazy var _IVector: IVectorIBasic! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.getat)
     fileprivate func getAt(_ index: UInt32) -> AnyIBasic? {
-        try! _IVector.GetAtImpl(index)
+        try! _IVector.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.getview)
     fileprivate func getView() -> AnyIVectorView<AnyIBasic?>? {
-        try! _IVector.GetViewImpl()
+        try! _IVector.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.indexof)
     fileprivate func indexOf(_ value: AnyIBasic?, _ index: inout UInt32) -> Bool {
-        try! _IVector.IndexOfImpl(value, &index)
+        try! _IVector.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.setat)
     fileprivate func setAt(_ index: UInt32, _ value: AnyIBasic?) {
-        try! _IVector.SetAtImpl(index, value)
+        try! _IVector.SetAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.insertat)
     fileprivate func insertAt(_ index: UInt32, _ value: AnyIBasic?) {
-        try! _IVector.InsertAtImpl(index, value)
+        try! _IVector.InsertAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.removeat)
     fileprivate func removeAt(_ index: UInt32) {
-        try! _IVector.RemoveAtImpl(index)
+        try! _IVector.RemoveAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.append)
     fileprivate func append(_ value: AnyIBasic?) {
-        try! _IVector.AppendImpl(value)
+        try! _IVector.Append(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.removeatend)
     fileprivate func removeAtEnd() {
-        try! _IVector.RemoveAtEndImpl()
+        try! _IVector.RemoveAtEnd()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.clear)
     fileprivate func clear() {
-        try! _IVector.ClearImpl()
+        try! _IVector.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _IVector.get_SizeImpl() }
+        get { try! _IVector.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIBasic! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.iobservablevector-1.first)
     fileprivate func first() -> AnyIIterator<AnyIBasic?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -7947,7 +7947,7 @@ typealias __x_ABI_C__FIVectorView_1_IInspectableWrapper = InterfaceWrapperBase<t
 public class IVectorViewAny: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1_IInspectable }
 
-    open func GetAtImpl(_ index: UInt32) throws -> Any? {
+    open func GetAt(_ index: UInt32) throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -7956,7 +7956,7 @@ public class IVectorViewAny: test_component.IInspectable {
         return __ABI_.AnyWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -7964,7 +7964,7 @@ public class IVectorViewAny: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: Any?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: Any?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_.AnyWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -8023,23 +8023,23 @@ fileprivate class __x_ABI_C__FIVectorView_1_IInspectableImpl : IVectorView, AbiI
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> Any? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: Any?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableAny! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<Any?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -8109,7 +8109,7 @@ typealias __x_ABI_C__FIVectorView_1_GUIDWrapper = InterfaceWrapperBase<test_comp
 public class IVectorViewUUID: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1_GUID }
 
-    open func GetAtImpl(_ index: UInt32) throws -> Foundation.UUID {
+    open func GetAt(_ index: UInt32) throws -> Foundation.UUID {
         var result: test_component.GUID = .init()
         _ = try perform(as: __x_ABI_C__FIVectorView_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -8117,7 +8117,7 @@ public class IVectorViewUUID: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8125,7 +8125,7 @@ public class IVectorViewUUID: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: Foundation.UUID, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: Foundation.UUID, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, .init(from: value), &index, &result))
@@ -8182,23 +8182,23 @@ fileprivate class __x_ABI_C__FIVectorView_1_GUIDImpl : IVectorView, AbiInterface
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> Foundation.UUID {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: Foundation.UUID, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableUUID! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<Foundation.UUID>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -8268,7 +8268,7 @@ typealias __x_ABI_C__FIVectorView_1_HSTRINGWrapper = InterfaceWrapperBase<test_c
 public class IVectorViewString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1_HSTRING }
 
-    open func GetAtImpl(_ index: UInt32) throws -> String {
+    open func GetAt(_ index: UInt32) throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIVectorView_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -8276,7 +8276,7 @@ public class IVectorViewString: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8284,7 +8284,7 @@ public class IVectorViewString: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: String, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: String, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let _value = try! HString(value)
         _ = try perform(as: __x_ABI_C__FIVectorView_1_HSTRING.self) { pThis in
@@ -8342,23 +8342,23 @@ fileprivate class __x_ABI_C__FIVectorView_1_HSTRINGImpl : IVectorView, AbiInterf
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> String {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: String, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableString! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<String>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -8428,7 +8428,7 @@ typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment
 public class IVectorViewTextSegment: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.TextSegment {
+    open func GetAt(_ index: UInt32) throws -> test_component.TextSegment {
         var result: __x_ABI_CWindows_CData_CText_CTextSegment = .init()
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -8436,7 +8436,7 @@ public class IVectorViewTextSegment: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8444,7 +8444,7 @@ public class IVectorViewTextSegment: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: test_component.TextSegment, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.TextSegment, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, .from(swift: value), &index, &result))
@@ -8501,23 +8501,23 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTex
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> test_component.TextSegment {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: test_component.TextSegment, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableTextSegment! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<test_component.TextSegment>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -8588,7 +8588,7 @@ typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlD
 public class IVectorViewIWwwFormUrlDecoderEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIWwwFormUrlDecoderEntry? {
+    open func GetAt(_ index: UInt32) throws -> test_component.AnyIWwwFormUrlDecoderEntry? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -8597,7 +8597,7 @@ public class IVectorViewIWwwFormUrlDecoderEntry: test_component.IInspectable {
         return __ABI_Windows_Foundation.IWwwFormUrlDecoderEntryWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8605,7 +8605,7 @@ public class IVectorViewIWwwFormUrlDecoderEntry: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: test_component.AnyIWwwFormUrlDecoderEntry?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.AnyIWwwFormUrlDecoderEntry?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_Windows_Foundation.IWwwFormUrlDecoderEntryWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -8664,23 +8664,23 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWww
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> test_component.AnyIWwwFormUrlDecoderEntry? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: test_component.AnyIWwwFormUrlDecoderEntry?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIWwwFormUrlDecoderEntry! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<test_component.AnyIWwwFormUrlDecoderEntry?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -8751,7 +8751,7 @@ typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWra
 public class IVectorViewIStorageItem: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIStorageItem? {
+    open func GetAt(_ index: UInt32) throws -> test_component.AnyIStorageItem? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -8760,7 +8760,7 @@ public class IVectorViewIStorageItem: test_component.IInspectable {
         return __ABI_Windows_Storage.IStorageItemWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8768,7 +8768,7 @@ public class IVectorViewIStorageItem: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: test_component.AnyIStorageItem?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.AnyIStorageItem?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_Windows_Storage.IStorageItemWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -8827,23 +8827,23 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorag
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> test_component.AnyIStorageItem? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: test_component.AnyIStorageItem?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIStorageItem! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<test_component.AnyIStorageItem?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -8914,7 +8914,7 @@ typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEn
 public class IVectorViewSortEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.SortEntry {
+    open func GetAt(_ index: UInt32) throws -> test_component.SortEntry {
         var result: __x_ABI_CWindows_CStorage_CSearch_CSortEntry = .init()
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -8922,7 +8922,7 @@ public class IVectorViewSortEntry: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -8930,7 +8930,7 @@ public class IVectorViewSortEntry: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: test_component.SortEntry, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.SortEntry, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let _value = __ABI_Windows_Storage_Search._ABI_SortEntry(from: value)
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
@@ -8988,23 +8988,23 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch_
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> test_component.SortEntry {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: test_component.SortEntry, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableSortEntry! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<test_component.SortEntry>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -9074,7 +9074,7 @@ typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrap
 public class IVectorViewStorageFile: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.StorageFile? {
+    open func GetAt(_ index: UInt32) throws -> test_component.StorageFile? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9083,7 +9083,7 @@ public class IVectorViewStorageFile: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9091,7 +9091,7 @@ public class IVectorViewStorageFile: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: test_component.StorageFile?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.StorageFile?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, RawPointer(value), &index, &result))
@@ -9148,23 +9148,23 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorage
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> test_component.StorageFile? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: test_component.StorageFile?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableStorageFile! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<test_component.StorageFile?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -9234,7 +9234,7 @@ typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWr
 public class IVectorViewStorageFolder: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.StorageFolder? {
+    open func GetAt(_ index: UInt32) throws -> test_component.StorageFolder? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9243,7 +9243,7 @@ public class IVectorViewStorageFolder: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9251,7 +9251,7 @@ public class IVectorViewStorageFolder: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: test_component.StorageFolder?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.StorageFolder?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, RawPointer(value), &index, &result))
@@ -9308,23 +9308,23 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorage
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> test_component.StorageFolder? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: test_component.StorageFolder?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableStorageFolder! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<test_component.StorageFolder?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -9394,7 +9394,7 @@ typealias __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryC
 public class IVectorViewStorageLibraryChange: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.StorageLibraryChange? {
+    open func GetAt(_ index: UInt32) throws -> test_component.StorageLibraryChange? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9403,7 +9403,7 @@ public class IVectorViewStorageLibraryChange: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9411,7 +9411,7 @@ public class IVectorViewStorageLibraryChange: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: test_component.StorageLibraryChange?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.StorageLibraryChange?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, RawPointer(value), &index, &result))
@@ -9468,23 +9468,23 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorage
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> test_component.StorageLibraryChange? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: test_component.StorageLibraryChange?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableStorageLibraryChange! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<test_component.StorageLibraryChange?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -9554,7 +9554,7 @@ typealias __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseWrapper = In
 public class IVectorViewBase: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBase }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.Base? {
+    open func GetAt(_ index: UInt32) throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9563,7 +9563,7 @@ public class IVectorViewBase: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9571,7 +9571,7 @@ public class IVectorViewBase: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: test_component.Base?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.Base?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, RawPointer(value), &index, &result))
@@ -9628,23 +9628,23 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseImpl
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> Base? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: Base?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableBase! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<Base?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -9715,7 +9715,7 @@ typealias __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = 
 public class IVectorViewIBasic: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIBasic? {
+    open func GetAt(_ index: UInt32) throws -> test_component.AnyIBasic? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9724,7 +9724,7 @@ public class IVectorViewIBasic: test_component.IInspectable {
         return __ABI_test_component.IBasicWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9732,7 +9732,7 @@ public class IVectorViewIBasic: test_component.IInspectable {
         return result
     }
 
-    open func IndexOfImpl(_ value: test_component.AnyIBasic?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.AnyIBasic?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_test_component.IBasicWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -9791,23 +9791,23 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicIm
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.getat)
     fileprivate func getAt(_ index: UInt32) -> AnyIBasic? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.indexof)
     fileprivate func indexOf(_ value: AnyIBasic?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIBasic! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivectorview-1.first)
     fileprivate func first() -> AnyIIterator<AnyIBasic?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -9930,7 +9930,7 @@ typealias __x_ABI_C__FIVector_1_IInspectableWrapper = InterfaceWrapperBase<test_
 public class IVectorAny: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1_IInspectable }
 
-    open func GetAtImpl(_ index: UInt32) throws -> Any? {
+    open func GetAt(_ index: UInt32) throws -> Any? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -9939,7 +9939,7 @@ public class IVectorAny: test_component.IInspectable {
         return __ABI_.AnyWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -9947,7 +9947,7 @@ public class IVectorAny: test_component.IInspectable {
         return result
     }
 
-    open func GetViewImpl() throws -> test_component.AnyIVectorView<Any?>? {
+    open func GetView() throws -> test_component.AnyIVectorView<Any?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -9956,7 +9956,7 @@ public class IVectorAny: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1_IInspectableWrapper.unwrapFrom(abi: result)
     }
 
-    open func IndexOfImpl(_ value: Any?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: Any?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_.AnyWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -9966,7 +9966,7 @@ public class IVectorAny: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func SetAtImpl(_ index: UInt32, _ value: Any?) throws {
+    open func SetAt(_ index: UInt32, _ value: Any?) throws {
         let valueWrapper = __ABI_.AnyWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
@@ -9974,7 +9974,7 @@ public class IVectorAny: test_component.IInspectable {
         }
     }
 
-    open func InsertAtImpl(_ index: UInt32, _ value: Any?) throws {
+    open func InsertAt(_ index: UInt32, _ value: Any?) throws {
         let valueWrapper = __ABI_.AnyWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
@@ -9982,13 +9982,13 @@ public class IVectorAny: test_component.IInspectable {
         }
     }
 
-    open func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAt(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    open func AppendImpl(_ value: Any?) throws {
+    open func Append(_ value: Any?) throws {
         let valueWrapper = __ABI_.AnyWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
@@ -9996,13 +9996,13 @@ public class IVectorAny: test_component.IInspectable {
         }
     }
 
-    open func RemoveAtEndImpl() throws {
+    open func RemoveAtEnd() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    open func ClearImpl() throws {
+    open func Clear() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -10066,58 +10066,58 @@ fileprivate class __x_ABI_C__FIVector_1_IInspectableImpl : IVector, AbiInterface
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getat)
     fileprivate func getAt(_ index: UInt32) -> Any? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getview)
     fileprivate func getView() -> AnyIVectorView<Any?>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.indexof)
     fileprivate func indexOf(_ value: Any?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.setat)
     fileprivate func setAt(_ index: UInt32, _ value: Any?) {
-        try! _default.SetAtImpl(index, value)
+        try! _default.SetAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.insertat)
     fileprivate func insertAt(_ index: UInt32, _ value: Any?) {
-        try! _default.InsertAtImpl(index, value)
+        try! _default.InsertAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeat)
     fileprivate func removeAt(_ index: UInt32) {
-        try! _default.RemoveAtImpl(index)
+        try! _default.RemoveAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.append)
     fileprivate func append(_ value: Any?) {
-        try! _default.AppendImpl(value)
+        try! _default.Append(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeatend)
     fileprivate func removeAtEnd() {
-        try! _default.RemoveAtEndImpl()
+        try! _default.RemoveAtEnd()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.clear)
     fileprivate func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableAny! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.first)
     fileprivate func first() -> AnyIIterator<Any?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -10239,7 +10239,7 @@ typealias __x_ABI_C__FIVector_1_GUIDWrapper = InterfaceWrapperBase<test_componen
 public class IVectorUUID: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1_GUID }
 
-    open func GetAtImpl(_ index: UInt32) throws -> Foundation.UUID {
+    open func GetAt(_ index: UInt32) throws -> Foundation.UUID {
         var result: test_component.GUID = .init()
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -10247,7 +10247,7 @@ public class IVectorUUID: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -10255,7 +10255,7 @@ public class IVectorUUID: test_component.IInspectable {
         return result
     }
 
-    open func GetViewImpl() throws -> test_component.AnyIVectorView<Foundation.UUID>? {
+    open func GetView() throws -> test_component.AnyIVectorView<Foundation.UUID>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -10264,7 +10264,7 @@ public class IVectorUUID: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1_GUIDWrapper.unwrapFrom(abi: result)
     }
 
-    open func IndexOfImpl(_ value: Foundation.UUID, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: Foundation.UUID, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, .init(from: value), &index, &result))
@@ -10272,37 +10272,37 @@ public class IVectorUUID: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func SetAtImpl(_ index: UInt32, _ value: Foundation.UUID) throws {
+    open func SetAt(_ index: UInt32, _ value: Foundation.UUID) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.SetAt(pThis, index, .init(from: value)))
         }
     }
 
-    open func InsertAtImpl(_ index: UInt32, _ value: Foundation.UUID) throws {
+    open func InsertAt(_ index: UInt32, _ value: Foundation.UUID) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.InsertAt(pThis, index, .init(from: value)))
         }
     }
 
-    open func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAt(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    open func AppendImpl(_ value: Foundation.UUID) throws {
+    open func Append(_ value: Foundation.UUID) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Append(pThis, .init(from: value)))
         }
     }
 
-    open func RemoveAtEndImpl() throws {
+    open func RemoveAtEnd() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    open func ClearImpl() throws {
+    open func Clear() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_GUID.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -10366,58 +10366,58 @@ fileprivate class __x_ABI_C__FIVector_1_GUIDImpl : IVector, AbiInterfaceImpl {
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getat)
     fileprivate func getAt(_ index: UInt32) -> Foundation.UUID {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getview)
     fileprivate func getView() -> AnyIVectorView<Foundation.UUID>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.indexof)
     fileprivate func indexOf(_ value: Foundation.UUID, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.setat)
     fileprivate func setAt(_ index: UInt32, _ value: Foundation.UUID) {
-        try! _default.SetAtImpl(index, value)
+        try! _default.SetAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.insertat)
     fileprivate func insertAt(_ index: UInt32, _ value: Foundation.UUID) {
-        try! _default.InsertAtImpl(index, value)
+        try! _default.InsertAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeat)
     fileprivate func removeAt(_ index: UInt32) {
-        try! _default.RemoveAtImpl(index)
+        try! _default.RemoveAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.append)
     fileprivate func append(_ value: Foundation.UUID) {
-        try! _default.AppendImpl(value)
+        try! _default.Append(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeatend)
     fileprivate func removeAtEnd() {
-        try! _default.RemoveAtEndImpl()
+        try! _default.RemoveAtEnd()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.clear)
     fileprivate func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableUUID! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.first)
     fileprivate func first() -> AnyIIterator<Foundation.UUID>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -10539,7 +10539,7 @@ typealias __x_ABI_C__FIVector_1_HSTRINGWrapper = InterfaceWrapperBase<test_compo
 public class IVectorString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1_HSTRING }
 
-    open func GetAtImpl(_ index: UInt32) throws -> String {
+    open func GetAt(_ index: UInt32) throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -10547,7 +10547,7 @@ public class IVectorString: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -10555,7 +10555,7 @@ public class IVectorString: test_component.IInspectable {
         return result
     }
 
-    open func GetViewImpl() throws -> test_component.AnyIVectorView<String>? {
+    open func GetView() throws -> test_component.AnyIVectorView<String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -10564,7 +10564,7 @@ public class IVectorString: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1_HSTRINGWrapper.unwrapFrom(abi: result)
     }
 
-    open func IndexOfImpl(_ value: String, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: String, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let _value = try! HString(value)
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
@@ -10573,40 +10573,40 @@ public class IVectorString: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func SetAtImpl(_ index: UInt32, _ value: String) throws {
+    open func SetAt(_ index: UInt32, _ value: String) throws {
         let _value = try! HString(value)
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.SetAt(pThis, index, _value.get()))
         }
     }
 
-    open func InsertAtImpl(_ index: UInt32, _ value: String) throws {
+    open func InsertAt(_ index: UInt32, _ value: String) throws {
         let _value = try! HString(value)
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.InsertAt(pThis, index, _value.get()))
         }
     }
 
-    open func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAt(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    open func AppendImpl(_ value: String) throws {
+    open func Append(_ value: String) throws {
         let _value = try! HString(value)
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Append(pThis, _value.get()))
         }
     }
 
-    open func RemoveAtEndImpl() throws {
+    open func RemoveAtEnd() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    open func ClearImpl() throws {
+    open func Clear() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -10670,58 +10670,58 @@ fileprivate class __x_ABI_C__FIVector_1_HSTRINGImpl : IVector, AbiInterfaceImpl 
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getat)
     fileprivate func getAt(_ index: UInt32) -> String {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getview)
     fileprivate func getView() -> AnyIVectorView<String>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.indexof)
     fileprivate func indexOf(_ value: String, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.setat)
     fileprivate func setAt(_ index: UInt32, _ value: String) {
-        try! _default.SetAtImpl(index, value)
+        try! _default.SetAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.insertat)
     fileprivate func insertAt(_ index: UInt32, _ value: String) {
-        try! _default.InsertAtImpl(index, value)
+        try! _default.InsertAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeat)
     fileprivate func removeAt(_ index: UInt32) {
-        try! _default.RemoveAtImpl(index)
+        try! _default.RemoveAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.append)
     fileprivate func append(_ value: String) {
-        try! _default.AppendImpl(value)
+        try! _default.Append(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeatend)
     fileprivate func removeAtEnd() {
-        try! _default.RemoveAtEndImpl()
+        try! _default.RemoveAtEnd()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.clear)
     fileprivate func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableString! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.first)
     fileprivate func first() -> AnyIIterator<String>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -10844,7 +10844,7 @@ typealias __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryW
 public class IVectorSortEntry: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.SortEntry {
+    open func GetAt(_ index: UInt32) throws -> test_component.SortEntry {
         var result: __x_ABI_CWindows_CStorage_CSearch_CSortEntry = .init()
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
@@ -10852,7 +10852,7 @@ public class IVectorSortEntry: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -10860,7 +10860,7 @@ public class IVectorSortEntry: test_component.IInspectable {
         return result
     }
 
-    open func GetViewImpl() throws -> test_component.AnyIVectorView<test_component.SortEntry>? {
+    open func GetView() throws -> test_component.AnyIVectorView<test_component.SortEntry>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -10869,7 +10869,7 @@ public class IVectorSortEntry: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryWrapper.unwrapFrom(abi: result)
     }
 
-    open func IndexOfImpl(_ value: test_component.SortEntry, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.SortEntry, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let _value = __ABI_Windows_Storage_Search._ABI_SortEntry(from: value)
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
@@ -10878,40 +10878,40 @@ public class IVectorSortEntry: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func SetAtImpl(_ index: UInt32, _ value: test_component.SortEntry) throws {
+    open func SetAt(_ index: UInt32, _ value: test_component.SortEntry) throws {
         let _value = __ABI_Windows_Storage_Search._ABI_SortEntry(from: value)
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.SetAt(pThis, index, _value.val))
         }
     }
 
-    open func InsertAtImpl(_ index: UInt32, _ value: test_component.SortEntry) throws {
+    open func InsertAt(_ index: UInt32, _ value: test_component.SortEntry) throws {
         let _value = __ABI_Windows_Storage_Search._ABI_SortEntry(from: value)
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.InsertAt(pThis, index, _value.val))
         }
     }
 
-    open func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAt(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    open func AppendImpl(_ value: test_component.SortEntry) throws {
+    open func Append(_ value: test_component.SortEntry) throws {
         let _value = __ABI_Windows_Storage_Search._ABI_SortEntry(from: value)
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Append(pThis, _value.val))
         }
     }
 
-    open func RemoveAtEndImpl() throws {
+    open func RemoveAtEnd() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    open func ClearImpl() throws {
+    open func Clear() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -10975,58 +10975,58 @@ fileprivate class __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSo
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getat)
     fileprivate func getAt(_ index: UInt32) -> test_component.SortEntry {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getview)
     fileprivate func getView() -> AnyIVectorView<test_component.SortEntry>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.indexof)
     fileprivate func indexOf(_ value: test_component.SortEntry, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.setat)
     fileprivate func setAt(_ index: UInt32, _ value: test_component.SortEntry) {
-        try! _default.SetAtImpl(index, value)
+        try! _default.SetAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.insertat)
     fileprivate func insertAt(_ index: UInt32, _ value: test_component.SortEntry) {
-        try! _default.InsertAtImpl(index, value)
+        try! _default.InsertAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeat)
     fileprivate func removeAt(_ index: UInt32) {
-        try! _default.RemoveAtImpl(index)
+        try! _default.RemoveAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.append)
     fileprivate func append(_ value: test_component.SortEntry) {
-        try! _default.AppendImpl(value)
+        try! _default.Append(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeatend)
     fileprivate func removeAtEnd() {
-        try! _default.RemoveAtEndImpl()
+        try! _default.RemoveAtEnd()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.clear)
     fileprivate func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableSortEntry! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.first)
     fileprivate func first() -> AnyIIterator<test_component.SortEntry>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -11148,7 +11148,7 @@ typealias __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper = Interf
 public class IVectorBase: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.Base? {
+    open func GetAt(_ index: UInt32) throws -> test_component.Base? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -11157,7 +11157,7 @@ public class IVectorBase: test_component.IInspectable {
         return .from(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -11165,7 +11165,7 @@ public class IVectorBase: test_component.IInspectable {
         return result
     }
 
-    open func GetViewImpl() throws -> test_component.AnyIVectorView<test_component.Base?>? {
+    open func GetView() throws -> test_component.AnyIVectorView<test_component.Base?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -11174,7 +11174,7 @@ public class IVectorBase: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseWrapper.unwrapFrom(abi: result)
     }
 
-    open func IndexOfImpl(_ value: test_component.Base?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.Base?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.IndexOf(pThis, RawPointer(value), &index, &result))
@@ -11182,37 +11182,37 @@ public class IVectorBase: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func SetAtImpl(_ index: UInt32, _ value: test_component.Base?) throws {
+    open func SetAt(_ index: UInt32, _ value: test_component.Base?) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.SetAt(pThis, index, RawPointer(value)))
         }
     }
 
-    open func InsertAtImpl(_ index: UInt32, _ value: test_component.Base?) throws {
+    open func InsertAt(_ index: UInt32, _ value: test_component.Base?) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.InsertAt(pThis, index, RawPointer(value)))
         }
     }
 
-    open func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAt(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    open func AppendImpl(_ value: test_component.Base?) throws {
+    open func Append(_ value: test_component.Base?) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Append(pThis, RawPointer(value)))
         }
     }
 
-    open func RemoveAtEndImpl() throws {
+    open func RemoveAtEnd() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    open func ClearImpl() throws {
+    open func Clear() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -11276,58 +11276,58 @@ fileprivate class __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseImpl : I
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getat)
     fileprivate func getAt(_ index: UInt32) -> Base? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getview)
     fileprivate func getView() -> AnyIVectorView<Base?>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.indexof)
     fileprivate func indexOf(_ value: Base?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.setat)
     fileprivate func setAt(_ index: UInt32, _ value: Base?) {
-        try! _default.SetAtImpl(index, value)
+        try! _default.SetAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.insertat)
     fileprivate func insertAt(_ index: UInt32, _ value: Base?) {
-        try! _default.InsertAtImpl(index, value)
+        try! _default.InsertAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeat)
     fileprivate func removeAt(_ index: UInt32) {
-        try! _default.RemoveAtImpl(index)
+        try! _default.RemoveAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.append)
     fileprivate func append(_ value: Base?) {
-        try! _default.AppendImpl(value)
+        try! _default.Append(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeatend)
     fileprivate func removeAtEnd() {
-        try! _default.RemoveAtEndImpl()
+        try! _default.RemoveAtEnd()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.clear)
     fileprivate func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableBase! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.first)
     fileprivate func first() -> AnyIIterator<Base?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -11450,7 +11450,7 @@ typealias __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper = Inte
 public class IVectorIBasic: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    open func GetAtImpl(_ index: UInt32) throws -> test_component.AnyIBasic? {
+    open func GetAt(_ index: UInt32) throws -> test_component.AnyIBasic? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
@@ -11459,7 +11459,7 @@ public class IVectorIBasic: test_component.IInspectable {
         return __ABI_test_component.IBasicWrapper.unwrapFrom(abi: result)
     }
 
-    open func get_SizeImpl() throws -> UInt32 {
+    open func get_Size() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Size(pThis, &result))
@@ -11467,7 +11467,7 @@ public class IVectorIBasic: test_component.IInspectable {
         return result
     }
 
-    open func GetViewImpl() throws -> test_component.AnyIVectorView<test_component.AnyIBasic?>? {
+    open func GetView() throws -> test_component.AnyIVectorView<test_component.AnyIBasic?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetView(pThis, &resultAbi))
@@ -11476,7 +11476,7 @@ public class IVectorIBasic: test_component.IInspectable {
         return test_component.__x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicWrapper.unwrapFrom(abi: result)
     }
 
-    open func IndexOfImpl(_ value: test_component.AnyIBasic?, _ index: inout UInt32) throws -> Bool {
+    open func IndexOf(_ value: test_component.AnyIBasic?, _ index: inout UInt32) throws -> Bool {
         var result: boolean = 0
         let valueWrapper = __ABI_test_component.IBasicWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
@@ -11486,7 +11486,7 @@ public class IVectorIBasic: test_component.IInspectable {
         return .init(from: result)
     }
 
-    open func SetAtImpl(_ index: UInt32, _ value: test_component.AnyIBasic?) throws {
+    open func SetAt(_ index: UInt32, _ value: test_component.AnyIBasic?) throws {
         let valueWrapper = __ABI_test_component.IBasicWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
@@ -11494,7 +11494,7 @@ public class IVectorIBasic: test_component.IInspectable {
         }
     }
 
-    open func InsertAtImpl(_ index: UInt32, _ value: test_component.AnyIBasic?) throws {
+    open func InsertAt(_ index: UInt32, _ value: test_component.AnyIBasic?) throws {
         let valueWrapper = __ABI_test_component.IBasicWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
@@ -11502,13 +11502,13 @@ public class IVectorIBasic: test_component.IInspectable {
         }
     }
 
-    open func RemoveAtImpl(_ index: UInt32) throws {
+    open func RemoveAt(_ index: UInt32) throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAt(pThis, index))
         }
     }
 
-    open func AppendImpl(_ value: test_component.AnyIBasic?) throws {
+    open func Append(_ value: test_component.AnyIBasic?) throws {
         let valueWrapper = __ABI_test_component.IBasicWrapper(value)
         let _value = try! valueWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
@@ -11516,13 +11516,13 @@ public class IVectorIBasic: test_component.IInspectable {
         }
     }
 
-    open func RemoveAtEndImpl() throws {
+    open func RemoveAtEnd() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.RemoveAtEnd(pThis))
         }
     }
 
-    open func ClearImpl() throws {
+    open func Clear() throws {
         _ = try perform(as: __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Clear(pThis))
         }
@@ -11586,58 +11586,58 @@ fileprivate class __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicImpl :
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getat)
     fileprivate func getAt(_ index: UInt32) -> AnyIBasic? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.getview)
     fileprivate func getView() -> AnyIVectorView<AnyIBasic?>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.indexof)
     fileprivate func indexOf(_ value: AnyIBasic?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.setat)
     fileprivate func setAt(_ index: UInt32, _ value: AnyIBasic?) {
-        try! _default.SetAtImpl(index, value)
+        try! _default.SetAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.insertat)
     fileprivate func insertAt(_ index: UInt32, _ value: AnyIBasic?) {
-        try! _default.InsertAtImpl(index, value)
+        try! _default.InsertAt(index, value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeat)
     fileprivate func removeAt(_ index: UInt32) {
-        try! _default.RemoveAtImpl(index)
+        try! _default.RemoveAt(index)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.append)
     fileprivate func append(_ value: AnyIBasic?) {
-        try! _default.AppendImpl(value)
+        try! _default.Append(value)
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.removeatend)
     fileprivate func removeAtEnd() {
-        try! _default.RemoveAtEndImpl()
+        try! _default.RemoveAtEnd()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.clear)
     fileprivate func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.size)
     fileprivate var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIBasic! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.collections.ivector-1.first)
     fileprivate func first() -> AnyIIterator<AnyIBasic?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -11672,7 +11672,7 @@ typealias __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableWrapper = Int
 public class MapChangedEventHandlerString_Any: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectable }
 
-    open func InvokeImpl(_ sender: test_component.AnyIObservableMap<String, Any?>?, _ event: test_component.AnyIMapChangedEventArgs<String>?) throws {
+    open func Invoke(_ sender: test_component.AnyIObservableMap<String, Any?>?, _ event: test_component.AnyIMapChangedEventArgs<String>?) throws {
         let senderWrapper = test_component.__x_ABI_C__FIObservableMap_2_HSTRING_IInspectableWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let eventWrapper = test_component.__x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper(event)
@@ -11693,7 +11693,7 @@ internal class __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableBridge :
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
-            try _default.InvokeImpl(sender, event)
+            try _default.Invoke(sender, event)
         }
         return handler
     }
@@ -11727,7 +11727,7 @@ typealias __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGWrapper = Interfac
 public class MapChangedEventHandlerString_String: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRING }
 
-    open func InvokeImpl(_ sender: test_component.AnyIObservableMap<String, String>?, _ event: test_component.AnyIMapChangedEventArgs<String>?) throws {
+    open func Invoke(_ sender: test_component.AnyIObservableMap<String, String>?, _ event: test_component.AnyIMapChangedEventArgs<String>?) throws {
         let senderWrapper = test_component.__x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let eventWrapper = test_component.__x_ABI_C__FIMapChangedEventArgs_1_HSTRINGWrapper(event)
@@ -11748,7 +11748,7 @@ internal class __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGBridge : WinR
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
-            try _default.InvokeImpl(sender, event)
+            try _default.Invoke(sender, event)
         }
         return handler
     }
@@ -11782,7 +11782,7 @@ typealias __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBa
 public class VectorChangedEventHandlerBase: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBase }
 
-    open func InvokeImpl(_ sender: test_component.AnyIObservableVector<test_component.Base?>?, _ event: test_component.AnyIVectorChangedEventArgs?) throws {
+    open func Invoke(_ sender: test_component.AnyIObservableVector<test_component.Base?>?, _ event: test_component.AnyIVectorChangedEventArgs?) throws {
         let senderWrapper = test_component.__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let eventWrapper = __ABI_Windows_Foundation_Collections.IVectorChangedEventArgsWrapper(event)
@@ -11803,7 +11803,7 @@ internal class __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
-            try _default.InvokeImpl(sender, event)
+            try _default.Invoke(sender, event)
         }
         return handler
     }
@@ -11837,7 +11837,7 @@ typealias __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIB
 public class VectorChangedEventHandlerIBasic: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasic }
 
-    open func InvokeImpl(_ sender: test_component.AnyIObservableVector<test_component.AnyIBasic?>?, _ event: test_component.AnyIVectorChangedEventArgs?) throws {
+    open func Invoke(_ sender: test_component.AnyIObservableVector<test_component.AnyIBasic?>?, _ event: test_component.AnyIVectorChangedEventArgs?) throws {
         let senderWrapper = test_component.__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let eventWrapper = __ABI_Windows_Foundation_Collections.IVectorChangedEventArgsWrapper(event)
@@ -11858,7 +11858,7 @@ internal class __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
-            try _default.InvokeImpl(sender, event)
+            try _default.Invoke(sender, event)
         }
         return handler
     }
@@ -11892,7 +11892,7 @@ typealias __x_ABI_C__FIEventHandler_1_IInspectableWrapper = InterfaceWrapperBase
 public class EventHandlerAny: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIEventHandler_1_IInspectable }
 
-    open func InvokeImpl(_ sender: Any?, _ args: Any?) throws {
+    open func Invoke(_ sender: Any?, _ args: Any?) throws {
         let senderWrapper = __ABI_.AnyWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let argsWrapper = __ABI_.AnyWrapper(args)
@@ -11913,7 +11913,7 @@ internal class __x_ABI_C__FIEventHandler_1_IInspectableBridge : WinRTDelegateBri
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
-            try _default.InvokeImpl(sender, args)
+            try _default.Invoke(sender, args)
         }
         return handler
     }
@@ -11994,7 +11994,7 @@ typealias __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleWrapper = Interfac
 public class IAsyncOperationWithProgressInt32_Double: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgress_2_int_double }
 
-    open func put_ProgressImpl(_ handler: AsyncOperationProgressHandler<Int32, Double>?) throws {
+    open func put_Progress(_ handler: AsyncOperationProgressHandler<Int32, Double>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_int_double.self) { pThis in
@@ -12002,7 +12002,7 @@ public class IAsyncOperationWithProgressInt32_Double: test_component.IInspectabl
         }
     }
 
-    open func get_ProgressImpl() throws -> AsyncOperationProgressHandler<Int32, Double>? {
+    open func get_Progress() throws -> AsyncOperationProgressHandler<Int32, Double>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_int_double.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Progress(pThis, &resultAbi))
@@ -12011,7 +12011,7 @@ public class IAsyncOperationWithProgressInt32_Double: test_component.IInspectabl
         return test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleWrapper.unwrapFrom(abi: result)
     }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationWithProgressCompletedHandler<Int32, Double>?) throws {
+    open func put_Completed(_ handler: AsyncOperationWithProgressCompletedHandler<Int32, Double>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_int_double.self) { pThis in
@@ -12019,7 +12019,7 @@ public class IAsyncOperationWithProgressInt32_Double: test_component.IInspectabl
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationWithProgressCompletedHandler<Int32, Double>? {
+    open func get_Completed() throws -> AsyncOperationWithProgressCompletedHandler<Int32, Double>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_int_double.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12028,7 +12028,7 @@ public class IAsyncOperationWithProgressInt32_Double: test_component.IInspectabl
         return test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_doubleWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> Int32 {
+    open func GetResults() throws -> Int32 {
         var result: INT32 = 0
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_int_double.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -12065,45 +12065,45 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleImpl : IAs
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.getresults)
     fileprivate func getResults() throws -> Int32 {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.progress)
     fileprivate var progress : AsyncOperationProgressHandler<Int32, Double>? {
-        get { try! _default.get_ProgressImpl() }
-        set { try! _default.put_ProgressImpl(newValue) }
+        get { try! _default.get_Progress() }
+        set { try! _default.put_Progress(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.completed)
     fileprivate var completed : AsyncOperationWithProgressCompletedHandler<Int32, Double>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -12185,7 +12185,7 @@ typealias __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Wrapper = Inter
 public class IAsyncOperationWithProgressUInt32_UInt32: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32 }
 
-    open func put_ProgressImpl(_ handler: AsyncOperationProgressHandler<UInt32, UInt32>?) throws {
+    open func put_Progress(_ handler: AsyncOperationProgressHandler<UInt32, UInt32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32Wrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32.self) { pThis in
@@ -12193,7 +12193,7 @@ public class IAsyncOperationWithProgressUInt32_UInt32: test_component.IInspectab
         }
     }
 
-    open func get_ProgressImpl() throws -> AsyncOperationProgressHandler<UInt32, UInt32>? {
+    open func get_Progress() throws -> AsyncOperationProgressHandler<UInt32, UInt32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Progress(pThis, &resultAbi))
@@ -12202,7 +12202,7 @@ public class IAsyncOperationWithProgressUInt32_UInt32: test_component.IInspectab
         return test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32Wrapper.unwrapFrom(abi: result)
     }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationWithProgressCompletedHandler<UInt32, UInt32>?) throws {
+    open func put_Completed(_ handler: AsyncOperationWithProgressCompletedHandler<UInt32, UInt32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32Wrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32.self) { pThis in
@@ -12210,7 +12210,7 @@ public class IAsyncOperationWithProgressUInt32_UInt32: test_component.IInspectab
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationWithProgressCompletedHandler<UInt32, UInt32>? {
+    open func get_Completed() throws -> AsyncOperationWithProgressCompletedHandler<UInt32, UInt32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12219,7 +12219,7 @@ public class IAsyncOperationWithProgressUInt32_UInt32: test_component.IInspectab
         return test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32Wrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> UInt32 {
+    open func GetResults() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -12256,45 +12256,45 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Impl : 
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.getresults)
     fileprivate func getResults() throws -> UInt32 {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.progress)
     fileprivate var progress : AsyncOperationProgressHandler<UInt32, UInt32>? {
-        get { try! _default.get_ProgressImpl() }
-        set { try! _default.put_ProgressImpl(newValue) }
+        get { try! _default.get_Progress() }
+        set { try! _default.put_Progress(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.completed)
     fileprivate var completed : AsyncOperationWithProgressCompletedHandler<UInt32, UInt32>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -12377,7 +12377,7 @@ typealias __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__
 public class IAsyncOperationWithProgressIBuffer_UInt32: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32 }
 
-    open func put_ProgressImpl(_ handler: AsyncOperationProgressHandler<test_component.AnyIBuffer?, UInt32>?) throws {
+    open func put_Progress(_ handler: AsyncOperationProgressHandler<test_component.AnyIBuffer?, UInt32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
@@ -12385,7 +12385,7 @@ public class IAsyncOperationWithProgressIBuffer_UInt32: test_component.IInspecta
         }
     }
 
-    open func get_ProgressImpl() throws -> AsyncOperationProgressHandler<test_component.AnyIBuffer?, UInt32>? {
+    open func get_Progress() throws -> AsyncOperationProgressHandler<test_component.AnyIBuffer?, UInt32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Progress(pThis, &resultAbi))
@@ -12394,7 +12394,7 @@ public class IAsyncOperationWithProgressIBuffer_UInt32: test_component.IInspecta
         return test_component.__x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper.unwrapFrom(abi: result)
     }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationWithProgressCompletedHandler<test_component.AnyIBuffer?, UInt32>?) throws {
+    open func put_Completed(_ handler: AsyncOperationWithProgressCompletedHandler<test_component.AnyIBuffer?, UInt32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
@@ -12402,7 +12402,7 @@ public class IAsyncOperationWithProgressIBuffer_UInt32: test_component.IInspecta
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationWithProgressCompletedHandler<test_component.AnyIBuffer?, UInt32>? {
+    open func get_Completed() throws -> AsyncOperationWithProgressCompletedHandler<test_component.AnyIBuffer?, UInt32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12411,7 +12411,7 @@ public class IAsyncOperationWithProgressIBuffer_UInt32: test_component.IInspecta
         return test_component.__x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Wrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIBuffer? {
+    open func GetResults() throws -> test_component.AnyIBuffer? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -12449,45 +12449,45 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CS
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.getresults)
     fileprivate func getResults() throws -> test_component.AnyIBuffer? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.progress)
     fileprivate var progress : AsyncOperationProgressHandler<test_component.AnyIBuffer?, UInt32>? {
-        get { try! _default.get_ProgressImpl() }
-        set { try! _default.put_ProgressImpl(newValue) }
+        get { try! _default.get_Progress() }
+        set { try! _default.put_Progress(newValue) }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.completed)
     fileprivate var completed : AsyncOperationWithProgressCompletedHandler<test_component.AnyIBuffer?, UInt32>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperationwithprogress-2.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -12554,7 +12554,7 @@ typealias __x_ABI_C__FIAsyncOperation_1_booleanWrapper = InterfaceWrapperBase<te
 public class IAsyncOperationBool: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1_boolean }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<Bool>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<Bool>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_boolean.self) { pThis in
@@ -12562,7 +12562,7 @@ public class IAsyncOperationBool: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<Bool>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<Bool>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_boolean.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12571,7 +12571,7 @@ public class IAsyncOperationBool: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> Bool {
+    open func GetResults() throws -> Bool {
         var result: boolean = 0
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_boolean.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -12607,39 +12607,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_booleanImpl : IAsyncOperation, A
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> Bool {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<Bool>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -12706,7 +12706,7 @@ typealias __x_ABI_C__FIAsyncOperation_1_intWrapper = InterfaceWrapperBase<test_c
 public class IAsyncOperationInt32: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1_int }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<Int32>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<Int32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_int.self) { pThis in
@@ -12714,7 +12714,7 @@ public class IAsyncOperationInt32: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<Int32>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<Int32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_int.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12723,7 +12723,7 @@ public class IAsyncOperationInt32: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_intWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> Int32 {
+    open func GetResults() throws -> Int32 {
         var result: INT32 = 0
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_int.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -12759,39 +12759,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_intImpl : IAsyncOperation, AbiIn
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> Int32 {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<Int32>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -12858,7 +12858,7 @@ typealias __x_ABI_C__FIAsyncOperation_1_HSTRINGWrapper = InterfaceWrapperBase<te
 public class IAsyncOperationString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1_HSTRING }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<String>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<String>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_HSTRING.self) { pThis in
@@ -12866,7 +12866,7 @@ public class IAsyncOperationString: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<String>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -12875,7 +12875,7 @@ public class IAsyncOperationString: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> String {
+    open func GetResults() throws -> String {
         var result: HSTRING?
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -12911,39 +12911,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_HSTRINGImpl : IAsyncOperation, A
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> String {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<String>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13010,7 +13010,7 @@ typealias __x_ABI_C__FIAsyncOperation_1_UINT32Wrapper = InterfaceWrapperBase<tes
 public class IAsyncOperationUInt32: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1_UINT32 }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<UInt32>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<UInt32>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32Wrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_UINT32.self) { pThis in
@@ -13018,7 +13018,7 @@ public class IAsyncOperationUInt32: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<UInt32>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<UInt32>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_UINT32.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13027,7 +13027,7 @@ public class IAsyncOperationUInt32: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32Wrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> UInt32 {
+    open func GetResults() throws -> UInt32 {
         var result: UINT32 = 0
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_UINT32.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -13063,39 +13063,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_UINT32Impl : IAsyncOperation, Ab
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> UInt32 {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<UInt32>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13163,7 +13163,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectableW
 public class IAsyncOperationIMapString_Any: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectable }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIMap<String, Any?>?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.AnyIMap<String, Any?>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
@@ -13171,7 +13171,7 @@ public class IAsyncOperationIMapString_Any: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIMap<String, Any?>?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.AnyIMap<String, Any?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13180,7 +13180,7 @@ public class IAsyncOperationIMapString_Any: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIMap<String, Any?>? {
+    open func GetResults() throws -> test_component.AnyIMap<String, Any?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -13217,39 +13217,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInsp
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> AnyIMap<String, Any?>? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIMap<String, Any?>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13317,7 +13317,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindo
 public class IAsyncOperationIVectorViewIStorageItem: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
@@ -13325,7 +13325,7 @@ public class IAsyncOperationIVectorViewIStorageItem: test_component.IInspectable
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.AnyIStorageItem?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13334,7 +13334,7 @@ public class IAsyncOperationIVectorViewIStorageItem: test_component.IInspectable
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.AnyIStorageItem?>? {
+    open func GetResults() throws -> test_component.AnyIVectorView<test_component.AnyIStorageItem?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -13371,39 +13371,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> AnyIVectorView<test_component.AnyIStorageItem?>? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIVectorView<test_component.AnyIStorageItem?>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13471,7 +13471,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindo
 public class IAsyncOperationIVectorViewStorageFile: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFile?>?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFile?>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
@@ -13479,7 +13479,7 @@ public class IAsyncOperationIVectorViewStorageFile: test_component.IInspectable 
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13488,7 +13488,7 @@ public class IAsyncOperationIVectorViewStorageFile: test_component.IInspectable 
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.StorageFile?>? {
+    open func GetResults() throws -> test_component.AnyIVectorView<test_component.StorageFile?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -13525,39 +13525,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> AnyIVectorView<test_component.StorageFile?>? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIVectorView<test_component.StorageFile?>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13625,7 +13625,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindo
 public class IAsyncOperationIVectorViewStorageFolder: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFolder?>?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFolder?>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
@@ -13633,7 +13633,7 @@ public class IAsyncOperationIVectorViewStorageFolder: test_component.IInspectabl
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageFolder?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13642,7 +13642,7 @@ public class IAsyncOperationIVectorViewStorageFolder: test_component.IInspectabl
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.StorageFolder?>? {
+    open func GetResults() throws -> test_component.AnyIVectorView<test_component.StorageFolder?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -13679,39 +13679,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> AnyIVectorView<test_component.StorageFolder?>? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIVectorView<test_component.StorageFolder?>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13779,7 +13779,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindo
 public class IAsyncOperationIVectorViewStorageLibraryChange: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
@@ -13787,7 +13787,7 @@ public class IAsyncOperationIVectorViewStorageLibraryChange: test_component.IIns
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.AnyIVectorView<test_component.StorageLibraryChange?>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13796,7 +13796,7 @@ public class IAsyncOperationIVectorViewStorageLibraryChange: test_component.IIns
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIVectorView<test_component.StorageLibraryChange?>? {
+    open func GetResults() throws -> test_component.AnyIVectorView<test_component.StorageLibraryChange?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -13833,39 +13833,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> AnyIVectorView<test_component.StorageLibraryChange?>? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIVectorView<test_component.StorageLibraryChange?>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -13933,7 +13933,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGWrapper = I
 public class IAsyncOperationIVectorString: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRING }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVector<String>?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.AnyIVector<String>?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRINGWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRING.self) { pThis in
@@ -13941,7 +13941,7 @@ public class IAsyncOperationIVectorString: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIVector<String>?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.AnyIVector<String>?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -13950,7 +13950,7 @@ public class IAsyncOperationIVectorString: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRINGWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIVector<String>? {
+    open func GetResults() throws -> test_component.AnyIVector<String>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRING.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -13987,39 +13987,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGImp
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> AnyIVector<String>? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<AnyIVector<String>?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14086,7 +14086,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePropert
 public class IAsyncOperationBasicProperties: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.BasicProperties?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.BasicProperties?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties.self) { pThis in
@@ -14094,7 +14094,7 @@ public class IAsyncOperationBasicProperties: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.BasicProperties?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.BasicProperties?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14103,7 +14103,7 @@ public class IAsyncOperationBasicProperties: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.BasicProperties? {
+    open func GetResults() throws -> test_component.BasicProperties? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14140,39 +14140,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.BasicProperties? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.BasicProperties?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14239,7 +14239,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePropert
 public class IAsyncOperationDocumentProperties: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.DocumentProperties?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.DocumentProperties?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties.self) { pThis in
@@ -14247,7 +14247,7 @@ public class IAsyncOperationDocumentProperties: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.DocumentProperties?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.DocumentProperties?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14256,7 +14256,7 @@ public class IAsyncOperationDocumentProperties: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.DocumentProperties? {
+    open func GetResults() throws -> test_component.DocumentProperties? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14293,39 +14293,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.DocumentProperties? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.DocumentProperties?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14392,7 +14392,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePropert
 public class IAsyncOperationImageProperties: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.ImageProperties?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.ImageProperties?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties.self) { pThis in
@@ -14400,7 +14400,7 @@ public class IAsyncOperationImageProperties: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.ImageProperties?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.ImageProperties?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14409,7 +14409,7 @@ public class IAsyncOperationImageProperties: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.ImageProperties? {
+    open func GetResults() throws -> test_component.ImageProperties? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14446,39 +14446,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.ImageProperties? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.ImageProperties?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14545,7 +14545,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePropert
 public class IAsyncOperationMusicProperties: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.MusicProperties?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.MusicProperties?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties.self) { pThis in
@@ -14553,7 +14553,7 @@ public class IAsyncOperationMusicProperties: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.MusicProperties?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.MusicProperties?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14562,7 +14562,7 @@ public class IAsyncOperationMusicProperties: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.MusicProperties? {
+    open func GetResults() throws -> test_component.MusicProperties? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14599,39 +14599,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.MusicProperties? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.MusicProperties?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14698,7 +14698,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePropert
 public class IAsyncOperationStorageItemThumbnail: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageItemThumbnail?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.StorageItemThumbnail?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail.self) { pThis in
@@ -14706,7 +14706,7 @@ public class IAsyncOperationStorageItemThumbnail: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageItemThumbnail?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.StorageItemThumbnail?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14715,7 +14715,7 @@ public class IAsyncOperationStorageItemThumbnail: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.StorageItemThumbnail? {
+    open func GetResults() throws -> test_component.StorageItemThumbnail? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14752,39 +14752,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.StorageItemThumbnail? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.StorageItemThumbnail?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -14851,7 +14851,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePropert
 public class IAsyncOperationVideoProperties: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.VideoProperties?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.VideoProperties?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties.self) { pThis in
@@ -14859,7 +14859,7 @@ public class IAsyncOperationVideoProperties: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.VideoProperties?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.VideoProperties?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -14868,7 +14868,7 @@ public class IAsyncOperationVideoProperties: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.VideoProperties? {
+    open func GetResults() throws -> test_component.VideoProperties? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -14905,39 +14905,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.VideoProperties? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.VideoProperties?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15005,7 +15005,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageIte
 public class IAsyncOperationIStorageItem: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItem }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIStorageItem?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.AnyIStorageItem?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
@@ -15013,7 +15013,7 @@ public class IAsyncOperationIStorageItem: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIStorageItem?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.AnyIStorageItem?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15022,7 +15022,7 @@ public class IAsyncOperationIStorageItem: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItemWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIStorageItem? {
+    open func GetResults() throws -> test_component.AnyIStorageItem? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15059,39 +15059,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CISt
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.AnyIStorageItem? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.AnyIStorageItem?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15158,7 +15158,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIn
 public class IAsyncOperationIndexedState: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.IndexedState>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.IndexedState>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState.self) { pThis in
@@ -15166,7 +15166,7 @@ public class IAsyncOperationIndexedState: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.IndexedState>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.IndexedState>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15175,7 +15175,7 @@ public class IAsyncOperationIndexedState: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.IndexedState {
+    open func GetResults() throws -> test_component.IndexedState {
         var result: __x_ABI_CWindows_CStorage_CSearch_CIndexedState = .init(0)
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
@@ -15211,39 +15211,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSea
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.IndexedState {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.IndexedState>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15310,7 +15310,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFile
 public class IAsyncOperationStorageFile: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFile }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageFile?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.StorageFile?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFileWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
@@ -15318,7 +15318,7 @@ public class IAsyncOperationStorageFile: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageFile?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.StorageFile?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15327,7 +15327,7 @@ public class IAsyncOperationStorageFile: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.StorageFile? {
+    open func GetResults() throws -> test_component.StorageFile? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15364,39 +15364,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.StorageFile? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.StorageFile?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15463,7 +15463,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFold
 public class IAsyncOperationStorageFolder: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolder }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageFolder?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.StorageFolder?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
@@ -15471,7 +15471,7 @@ public class IAsyncOperationStorageFolder: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageFolder?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.StorageFolder?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15480,7 +15480,7 @@ public class IAsyncOperationStorageFolder: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.StorageFolder? {
+    open func GetResults() throws -> test_component.StorageFolder? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolder.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15517,39 +15517,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.StorageFolder? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.StorageFolder?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15616,7 +15616,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStre
 public class IAsyncOperationStorageStreamTransaction: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.StorageStreamTransaction?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.StorageStreamTransaction?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction.self) { pThis in
@@ -15624,7 +15624,7 @@ public class IAsyncOperationStorageStreamTransaction: test_component.IInspectabl
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.StorageStreamTransaction?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.StorageStreamTransaction?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15633,7 +15633,7 @@ public class IAsyncOperationStorageStreamTransaction: test_component.IInspectabl
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.StorageStreamTransaction? {
+    open func GetResults() throws -> test_component.StorageStreamTransaction? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15670,39 +15670,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.StorageStreamTransaction? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.StorageStreamTransaction?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15770,7 +15770,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CI
 public class IAsyncOperationIBuffer: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIBuffer?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.AnyIBuffer?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer.self) { pThis in
@@ -15778,7 +15778,7 @@ public class IAsyncOperationIBuffer: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIBuffer?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.AnyIBuffer?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15787,7 +15787,7 @@ public class IAsyncOperationIBuffer: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBufferWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIBuffer? {
+    open func GetResults() throws -> test_component.AnyIBuffer? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15824,39 +15824,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.AnyIBuffer? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.AnyIBuffer?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -15924,7 +15924,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CI
 public class IAsyncOperationIInputStream: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIInputStream?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.AnyIInputStream?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream.self) { pThis in
@@ -15932,7 +15932,7 @@ public class IAsyncOperationIInputStream: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIInputStream?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.AnyIInputStream?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -15941,7 +15941,7 @@ public class IAsyncOperationIInputStream: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIInputStream? {
+    open func GetResults() throws -> test_component.AnyIInputStream? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -15978,39 +15978,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.AnyIInputStream? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.AnyIInputStream?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -16078,7 +16078,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CI
 public class IAsyncOperationIRandomAccessStream: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStream?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStream?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream.self) { pThis in
@@ -16086,7 +16086,7 @@ public class IAsyncOperationIRandomAccessStream: test_component.IInspectable {
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStream?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStream?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -16095,7 +16095,7 @@ public class IAsyncOperationIRandomAccessStream: test_component.IInspectable {
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIRandomAccessStream? {
+    open func GetResults() throws -> test_component.AnyIRandomAccessStream? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -16132,39 +16132,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.AnyIRandomAccessStream? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStream?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -16232,7 +16232,7 @@ typealias __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CI
 public class IAsyncOperationIRandomAccessStreamWithContentType: test_component.IInspectable {
     override public class var IID: test_component.IID { IID___x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType }
 
-    open func put_CompletedImpl(_ handler: AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStreamWithContentType?>?) throws {
+    open func put_Completed(_ handler: AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStreamWithContentType?>?) throws {
         let handlerWrapper = test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeWrapper(handler)
         let _handler = try! handlerWrapper?.toABI { $0 }
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType.self) { pThis in
@@ -16240,7 +16240,7 @@ public class IAsyncOperationIRandomAccessStreamWithContentType: test_component.I
         }
     }
 
-    open func get_CompletedImpl() throws -> AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStreamWithContentType?>? {
+    open func get_Completed() throws -> AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStreamWithContentType?>? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Completed(pThis, &resultAbi))
@@ -16249,7 +16249,7 @@ public class IAsyncOperationIRandomAccessStreamWithContentType: test_component.I
         return test_component.__x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeWrapper.unwrapFrom(abi: result)
     }
 
-    open func GetResultsImpl() throws -> test_component.AnyIRandomAccessStreamWithContentType? {
+    open func GetResults() throws -> test_component.AnyIRandomAccessStreamWithContentType? {
         let (result) = try ComPtrs.initialize { resultAbi in
             _ = try perform(as: __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
@@ -16286,39 +16286,39 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
     // MARK: WinRT
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.getresults)
     fileprivate func getResults() throws -> test_component.AnyIRandomAccessStreamWithContentType? {
-        try _default.GetResultsImpl()
+        try _default.GetResults()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.completed)
     fileprivate var completed : AsyncOperationCompletedHandler<test_component.AnyIRandomAccessStreamWithContentType?>? {
-        get { try! _default.get_CompletedImpl() }
-        set { try! _default.put_CompletedImpl(newValue) }
+        get { try! _default.get_Completed() }
+        set { try! _default.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.cancel)
     fileprivate func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.close)
     fileprivate func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.errorcode)
     fileprivate var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.id)
     fileprivate var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.iasyncoperation-1.status)
     fileprivate var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? { nil }
@@ -16585,7 +16585,7 @@ typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__CIMemo
 public class TypedEventHandlerIMemoryBufferReference_Any: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__CIMemoryBufferReference_IInspectable }
 
-    open func InvokeImpl(_ sender: test_component.AnyIMemoryBufferReference?, _ args: Any?) throws {
+    open func Invoke(_ sender: test_component.AnyIMemoryBufferReference?, _ args: Any?) throws {
         let senderWrapper = __ABI_Windows_Foundation.IMemoryBufferReferenceWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let argsWrapper = __ABI_.AnyWrapper(args)
@@ -16606,7 +16606,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__C
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
-            try _default.InvokeImpl(sender, args)
+            try _default.Invoke(sender, args)
         }
         return handler
     }
@@ -16640,7 +16640,7 @@ typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearch__
 public class TypedEventHandlerIStorageQueryResultBase_Any: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearch__CIStorageQueryResultBase_IInspectable }
 
-    open func InvokeImpl(_ sender: test_component.AnyIStorageQueryResultBase?, _ args: Any?) throws {
+    open func Invoke(_ sender: test_component.AnyIStorageQueryResultBase?, _ args: Any?) throws {
         let senderWrapper = __ABI_Windows_Storage_Search.IStorageQueryResultBaseWrapper(sender)
         let _sender = try! senderWrapper?.toABI { $0 }
         let argsWrapper = __ABI_.AnyWrapper(args)
@@ -16661,7 +16661,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSea
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
-            try _default.InvokeImpl(sender, args)
+            try _default.Invoke(sender, args)
         }
         return handler
     }
@@ -16695,7 +16695,7 @@ typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x
 public class TypedEventHandlerClass_DeferrableEventArgs: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgs }
 
-    open func InvokeImpl(_ sender: test_component.Class?, _ args: test_component.DeferrableEventArgs?) throws {
+    open func Invoke(_ sender: test_component.Class?, _ args: test_component.DeferrableEventArgs?) throws {
         _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgs.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), RawPointer(args)))
         }
@@ -16712,7 +16712,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClas
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
-            try _default.InvokeImpl(sender, args)
+            try _default.Invoke(sender, args)
         }
         return handler
     }
@@ -16746,7 +16746,7 @@ typealias __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___
 public class TypedEventHandlerSimple_SimpleEventArgs: test_component.IUnknown {
     override public class var IID: test_component.IID { IID___x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgs }
 
-    open func InvokeImpl(_ sender: test_component.Simple?, _ args: test_component.SimpleEventArgs) throws {
+    open func Invoke(_ sender: test_component.Simple?, _ args: test_component.SimpleEventArgs) throws {
         _ = try perform(as: __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgs.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, RawPointer(sender), .from(swift: args)))
         }
@@ -16763,7 +16763,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimp
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
-            try _default.InvokeImpl(sender, args)
+            try _default.Invoke(sender, args)
         }
         return handler
     }

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -29,7 +29,7 @@ public enum __IMPL_test_component {
         }
 
         fileprivate func operationWithProgress(_ value: test_component.DateTime) throws -> AnyIAsyncOperationWithProgress<Int32, Double>! {
-            try _default.OperationWithProgressImpl(value)
+            try _default.OperationWithProgress(value)
         }
 
     }
@@ -58,11 +58,11 @@ public enum __IMPL_test_component {
         }
 
         fileprivate func complete(_ result: Int32) throws {
-            try _default.CompleteImpl(result)
+            try _default.Complete(result)
         }
 
         fileprivate func completeWithError(_ errorCode: HRESULT) throws {
-            try _default.CompleteWithErrorImpl(errorCode)
+            try _default.CompleteWithError(errorCode)
         }
 
     }
@@ -91,7 +91,7 @@ public enum __IMPL_test_component {
         }
 
         fileprivate func method() {
-            try! _default.MethodImpl()
+            try! _default.Method()
         }
 
     }
@@ -120,75 +120,75 @@ public enum __IMPL_test_component {
         }
 
         fileprivate func inInt32(_ value: Int32) throws -> String {
-            try _default.InInt32Impl(value)
+            try _default.InInt32(value)
         }
 
         fileprivate func inString(_ value: String) throws -> String {
-            try _default.InStringImpl(value)
+            try _default.InString(value)
         }
 
         fileprivate func inObject(_ value: Any!) throws -> String {
-            try _default.InObjectImpl(value)
+            try _default.InObject(value)
         }
 
         fileprivate func inEnum(_ value: Signed) throws -> String {
-            try _default.InEnumImpl(value)
+            try _default.InEnum(value)
         }
 
         fileprivate func outInt32(_ value: inout Int32) throws {
-            try _default.OutInt32Impl(&value)
+            try _default.OutInt32(&value)
         }
 
         fileprivate func outString(_ value: inout String) throws {
-            try _default.OutStringImpl(&value)
+            try _default.OutString(&value)
         }
 
         fileprivate func outObject(_ value: inout Any!) throws {
-            try _default.OutObjectImpl(&value)
+            try _default.OutObject(&value)
         }
 
         fileprivate func outBlittableStruct(_ value: inout BlittableStruct) throws {
-            try _default.OutBlittableStructImpl(&value)
+            try _default.OutBlittableStruct(&value)
         }
 
         fileprivate func outNonBlittableStruct(_ value: inout NonBlittableStruct) throws {
-            try _default.OutNonBlittableStructImpl(&value)
+            try _default.OutNonBlittableStruct(&value)
         }
 
         fileprivate func outEnum(_ value: inout Signed) throws {
-            try _default.OutEnumImpl(&value)
+            try _default.OutEnum(&value)
         }
 
         fileprivate func returnObject() throws -> Any! {
-            try _default.ReturnObjectImpl()
+            try _default.ReturnObject()
         }
 
         fileprivate func returnEnum() throws -> Signed {
-            try _default.ReturnEnumImpl()
+            try _default.ReturnEnum()
         }
 
         fileprivate func fireEvent(_ data: String) throws {
-            try _default.FireEventImpl(data)
+            try _default.FireEvent(data)
         }
 
         fileprivate var enumProperty : Fruit {
-            get { try! _default.get_EnumPropertyImpl() }
-            set { try! _default.put_EnumPropertyImpl(newValue) }
+            get { try! _default.get_EnumProperty() }
+            set { try! _default.put_EnumProperty(newValue) }
         }
 
         fileprivate var id : Foundation.UUID? {
-            get { try! _default.get_IdImpl() }
-            set { try! _default.put_IdImpl(newValue) }
+            get { try! _default.get_Id() }
+            set { try! _default.put_Id(newValue) }
         }
 
         fileprivate lazy var implementableEvent : Event<test_component.InDelegate> = {
           .init(
             add: { [weak self] in
               guard let this = self?._default else { return .init() }
-              return try! this.add_ImplementableEventImpl($0)
+              return try! this.add_ImplementableEvent($0)
             },
             remove: { [weak self] in
-             try? self?._default.remove_ImplementableEventImpl($0)
+             try? self?._default.remove_ImplementableEvent($0)
            }
           )
         }()
@@ -219,7 +219,7 @@ public enum __IMPL_test_component {
         }
 
         fileprivate func takeObservable(_ basics: AnyIObservableVector<AnyIBasic?>!) throws {
-            try _default.TakeObservableImpl(basics)
+            try _default.TakeObservable(basics)
         }
 
     }
@@ -248,7 +248,7 @@ public enum __IMPL_test_component {
         }
 
         fileprivate func method() throws {
-            try _default.MethodImpl()
+            try _default.Method()
         }
 
     }
@@ -277,11 +277,11 @@ public enum __IMPL_test_component {
         }
 
         fileprivate func doThis() throws {
-            try _default.DoThisImpl()
+            try _default.DoThis()
         }
 
         fileprivate func doThat(_ val: Int32) throws {
-            try _default.DoThatImpl(val)
+            try _default.DoThat(val)
         }
 
     }
@@ -313,10 +313,10 @@ public enum __IMPL_test_component {
           .init(
             add: { [weak self] in
               guard let this = self?._default else { return .init() }
-              return try! this.add_EventWithReturnImpl($0)
+              return try! this.add_EventWithReturn($0)
             },
             remove: { [weak self] in
-             try? self?._default.remove_EventWithReturnImpl($0)
+             try? self?._default.remove_EventWithReturn($0)
            }
           )
         }()
@@ -347,7 +347,7 @@ public enum __IMPL_test_component {
         }
 
         fileprivate func ids() throws -> AnyIVector<Foundation.UUID>! {
-            try _default.IDsImpl()
+            try _default.IDs()
         }
 
     }
@@ -376,26 +376,26 @@ public enum __IMPL_test_component {
         }
 
         fileprivate func `enum`(_ `extension`: String) throws {
-            try _default.EnumImpl(`extension`)
+            try _default.Enum(`extension`)
         }
 
         fileprivate func `subscript`() throws {
-            try _default.SubscriptImpl()
+            try _default.Subscript()
         }
 
         fileprivate var `struct` : String {
-            get { try! _default.get_StructImpl() }
-            set { try! _default.put_StructImpl(newValue) }
+            get { try! _default.get_Struct() }
+            set { try! _default.put_Struct(newValue) }
         }
 
         fileprivate lazy var `repeat` : Event<EventHandler<Any?>> = {
           .init(
             add: { [weak self] in
               guard let this = self?._default else { return .init() }
-              return try! this.add_RepeatImpl($0)
+              return try! this.add_Repeat($0)
             },
             remove: { [weak self] in
-             try? self?._default.remove_RepeatImpl($0)
+             try? self?._default.remove_Repeat($0)
            }
           )
         }()
@@ -411,7 +411,7 @@ public enum __IMPL_test_component {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (item) in
-                try _default.InvokeImpl(item)
+                try _default.Invoke(item)
             }
             return handler
         }
@@ -425,7 +425,7 @@ public enum __IMPL_test_component {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in
-                try _default.InvokeImpl()
+                try _default.Invoke()
             }
             return handler
         }

--- a/tests/test_component/Sources/test_component/test_component.Delegates+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+ABI.swift
@@ -27,7 +27,7 @@ extension __ABI_test_component_Delegates {
     public class InDelegate: test_component.IUnknown {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CDelegates_CIInDelegate }
 
-        open func InvokeImpl(_ value: String) throws {
+        open func Invoke(_ value: String) throws {
             let _value = try! HString(value)
             _ = try perform(as: __x_ABI_Ctest__component_CDelegates_CIInDelegate.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, _value.get()))
@@ -64,7 +64,7 @@ extension __ABI_test_component_Delegates {
     public class InObjectDelegate: test_component.IUnknown {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CDelegates_CIInObjectDelegate }
 
-        open func InvokeImpl(_ value: Any?) throws {
+        open func Invoke(_ value: Any?) throws {
             let valueWrapper = __ABI_.AnyWrapper(value)
             let _value = try! valueWrapper?.toABI { $0 }
             _ = try perform(as: __x_ABI_Ctest__component_CDelegates_CIInObjectDelegate.self) { pThis in
@@ -102,7 +102,7 @@ extension __ABI_test_component_Delegates {
     public class ReturnInt32Delegate: test_component.IUnknown {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CDelegates_CIReturnInt32Delegate }
 
-        open func InvokeImpl() throws -> Int32 {
+        open func Invoke() throws -> Int32 {
             var result: INT32 = 0
             _ = try perform(as: __x_ABI_Ctest__component_CDelegates_CIReturnInt32Delegate.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis, &result))
@@ -140,7 +140,7 @@ extension __ABI_test_component_Delegates {
     public class SignalDelegate: test_component.IUnknown {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CDelegates_CISignalDelegate }
 
-        open func InvokeImpl() throws {
+        open func Invoke() throws {
             _ = try perform(as: __x_ABI_Ctest__component_CDelegates_CISignalDelegate.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Invoke(pThis))
             }

--- a/tests/test_component/Sources/test_component/test_component.Delegates+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+Impl.swift
@@ -14,7 +14,7 @@ public enum __IMPL_test_component_Delegates {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (value) in
-                try _default.InvokeImpl(value)
+                try _default.Invoke(value)
             }
             return handler
         }
@@ -28,7 +28,7 @@ public enum __IMPL_test_component_Delegates {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (value) in
-                try _default.InvokeImpl(value)
+                try _default.Invoke(value)
             }
             return handler
         }
@@ -42,7 +42,7 @@ public enum __IMPL_test_component_Delegates {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in
-                try _default.InvokeImpl()
+                try _default.Invoke()
             }
             return handler
         }
@@ -56,7 +56,7 @@ public enum __IMPL_test_component_Delegates {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in
-                try _default.InvokeImpl()
+                try _default.Invoke()
             }
             return handler
         }

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -11,15 +11,15 @@ public typealias Unsigned = __x_ABI_Ctest__component_CUnsigned
 public final class AsyncMethods {
     private static let _IAsyncMethodsStatics: __ABI_test_component.IAsyncMethodsStatics = try! RoGetActivationFactory("test_component.AsyncMethods")
     public static func getCompletedAsync(_ result: Int32) throws -> AnyIAsyncOperation<Int32>! {
-        return try _IAsyncMethodsStatics.GetCompletedAsyncImpl(result)
+        return try _IAsyncMethodsStatics.GetCompletedAsync(result)
     }
 
     public static func getCompletedWithErrorAsync(_ errorCode: HRESULT) throws -> AnyIAsyncOperation<Int32>! {
-        return try _IAsyncMethodsStatics.GetCompletedWithErrorAsyncImpl(errorCode)
+        return try _IAsyncMethodsStatics.GetCompletedWithErrorAsync(errorCode)
     }
 
     public static func getPendingAsync() throws -> AsyncOperationInt! {
-        return try _IAsyncMethodsStatics.GetPendingAsyncImpl()
+        return try _IAsyncMethodsStatics.GetPendingAsync()
     }
 
 }
@@ -52,42 +52,42 @@ public final class AsyncOperationInt : WinRTClass, IAsyncOperationInt, IAsyncOpe
         return super.queryInterface(iid)
     }
     public func complete(_ result: Int32) throws {
-        try _default.CompleteImpl(result)
+        try _default.Complete(result)
     }
 
     public func completeWithError(_ errorCode: HRESULT) throws {
-        try _default.CompleteWithErrorImpl(errorCode)
+        try _default.CompleteWithError(errorCode)
     }
 
     private lazy var _IAsyncOperation: IAsyncOperationInt32! = getInterfaceForCaching()
     public func getResults() throws -> Int32 {
-        try _IAsyncOperation.GetResultsImpl()
+        try _IAsyncOperation.GetResults()
     }
 
     public var completed : AsyncOperationCompletedHandler<Int32>? {
-        get { try! _IAsyncOperation.get_CompletedImpl() }
-        set { try! _IAsyncOperation.put_CompletedImpl(newValue) }
+        get { try! _IAsyncOperation.get_Completed() }
+        set { try! _IAsyncOperation.put_Completed(newValue) }
     }
 
     private lazy var _IAsyncInfo: __ABI_Windows_Foundation.IAsyncInfo! = getInterfaceForCaching()
     public func cancel() throws {
-        try _IAsyncInfo.CancelImpl()
+        try _IAsyncInfo.Cancel()
     }
 
     public func close() throws {
-        try _IAsyncInfo.CloseImpl()
+        try _IAsyncInfo.Close()
     }
 
     public var errorCode : HRESULT {
-        get { try! _IAsyncInfo.get_ErrorCodeImpl() }
+        get { try! _IAsyncInfo.get_ErrorCode() }
     }
 
     public var id : UInt32 {
-        get { try! _IAsyncInfo.get_IdImpl() }
+        get { try! _IAsyncInfo.get_Id() }
     }
 
     public var status : test_component.AsyncStatus {
-        get { try! _IAsyncInfo.get_StatusImpl() }
+        get { try! _IAsyncInfo.get_Status() }
     }
 
     deinit {
@@ -141,22 +141,22 @@ open class Base : WinRTClass {
     override public init() {
         super.init()
         MakeComposed(composing: Self.Composable.self, self) { baseInterface, innerInterface in 
-            try! Self._IBaseProtectedFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+            try! Self._IBaseProtectedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
 
     private static let _IBaseStatics: __ABI_test_component.IBaseStatics = try! RoGetActivationFactory("test_component.Base")
     public class func createFromString(_ value: String) throws -> Base! {
-        return try _IBaseStatics.CreateFromStringImpl(value)
+        return try _IBaseStatics.CreateFromString(value)
     }
 
     public func doTheThing() throws {
-        try _default.DoTheThingImpl()
+        try _default.DoTheThing()
     }
 
     private lazy var _IBaseOverrides: __ABI_test_component.IBaseOverrides! = getInterfaceForCaching()
     open func onDoTheThing() throws {
-        try _IBaseOverrides.OnDoTheThingImpl()
+        try _IBaseOverrides.OnDoTheThing()
     }
 
     @_spi(WinRTInternal)
@@ -218,7 +218,7 @@ open class BaseCollection : WinRTClass, IVector, IIterable {
     override public init() {
         super.init()
         MakeComposed(composing: Self.Composable.self, self) { baseInterface, innerInterface in 
-            try! Self._IBaseCollectionProtectedFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+            try! Self._IBaseCollectionProtectedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
 
@@ -254,48 +254,48 @@ open class BaseCollection : WinRTClass, IVector, IIterable {
 
     // MARK: WinRT
     public func getAt(_ index: UInt32) -> Base? {
-        try! _default.GetAtImpl(index)
+        try! _default.GetAt(index)
     }
 
     public func getView() -> AnyIVectorView<Base?>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     public func indexOf(_ value: Base?, _ index: inout UInt32) -> Bool {
-        try! _default.IndexOfImpl(value, &index)
+        try! _default.IndexOf(value, &index)
     }
 
     public func setAt(_ index: UInt32, _ value: Base?) {
-        try! _default.SetAtImpl(index, value)
+        try! _default.SetAt(index, value)
     }
 
     public func insertAt(_ index: UInt32, _ value: Base?) {
-        try! _default.InsertAtImpl(index, value)
+        try! _default.InsertAt(index, value)
     }
 
     public func removeAt(_ index: UInt32) {
-        try! _default.RemoveAtImpl(index)
+        try! _default.RemoveAt(index)
     }
 
     public func append(_ value: Base?) {
-        try! _default.AppendImpl(value)
+        try! _default.Append(value)
     }
 
     public func removeAtEnd() {
-        try! _default.RemoveAtEndImpl()
+        try! _default.RemoveAtEnd()
     }
 
     public func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     public var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableBase! = getInterfaceForCaching()
     public func first() -> AnyIIterator<Base?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     @_spi(WinRTInternal)
@@ -347,36 +347,36 @@ public final class BaseMapCollection : WinRTClass, IMap, IIterable {
         return super.queryInterface(iid)
     }
     public func lookup(_ key: String) -> Base? {
-        try! _default.LookupImpl(key)
+        try! _default.Lookup(key)
     }
 
     public func hasKey(_ key: String) -> Bool {
-        try! _default.HasKeyImpl(key)
+        try! _default.HasKey(key)
     }
 
     public func getView() -> AnyIMapView<String, Base?>? {
-        try! _default.GetViewImpl()
+        try! _default.GetView()
     }
 
     public func insert(_ key: String, _ value: Base?) -> Bool {
-        try! _default.InsertImpl(key, value)
+        try! _default.Insert(key, value)
     }
 
     public func remove(_ key: String) {
-        try! _default.RemoveImpl(key)
+        try! _default.Remove(key)
     }
 
     public func clear() {
-        try! _default.ClearImpl()
+        try! _default.Clear()
     }
 
     public var size : UInt32 {
-        get { try! _default.get_SizeImpl() }
+        get { try! _default.get_Size() }
     }
 
     private lazy var _IIterable: IIterableIKeyValuePairString_Base! = getInterfaceForCaching()
     public func first() -> AnyIIterator<AnyIKeyValuePair<String, Base?>?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     deinit {
@@ -424,13 +424,13 @@ open class BaseNoOverrides : WinRTClass {
     override public init() {
         super.init()
         MakeComposed(composing: Self.Composable.self, self) { baseInterface, innerInterface in 
-            try! Self._IBaseNoOverridesProtectedFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+            try! Self._IBaseNoOverridesProtectedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
 
     private static let _IBaseNoOverridesStatics: __ABI_test_component.IBaseNoOverridesStatics = try! RoGetActivationFactory("test_component.BaseNoOverrides")
     public class func createFromString(_ value: String) throws -> BaseNoOverrides! {
-        return try _IBaseNoOverridesStatics.CreateFromStringImpl(value)
+        return try _IBaseNoOverridesStatics.CreateFromString(value)
     }
 
     @_spi(WinRTInternal)
@@ -513,58 +513,58 @@ public final class BaseObservableCollection : WinRTClass, IObservableVector, IVe
       .init(
         add: { [weak self] in
           guard let this = self?._default else { return .init() }
-          return try! this.add_VectorChangedImpl($0)
+          return try! this.add_VectorChanged($0)
         },
         remove: { [weak self] in
-         try? self?._default.remove_VectorChangedImpl($0)
+         try? self?._default.remove_VectorChanged($0)
        }
       )
     }()
 
     private lazy var _IVector: IVectorBase! = getInterfaceForCaching()
     public func getAt(_ index: UInt32) -> Base? {
-        try! _IVector.GetAtImpl(index)
+        try! _IVector.GetAt(index)
     }
 
     public func getView() -> AnyIVectorView<Base?>? {
-        try! _IVector.GetViewImpl()
+        try! _IVector.GetView()
     }
 
     public func indexOf(_ value: Base?, _ index: inout UInt32) -> Bool {
-        try! _IVector.IndexOfImpl(value, &index)
+        try! _IVector.IndexOf(value, &index)
     }
 
     public func setAt(_ index: UInt32, _ value: Base?) {
-        try! _IVector.SetAtImpl(index, value)
+        try! _IVector.SetAt(index, value)
     }
 
     public func insertAt(_ index: UInt32, _ value: Base?) {
-        try! _IVector.InsertAtImpl(index, value)
+        try! _IVector.InsertAt(index, value)
     }
 
     public func removeAt(_ index: UInt32) {
-        try! _IVector.RemoveAtImpl(index)
+        try! _IVector.RemoveAt(index)
     }
 
     public func append(_ value: Base?) {
-        try! _IVector.AppendImpl(value)
+        try! _IVector.Append(value)
     }
 
     public func removeAtEnd() {
-        try! _IVector.RemoveAtEndImpl()
+        try! _IVector.RemoveAtEnd()
     }
 
     public func clear() {
-        try! _IVector.ClearImpl()
+        try! _IVector.Clear()
     }
 
     public var size : UInt32 {
-        get { try! _IVector.get_SizeImpl() }
+        get { try! _IVector.get_Size() }
     }
 
     private lazy var _IIterable: IIterableBase! = getInterfaceForCaching()
     public func first() -> AnyIIterator<Base?>? {
-        try! _IIterable.FirstImpl()
+        try! _IIterable.First()
     }
 
     deinit {
@@ -577,7 +577,7 @@ public final class BaseObservableCollection : WinRTClass, IObservableVector, IVe
 public final class BufferTester {
     private static let _IBufferTesterStatics: __ABI_test_component.IBufferTesterStatics = try! RoGetActivationFactory("test_component.BufferTester")
     public static func getDataFrom(_ buffer: test_component.AnyIBuffer!, _ index: UInt32) throws -> UInt8 {
-        return try _IBufferTesterStatics.GetDataFromImpl(buffer, index)
+        return try _IBufferTesterStatics.GetDataFrom(buffer, index)
     }
 
 }
@@ -615,202 +615,202 @@ public final class Class : WinRTClass, IBasic {
 
     private static let _IClassFactory: __ABI_test_component.IClassFactory = try! RoGetActivationFactory("test_component.Class")
     public init(_ name: String) {
-        super.init(try! Self._IClassFactory.CreateInstanceImpl(name))
+        super.init(try! Self._IClassFactory.CreateInstance(name))
     }
 
     public init(_ name: String, _ fruit: Fruit) {
-        super.init(try! Self._IClassFactory.CreateInstance2Impl(name, fruit))
+        super.init(try! Self._IClassFactory.CreateInstance2(name, fruit))
     }
 
     public init(_ arg: AnyIMap<String, String>!, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32) {
-        super.init(try! Self._IClassFactory.CreateInstance3Impl(arg, dummy1, dummy2, dummy3))
+        super.init(try! Self._IClassFactory.CreateInstance3(arg, dummy1, dummy2, dummy3))
     }
 
     public init(_ arg: AnyIMapView<String, String>!, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32) {
-        super.init(try! Self._IClassFactory.CreateInstance4Impl(arg, dummy1, dummy2, dummy3, dummy4))
+        super.init(try! Self._IClassFactory.CreateInstance4(arg, dummy1, dummy2, dummy3, dummy4))
     }
 
     public init(_ arg: AnyIVector<String>!, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32, _ dummy5: Int32) {
-        super.init(try! Self._IClassFactory.CreateInstance5Impl(arg, dummy1, dummy2, dummy3, dummy4, dummy5))
+        super.init(try! Self._IClassFactory.CreateInstance5(arg, dummy1, dummy2, dummy3, dummy4, dummy5))
     }
 
     public init(_ arg: AnyIVectorView<String>!, _ dummy1: Int32, _ dummy2: Int32, _ dummy3: Int32, _ dummy4: Int32, _ dummy5: Int32, _ dummy6: Int32) {
-        super.init(try! Self._IClassFactory.CreateInstance6Impl(arg, dummy1, dummy2, dummy3, dummy4, dummy5, dummy6))
+        super.init(try! Self._IClassFactory.CreateInstance6(arg, dummy1, dummy2, dummy3, dummy4, dummy5, dummy6))
     }
 
     private static let _IClassFactory2: __ABI_test_component.IClassFactory2 = try! RoGetActivationFactory("test_component.Class")
     public init(_ name: String, _ fruit: Fruit, _ implementation: AnyIIAmImplementable!) {
-        super.init(try! Self._IClassFactory2.CreateInstanceImpl(name, fruit, implementation))
+        super.init(try! Self._IClassFactory2.CreateInstance(name, fruit, implementation))
     }
 
     private static let _IClassStatics: __ABI_test_component.IClassStatics = try! RoGetActivationFactory("test_component.Class")
     public static func staticTest() throws {
-        try _IClassStatics.StaticTestImpl()
+        try _IClassStatics.StaticTest()
     }
 
     public static func staticTestReturn() throws -> Int32 {
-        return try _IClassStatics.StaticTestReturnImpl()
+        return try _IClassStatics.StaticTestReturn()
     }
 
     public static func takeBaseAndGiveToCallbackAsObject(_ base: Base!, _ callback: test_component.InObjectDelegate!) throws {
-        try _IClassStatics.TakeBaseAndGiveToCallbackAsObjectImpl(base, callback)
+        try _IClassStatics.TakeBaseAndGiveToCallbackAsObject(base, callback)
     }
 
     public static var staticProperty : Int32 {
-        get { try! _IClassStatics.get_StaticPropertyImpl() }
+        get { try! _IClassStatics.get_StaticProperty() }
     }
 
     private static let _IClassStatics2: __ABI_test_component.IClassStatics2 = try! RoGetActivationFactory("test_component.Class")
     public static func staticTestReturnFloat() throws -> Float {
-        return try _IClassStatics2.StaticTestReturnFloatImpl()
+        return try _IClassStatics2.StaticTestReturnFloat()
     }
 
     public static var staticPropertyFloat : Float {
-        get { try! _IClassStatics2.get_StaticPropertyFloatImpl() }
-        set { try! _IClassStatics2.put_StaticPropertyFloatImpl(newValue) }
+        get { try! _IClassStatics2.get_StaticPropertyFloat() }
+        set { try! _IClassStatics2.put_StaticPropertyFloat(newValue) }
     }
 
     public func setDelegate(_ value: AnyISimpleDelegate!) throws {
-        try _default.SetDelegateImpl(value)
+        try _default.SetDelegate(value)
     }
 
     public func getDelegate() throws -> AnyISimpleDelegate! {
-        try _default.GetDelegateImpl()
+        try _default.GetDelegate()
     }
 
     public func fail(_ message: String) throws {
-        try _default.FailImpl(message)
+        try _default.Fail(message)
     }
 
     public func inInt32(_ value: Int32) throws -> String {
-        try _default.InInt32Impl(value)
+        try _default.InInt32(value)
     }
 
     public func inString(_ value: String) throws -> String {
-        try _default.InStringImpl(value)
+        try _default.InString(value)
     }
 
     public func inObject(_ value: Any!) throws -> String {
-        try _default.InObjectImpl(value)
+        try _default.InObject(value)
     }
 
     public func inEnum(_ value: Signed) throws -> String {
-        try _default.InEnumImpl(value)
+        try _default.InEnum(value)
     }
 
     public func outInt32(_ value: inout Int32) throws {
-        try _default.OutInt32Impl(&value)
+        try _default.OutInt32(&value)
     }
 
     public func outString(_ value: inout String) throws {
-        try _default.OutStringImpl(&value)
+        try _default.OutString(&value)
     }
 
     public func outObject(_ value: inout Any!) throws {
-        try _default.OutObjectImpl(&value)
+        try _default.OutObject(&value)
     }
 
     public func outStringable(_ value: inout test_component.AnyIStringable!) throws {
-        try _default.OutStringableImpl(&value)
+        try _default.OutStringable(&value)
     }
 
     public func outBlittableStruct(_ value: inout BlittableStruct) throws {
-        try _default.OutBlittableStructImpl(&value)
+        try _default.OutBlittableStruct(&value)
     }
 
     public func outNonBlittableStruct(_ value: inout NonBlittableStruct) throws {
-        try _default.OutNonBlittableStructImpl(&value)
+        try _default.OutNonBlittableStruct(&value)
     }
 
     public func outEnum(_ value: inout Signed) throws {
-        try _default.OutEnumImpl(&value)
+        try _default.OutEnum(&value)
     }
 
     public func returnObject() throws -> Any! {
-        try _default.ReturnObjectImpl()
+        try _default.ReturnObject()
     }
 
     public func returnEnum() throws -> Signed {
-        try _default.ReturnEnumImpl()
+        try _default.ReturnEnum()
     }
 
     public func returnReferenceEnum() throws -> Signed? {
-        try _default.ReturnReferenceEnumImpl()
+        try _default.ReturnReferenceEnum()
     }
 
     public func noexceptVoid() {
-        try! _default.NoexceptVoidImpl()
+        try! _default.NoexceptVoid()
     }
 
     public func noexceptInt32() -> Int32 {
-        try! _default.NoexceptInt32Impl()
+        try! _default.NoexceptInt32()
     }
 
     public func noexceptString() -> String {
-        try! _default.NoexceptStringImpl()
+        try! _default.NoexceptString()
     }
 
     public func raiseDeferrableEventAsync() throws -> AnyIAsyncOperation<Int32>! {
-        try _default.RaiseDeferrableEventAsyncImpl()
+        try _default.RaiseDeferrableEventAsync()
     }
 
     public func returnChar() throws -> Character {
-        try _default.ReturnCharImpl()
+        try _default.ReturnChar()
     }
 
     public func inChar(_ value: Character) throws -> String {
-        try _default.InCharImpl(value)
+        try _default.InChar(value)
     }
 
     public func outChar(_ value: inout Character) throws {
-        try _default.OutCharImpl(&value)
+        try _default.OutChar(&value)
     }
 
     public var baseNoOverridesProperty : BaseNoOverrides! {
-        get { try! _default.get_BaseNoOverridesPropertyImpl() }
-        set { try! _default.put_BaseNoOverridesPropertyImpl(newValue) }
+        get { try! _default.get_BaseNoOverridesProperty() }
+        set { try! _default.put_BaseNoOverridesProperty(newValue) }
     }
 
     public var baseProperty : Base! {
-        get { try! _default.get_BasePropertyImpl() }
-        set { try! _default.put_BasePropertyImpl(newValue) }
+        get { try! _default.get_BaseProperty() }
+        set { try! _default.put_BaseProperty(newValue) }
     }
 
     public var enumProperty : Fruit {
-        get { try! _default.get_EnumPropertyImpl() }
-        set { try! _default.put_EnumPropertyImpl(newValue) }
+        get { try! _default.get_EnumProperty() }
+        set { try! _default.put_EnumProperty(newValue) }
     }
 
     public var id : Foundation.UUID? {
-        get { try! _default.get_IdImpl() }
-        set { try! _default.put_IdImpl(newValue) }
+        get { try! _default.get_Id() }
+        set { try! _default.put_Id(newValue) }
     }
 
     public var implementation : AnyIBasic! {
-        get { try! _default.get_ImplementationImpl() }
-        set { try! _default.put_ImplementationImpl(newValue) }
+        get { try! _default.get_Implementation() }
+        set { try! _default.put_Implementation(newValue) }
     }
 
     public var startValue : Int32? {
-        get { try! _default.get_StartValueImpl() }
-        set { try! _default.put_StartValueImpl(newValue) }
+        get { try! _default.get_StartValue() }
+        set { try! _default.put_StartValue(newValue) }
     }
 
     public lazy var deferrableEvent : Event<TypedEventHandler<Class?, DeferrableEventArgs?>> = {
       .init(
         add: { [weak self] in
           guard let this = self?._default else { return .init() }
-          return try! this.add_DeferrableEventImpl($0)
+          return try! this.add_DeferrableEvent($0)
         },
         remove: { [weak self] in
-         try? self?._default.remove_DeferrableEventImpl($0)
+         try? self?._default.remove_DeferrableEvent($0)
        }
       )
     }()
 
     private lazy var _IBasic: __ABI_test_component.IBasic! = getInterfaceForCaching()
     public func method() {
-        try! _IBasic.MethodImpl()
+        try! _IBasic.Method()
     }
 
     deinit {
@@ -849,35 +849,35 @@ public final class CollectionTester : WinRTClass {
 
     private static let _ICollectionTesterStatics: __ABI_test_component.ICollectionTesterStatics = try! RoGetActivationFactory("test_component.CollectionTester")
     public static func inMap(_ value: AnyIMap<String, String>!) throws -> String {
-        return try _ICollectionTesterStatics.InMapImpl(value)
+        return try _ICollectionTesterStatics.InMap(value)
     }
 
     public static func inMapView(_ value: AnyIMapView<String, String>!) throws -> String {
-        return try _ICollectionTesterStatics.InMapViewImpl(value)
+        return try _ICollectionTesterStatics.InMapView(value)
     }
 
     public static func inVector(_ value: AnyIVector<String>!) throws -> String {
-        return try _ICollectionTesterStatics.InVectorImpl(value)
+        return try _ICollectionTesterStatics.InVector(value)
     }
 
     public static func inVectorView(_ value: AnyIVectorView<String>!) throws -> String {
-        return try _ICollectionTesterStatics.InVectorViewImpl(value)
+        return try _ICollectionTesterStatics.InVectorView(value)
     }
 
     public static func getObjectAt(_ value: AnyIVector<Any?>!, _ index: UInt32, _ callback: ObjectHandler!) throws {
-        try _ICollectionTesterStatics.GetObjectAtImpl(value, index, callback)
+        try _ICollectionTesterStatics.GetObjectAt(value, index, callback)
     }
 
     public static func vectorAsIterable(_ value: AnyIVector<String>!) throws -> AnyIIterable<String>! {
-        return try _ICollectionTesterStatics.VectorAsIterableImpl(value)
+        return try _ICollectionTesterStatics.VectorAsIterable(value)
     }
 
     public func returnStoredStringVector() throws -> AnyIVector<String>! {
-        try _default.ReturnStoredStringVectorImpl()
+        try _default.ReturnStoredStringVector()
     }
 
     public func returnMapFromStringToString() throws -> AnyIMap<String, String>! {
-        try _default.ReturnMapFromStringToStringImpl()
+        try _default.ReturnMapFromStringToString()
     }
 
     deinit {
@@ -909,11 +909,11 @@ public final class DeferrableEventArgs : WinRTClass {
     }
 
     public func getDeferral() throws -> test_component.Deferral! {
-        try _default.GetDeferralImpl()
+        try _default.GetDeferral()
     }
 
     public func incrementCounter() throws {
-        try _default.IncrementCounterImpl()
+        try _default.IncrementCounter()
     }
 
     deinit {
@@ -951,12 +951,12 @@ public final class Derived : test_component.Base {
 
     private static let _IDerivedStatics: __ABI_test_component.IDerivedStatics = try! RoGetActivationFactory("test_component.Derived")
     override public static func createFromString(_ value: String) throws -> Derived! {
-        return try _IDerivedStatics.CreateFromStringImpl(value)
+        return try _IDerivedStatics.CreateFromString(value)
     }
 
     public var prop : Int32 {
-        get { try! _default.get_PropImpl() }
-        set { try! _default.put_PropImpl(newValue) }
+        get { try! _default.get_Prop() }
+        set { try! _default.put_Prop(newValue) }
     }
 
     @_spi(WinRTInternal)
@@ -1001,7 +1001,7 @@ public final class DerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
     }
 
     public func method() throws {
-        try _default.MethodImpl()
+        try _default.Method()
     }
 
     @_spi(WinRTInternal)
@@ -1047,23 +1047,23 @@ public final class EventTester : WinRTClass {
 
     private static let _IEventTesterFactory: __ABI_test_component.IEventTesterFactory = try! RoGetActivationFactory("test_component.EventTester")
     public init(_ impl: AnyIIAmImplementable!) {
-        super.init(try! Self._IEventTesterFactory.CreateInstanceImpl(impl))
+        super.init(try! Self._IEventTesterFactory.CreateInstance(impl))
     }
 
     public func subscribe() throws {
-        try _default.SubscribeImpl()
+        try _default.Subscribe()
     }
 
     public func unsubscribe() throws {
-        try _default.UnsubscribeImpl()
+        try _default.Unsubscribe()
     }
 
     public func getResult() throws -> String {
-        try _default.GetResultImpl()
+        try _default.GetResult()
     }
 
     public var count : Int32 {
-        get { try! _default.get_CountImpl() }
+        get { try! _default.get_Count() }
     }
 
     deinit {
@@ -1103,7 +1103,7 @@ public final class NoopClosable : WinRTClass, test_component.IClosable {
     }
 
     public func close() throws {
-        try _default.CloseImpl()
+        try _default.Close()
     }
 
     deinit {
@@ -1114,43 +1114,43 @@ public final class NoopClosable : WinRTClass, test_component.IClosable {
 public final class NullValues {
     private static let _INullValuesStatics: __ABI_test_component.INullValuesStatics = try! RoGetActivationFactory("test_component.NullValues")
     public static func isObjectNull(_ value: Any!) throws -> Bool {
-        return try _INullValuesStatics.IsObjectNullImpl(value)
+        return try _INullValuesStatics.IsObjectNull(value)
     }
 
     public static func isInterfaceNull(_ value: test_component.AnyIClosable!) throws -> Bool {
-        return try _INullValuesStatics.IsInterfaceNullImpl(value)
+        return try _INullValuesStatics.IsInterfaceNull(value)
     }
 
     public static func isGenericInterfaceNull(_ value: AnyIVector<String>!) throws -> Bool {
-        return try _INullValuesStatics.IsGenericInterfaceNullImpl(value)
+        return try _INullValuesStatics.IsGenericInterfaceNull(value)
     }
 
     public static func isClassNull(_ value: NoopClosable!) throws -> Bool {
-        return try _INullValuesStatics.IsClassNullImpl(value)
+        return try _INullValuesStatics.IsClassNull(value)
     }
 
     public static func isDelegateNull(_ value: VoidToVoidDelegate!) throws -> Bool {
-        return try _INullValuesStatics.IsDelegateNullImpl(value)
+        return try _INullValuesStatics.IsDelegateNull(value)
     }
 
     public static func getNullObject() throws -> Any! {
-        return try _INullValuesStatics.GetNullObjectImpl()
+        return try _INullValuesStatics.GetNullObject()
     }
 
     public static func getNullInterface() throws -> test_component.AnyIClosable! {
-        return try _INullValuesStatics.GetNullInterfaceImpl()
+        return try _INullValuesStatics.GetNullInterface()
     }
 
     public static func getNullGenericInterface() throws -> AnyIVector<String>! {
-        return try _INullValuesStatics.GetNullGenericInterfaceImpl()
+        return try _INullValuesStatics.GetNullGenericInterface()
     }
 
     public static func getNullClass() throws -> NoopClosable! {
-        return try _INullValuesStatics.GetNullClassImpl()
+        return try _INullValuesStatics.GetNullClass()
     }
 
     public static func getNullDelegate() throws -> VoidToVoidDelegate! {
-        return try _INullValuesStatics.GetNullDelegateImpl()
+        return try _INullValuesStatics.GetNullDelegate()
     }
 
 }
@@ -1185,88 +1185,88 @@ public final class Simple : WinRTClass {
 
     private static let _ISimpleStatics: __ABI_test_component.ISimpleStatics = try! RoGetActivationFactory("test_component.Simple")
     public static func fireStaticEvent() throws {
-        try _ISimpleStatics.FireStaticEventImpl()
+        try _ISimpleStatics.FireStaticEvent()
     }
 
     public static var staticEvent : Event<EventHandler<Any?>> = {
       .init(
-        add: { try! _ISimpleStatics.add_StaticEventImpl($0) },
-        remove: { try? _ISimpleStatics.remove_StaticEventImpl($0) }
+        add: { try! _ISimpleStatics.add_StaticEvent($0) },
+        remove: { try? _ISimpleStatics.remove_StaticEvent($0) }
       )
     }()
 
     public func method() throws {
-        try _default.MethodImpl()
+        try _default.Method()
     }
 
     public func operation(_ value: test_component.DateTime) throws -> AnyIAsyncOperation<Int32>! {
-        try _default.OperationImpl(value)
+        try _default.Operation(value)
     }
 
     public func action(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncAction! {
-        try _default.ActionImpl(value)
+        try _default.Action(value)
     }
 
     public func object(_ value: test_component.DateTime) throws -> Any! {
-        try _default.ObjectImpl(value)
+        try _default.Object(value)
     }
 
     public func returnBlittableStruct() throws -> BlittableStruct {
-        try _default.ReturnBlittableStructImpl()
+        try _default.ReturnBlittableStruct()
     }
 
     public func takeBlittableStruct(_ value: BlittableStruct) throws {
-        try _default.TakeBlittableStructImpl(value)
+        try _default.TakeBlittableStruct(value)
     }
 
     public func returnStructWithReference() throws -> StructWithIReference {
-        try _default.ReturnStructWithReferenceImpl()
+        try _default.ReturnStructWithReference()
     }
 
     public func takeStructWithReference(_ value: StructWithIReference) throws {
-        try _default.TakeStructWithReferenceImpl(value)
+        try _default.TakeStructWithReference(value)
     }
 
     public func returnNonBlittableStruct() throws -> NonBlittableStruct {
-        try _default.ReturnNonBlittableStructImpl()
+        try _default.ReturnNonBlittableStruct()
     }
 
     public func takeNonBlittableStruct(_ value: NonBlittableStruct) throws {
-        try _default.TakeNonBlittableStructImpl(value)
+        try _default.TakeNonBlittableStruct(value)
     }
 
     public func fireEvent() throws {
-        try _default.FireEventImpl()
+        try _default.FireEvent()
     }
 
     public var blittableStructProperty : BlittableStruct {
-        get { try! _default.get_BlittableStructPropertyImpl() }
-        set { try! _default.put_BlittableStructPropertyImpl(newValue) }
+        get { try! _default.get_BlittableStructProperty() }
+        set { try! _default.put_BlittableStructProperty(newValue) }
     }
 
     public var nonBlittableStructProperty : NonBlittableStruct {
-        get { try! _default.get_NonBlittableStructPropertyImpl() }
-        set { try! _default.put_NonBlittableStructPropertyImpl(newValue) }
+        get { try! _default.get_NonBlittableStructProperty() }
+        set { try! _default.put_NonBlittableStructProperty(newValue) }
     }
 
     public var stringProperty : String {
-        get { try! _default.get_StringPropertyImpl() }
-        set { try! _default.put_StringPropertyImpl(newValue) }
+        get { try! _default.get_StringProperty() }
+        set { try! _default.put_StringProperty(newValue) }
     }
 
     public var structWithReferenceProperty : StructWithIReference {
-        get { try! _default.get_StructWithReferencePropertyImpl() }
-        set { try! _default.put_StructWithReferencePropertyImpl(newValue) }
+        get { try! _default.get_StructWithReferenceProperty() }
+        set { try! _default.put_StructWithReferenceProperty(newValue) }
     }
 
     public lazy var inEvent : Event<test_component.InDelegate> = {
       .init(
         add: { [weak self] in
           guard let this = self?._default else { return .init() }
-          return try! this.add_InEventImpl($0)
+          return try! this.add_InEvent($0)
         },
         remove: { [weak self] in
-         try? self?._default.remove_InEventImpl($0)
+         try? self?._default.remove_InEvent($0)
        }
       )
     }()
@@ -1275,10 +1275,10 @@ public final class Simple : WinRTClass {
       .init(
         add: { [weak self] in
           guard let this = self?._default else { return .init() }
-          return try! this.add_SignalEventImpl($0)
+          return try! this.add_SignalEvent($0)
         },
         remove: { [weak self] in
-         try? self?._default.remove_SignalEventImpl($0)
+         try? self?._default.remove_SignalEvent($0)
        }
       )
     }()
@@ -1287,10 +1287,10 @@ public final class Simple : WinRTClass {
       .init(
         add: { [weak self] in
           guard let this = self?._default else { return .init() }
-          return try! this.add_SimpleEventImpl($0)
+          return try! this.add_SimpleEvent($0)
         },
         remove: { [weak self] in
-         try? self?._default.remove_SimpleEventImpl($0)
+         try? self?._default.remove_SimpleEvent($0)
        }
       )
     }()
@@ -1303,20 +1303,20 @@ public final class Simple : WinRTClass {
 public final class StaticClass {
     private static let _IStaticClassStatics: __ABI_test_component.IStaticClassStatics = try! RoGetActivationFactory("test_component.StaticClass")
     public static func inEnum(_ value: Signed) throws -> String {
-        return try _IStaticClassStatics.InEnumImpl(value)
+        return try _IStaticClassStatics.InEnum(value)
     }
 
     public static func inNonBlittableStruct(_ value: NonBlittableStruct) throws -> String {
-        return try _IStaticClassStatics.InNonBlittableStructImpl(value)
+        return try _IStaticClassStatics.InNonBlittableStruct(value)
     }
 
     public static func takeBase(_ base: Base!) throws {
-        try _IStaticClassStatics.TakeBaseImpl(base)
+        try _IStaticClassStatics.TakeBase(base)
     }
 
     public static var enumProperty : Fruit {
-        get { try! _IStaticClassStatics.get_EnumPropertyImpl() }
-        set { try! _IStaticClassStatics.put_EnumPropertyImpl(newValue) }
+        get { try! _IStaticClassStatics.get_EnumProperty() }
+        set { try! _IStaticClassStatics.put_EnumProperty(newValue) }
     }
 
 }
@@ -1366,30 +1366,30 @@ open class UnsealedDerived : test_component.Base {
 
     override public init() {
         super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
-            try! Self._IUnsealedDerivedFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+            try! Self._IUnsealedDerivedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
 
     public init(_ prop: Int32) {
         super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
-            try! Self._IUnsealedDerivedFactory.CreateInstance2Impl(prop, baseInterface, &innerInterface)
+            try! Self._IUnsealedDerivedFactory.CreateInstance2(prop, baseInterface, &innerInterface)
         }
     }
 
     public init(_ prop1: String, _ prop2: Base!) {
         super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
-            try! Self._IUnsealedDerivedFactory.CreateInstance3Impl(prop1, prop2, baseInterface, &innerInterface)
+            try! Self._IUnsealedDerivedFactory.CreateInstance3(prop1, prop2, baseInterface, &innerInterface)
         }
     }
 
     public var prop : Int32 {
-        get { try! _default.get_PropImpl() }
-        set { try! _default.put_PropImpl(newValue) }
+        get { try! _default.get_Prop() }
+        set { try! _default.put_Prop(newValue) }
     }
 
     private lazy var _IUnsealedDerivedOverloads2: __ABI_test_component.IUnsealedDerivedOverloads2! = getInterfaceForCaching()
     open func onAfterDoTheThing() throws {
-        try _IUnsealedDerivedOverloads2.OnAfterDoTheThingImpl()
+        try _IUnsealedDerivedOverloads2.OnAfterDoTheThing()
     }
 
     @_spi(WinRTInternal)
@@ -1407,7 +1407,7 @@ open class UnsealedDerived : test_component.Base {
     public typealias Composable = IUnsealedDerivedOverloads2
     private lazy var _IUnsealedDerivedOverrides: __ABI_test_component.IUnsealedDerivedOverrides! = getInterfaceForCaching()
     open func onBeforeDoTheThing() throws {
-        try _IUnsealedDerivedOverrides.OnBeforeDoTheThingImpl()
+        try _IUnsealedDerivedOverrides.OnBeforeDoTheThing()
     }
 
     @_spi(WinRTInternal)
@@ -1465,7 +1465,7 @@ open class UnsealedDerived2 : test_component.UnsealedDerived {
 
     override public init(_ prop: Int32) {
         super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
-            try! Self._IUnsealedDerived2Factory.CreateInstanceImpl(prop, baseInterface, &innerInterface)
+            try! Self._IUnsealedDerived2Factory.CreateInstance(prop, baseInterface, &innerInterface)
         }
     }
 
@@ -1473,12 +1473,12 @@ open class UnsealedDerived2 : test_component.UnsealedDerived {
 
     override public init() {
         super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
-            try! Self._IUnsealedDerived2ProtectedFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+            try! Self._IUnsealedDerived2ProtectedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
 
     public func method() throws {
-        try _default.MethodImpl()
+        try _default.Method()
     }
 
     @_spi(WinRTInternal)
@@ -1536,7 +1536,7 @@ open class UnsealedDerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
 
     public init() {
         super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
-            try! Self._IUnsealedDerivedFromNoConstructorFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+            try! Self._IUnsealedDerivedFromNoConstructorFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
 
@@ -1648,7 +1648,7 @@ open class UnsealedDerivedNoOverrides : test_component.BaseNoOverrides {
 
     override public init() {
         super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
-            try! Self._IUnsealedDerivedNoOverridesProtectedFactory.CreateInstanceImpl(baseInterface, &innerInterface)
+            try! Self._IUnsealedDerivedNoOverridesProtectedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
 
@@ -1695,11 +1695,11 @@ public final class WeakReferencer : WinRTClass {
 
     private static let _IWeakReferencerFactory: __ABI_test_component.IWeakReferencerFactory = try! RoGetActivationFactory("test_component.WeakReferencer")
     public init(_ object: AnyIReferenceTarget!) {
-        super.init(try! Self._IWeakReferencerFactory.CreateInstanceImpl(object))
+        super.init(try! Self._IWeakReferencerFactory.CreateInstance(object))
     }
 
     public func resolve() throws -> AnyIReferenceTarget! {
-        try _default.ResolveImpl()
+        try _default.Resolve()
     }
 
     deinit {


### PR DESCRIPTION
Remove `Impl` from ABI function calls

Now that these APIs are publically callable as fallbacks for when need to access throwing property set/get, having this extra `Impl` tacked onto the end is an eyesore. plus, it's totally not necessary