### PR TITLE
Fix superfluous try/catch causing build warning

### DIFF
--- a/swiftwinrt/Resources/Support/Error.swift
+++ b/swiftwinrt/Resources/Support/Error.swift
@@ -180,12 +180,11 @@ public func failWith(error: Swift.Error) -> HRESULT {
         hresult = winrtError.hr
     }
 
-    do {
-        try message.withHStringRef {
-            _ = RoOriginateLanguageException(hresult, $0, nil)
-        }
-    } catch {
-        _ = RoOriginateLanguageException(hresult, nil, nil)
+    message.withHStringRef {
+      // Returns false if the string is empty or hresult is success,
+      // in which case there isn't more info to associate with the
+      // returned hresult.
+      _ = RoOriginateLanguageException(hresult, $0, nil)
     }
 
     return hresult


### PR DESCRIPTION
Causes:
```
[107/751] Building Swift Module 'WindowsFoundation' with 50 sources
C:\Code\arc\build\debug\generated\Frameworks\WinRT\Sources\WindowsFoundation\Support\error.swift:184:9: warning: no calls to throwing functions occur within 'try' expression
182 |
183 |     do {
184 |         try message.withHStringRef {
    |         `- warning: no calls to throwing functions occur within 'try' expression
185 |             _ = RoOriginateLanguageException(hresult, $0, nil)
186 |         }

C:\Code\arc\build\debug\generated\Frameworks\WinRT\Sources\WindowsFoundation\Support\error.swift:187:7: warning: 'catch' block is unreachable because no errors are thrown in 'do' block
185 |             _ = RoOriginateLanguageException(hresult, $0, nil)
186 |         }
187 |     } catch {
    |       `- warning: 'catch' block is unreachable because no errors are thrown in 'do' block
188 |         _ = RoOriginateLanguageException(hresult, nil, nil)
189 |     }
```