### PR TITLE
have winrtclass also use the bridge pattern

### DIFF
--- a/swiftwinrt/Resources/Support/Aggregation.swift
+++ b/swiftwinrt/Resources/Support/Aggregation.swift
@@ -52,9 +52,8 @@ public protocol ComposableImpl<Class> : AbiInterfaceBridge where SwiftABI: IInsp
 }
 
 @_spi(WinRTInternal)
-public protocol ComposableBridge<Class>: AbiBridge  {
-    associatedtype Class: WinRTClass
-    associatedtype Composable: ComposableImpl<Class>
+public protocol ComposableBridge<SwiftProjection>: AbiBridge where SwiftProjection: WinRTClass  {
+    associatedtype Composable: ComposableImpl<SwiftProjection>
 }
 
 // At a high level, aggregation simply requires the WinRT object to have a pointer back to the Swift world, so that it can call

--- a/swiftwinrt/Resources/Support/Aggregation.swift
+++ b/swiftwinrt/Resources/Support/Aggregation.swift
@@ -51,6 +51,12 @@ public protocol ComposableImpl<Class> : AbiInterfaceBridge where SwiftABI: IInsp
     static func makeAbi() -> CABI
 }
 
+@_spi(WinRTInternal)
+public protocol ComposableBridge<Class>: AbiBridge  {
+    associatedtype Class: WinRTClass
+    associatedtype Composable: ComposableImpl<Class>
+}
+
 // At a high level, aggregation simply requires the WinRT object to have a pointer back to the Swift world, so that it can call
 // overridable methods on the class. This Swift pointer is given to the WinRT object during construction. The construction of the
 // WinRT object returns us two different pointers:

--- a/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
+++ b/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
@@ -21,14 +21,17 @@ public protocol AbiInterface {
 public protocol AbiBridge {
     associatedtype CABI
     associatedtype SwiftProjection
-    static func makeAbi() -> CABI
     static func from(abi: ComPtr<CABI>?) -> SwiftProjection?
 }
 
-public protocol ReferenceBridge : AbiBridge, HasIID {
+public protocol SwiftImplementableBridge : AbiBridge {
+    static func makeAbi() -> CABI
 }
 
-public protocol AbiInterfaceBridge : AbiBridge & AbiInterface {
+public protocol ReferenceBridge : SwiftImplementableBridge, HasIID {
+}
+
+public protocol AbiInterfaceBridge : SwiftImplementableBridge & AbiInterface {
 }
 
 public protocol AbiInterfaceImpl<Bridge> {

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -2040,11 +2040,10 @@ public init<Composable: ComposableImpl>(
         if (auto default_interface = type.default_interface)
         {
             const bool composable = type.is_composable();
-            w.write("@_spi(WinRTInternal)\n");
             w.write("public enum %: % {\n", bind_bridge_name(type), composable ? "ComposableBridge" : "AbiBridge");
             {
                 auto indent = w.push_indent();
-                w.write("public typealias Swift = %\n", type.swift_type_name());
+                w.write("public typealias SwiftProjection = %\n", type.swift_type_name());
                 w.write("public typealias CABI = %\n", bind_type_mangled(default_interface));
                 // We unwrap composable types to try and get to any derived type.
                 // If not composable, then create a new instance
@@ -2370,8 +2369,7 @@ public init<Composable: ComposableImpl>(
 
         bool use_iinspectable_vtable = type_name(overrides) == type_name(*default_interface);
 
-        auto format = R"(^@_spi(WinRTInternal)
-public enum % : ComposableImpl {
+        auto format = R"(public enum % : ComposableImpl {
     public typealias CABI = %
     public typealias SwiftABI = %
     public typealias Class = %

--- a/swiftwinrt/code_writers/common_writers.h
+++ b/swiftwinrt/code_writers/common_writers.h
@@ -280,7 +280,7 @@ namespace swiftwinrt
             auto ptrVal = isOut ? std::string(name) : w.write_temp("ComPtr(%)", name);
             if (is_class(type))
             {
-                w.write(".from(abi: %)", ptrVal);
+                w.write("%.from(abi: %)", bind_bridge_fullname(*type), ptrVal);
             }
             else
             {

--- a/swiftwinrt/file_writers.h
+++ b/swiftwinrt/file_writers.h
@@ -232,6 +232,7 @@ namespace swiftwinrt
             auto impl_names = w.push_impl_names(true);
             w.write("%", w.filter.bind_each<write_interface_impl>(members.interfaces));
             w.write("%", w.filter.bind_each<write_delegate_implementation>(members.delegates));
+            w.write("%", w.filter.bind_each<write_class_bridge>(members.classes));
         }
         w.swap();
         write_preamble(w, /* swift_code: */ true);

--- a/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+ABI.swift
@@ -1096,7 +1096,7 @@ public enum __ABI_Windows_Foundation {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_QueryParsed(pThis, &ppWwwFormUrlDecoderAbi))
                 }
             }
-            return .from(abi: ppWwwFormUrlDecoder)
+            return __IMPL_Windows_Foundation.WwwFormUrlDecoderBridge.from(abi: ppWwwFormUrlDecoder)
         }
 
         public func get_RawUri() throws -> String {
@@ -1154,7 +1154,7 @@ public enum __ABI_Windows_Foundation {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CombineUri(pThis, _relativeUri.get(), &instanceAbi))
                 }
             }
-            return .from(abi: instance)
+            return __IMPL_Windows_Foundation.UriBridge.from(abi: instance)
         }
 
     }

--- a/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
@@ -425,9 +425,8 @@ public enum __IMPL_Windows_Foundation {
             return handler
         }
     }
-    @_spi(WinRTInternal)
     public enum DeferralBridge: AbiBridge {
-        public typealias Swift = Deferral
+        public typealias SwiftProjection = Deferral
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIDeferral
         public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIDeferral>?) -> Deferral? {
             guard let abi = abi else { return nil }
@@ -435,9 +434,8 @@ public enum __IMPL_Windows_Foundation {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum MemoryBufferBridge: AbiBridge {
-        public typealias Swift = MemoryBuffer
+        public typealias SwiftProjection = MemoryBuffer
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIMemoryBuffer
         public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIMemoryBuffer>?) -> MemoryBuffer? {
             guard let abi = abi else { return nil }
@@ -445,9 +443,8 @@ public enum __IMPL_Windows_Foundation {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum UriBridge: AbiBridge {
-        public typealias Swift = Uri
+        public typealias SwiftProjection = Uri
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIUriRuntimeClass
         public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIUriRuntimeClass>?) -> Uri? {
             guard let abi = abi else { return nil }
@@ -455,9 +452,8 @@ public enum __IMPL_Windows_Foundation {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum WwwFormUrlDecoderBridge: AbiBridge {
-        public typealias Swift = WwwFormUrlDecoder
+        public typealias SwiftProjection = WwwFormUrlDecoder
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass
         public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass>?) -> WwwFormUrlDecoder? {
             guard let abi = abi else { return nil }

--- a/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
@@ -425,4 +425,44 @@ public enum __IMPL_Windows_Foundation {
             return handler
         }
     }
+    @_spi(WinRTInternal)
+    public enum DeferralBridge: AbiBridge {
+        public typealias Swift = Deferral
+        public typealias CABI = __x_ABI_CWindows_CFoundation_CIDeferral
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIDeferral>?) -> Deferral? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum MemoryBufferBridge: AbiBridge {
+        public typealias Swift = MemoryBuffer
+        public typealias CABI = __x_ABI_CWindows_CFoundation_CIMemoryBuffer
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIMemoryBuffer>?) -> MemoryBuffer? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum UriBridge: AbiBridge {
+        public typealias Swift = Uri
+        public typealias CABI = __x_ABI_CWindows_CFoundation_CIUriRuntimeClass
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIUriRuntimeClass>?) -> Uri? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum WwwFormUrlDecoderBridge: AbiBridge {
+        public typealias Swift = WwwFormUrlDecoder
+        public typealias CABI = __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass>?) -> WwwFormUrlDecoder? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
 }

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
@@ -124,4 +124,34 @@ public enum __IMPL_Windows_Foundation_Collections {
 
     }
 
+    @_spi(WinRTInternal)
+    public enum PropertySetBridge: AbiBridge {
+        public typealias Swift = PropertySet
+        public typealias CABI = __x_ABI_CWindows_CFoundation_CCollections_CIPropertySet
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CCollections_CIPropertySet>?) -> PropertySet? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StringMapBridge: AbiBridge {
+        public typealias Swift = StringMap
+        public typealias CABI = __x_ABI_C__FIMap_2_HSTRING_HSTRING
+        public static func from(abi: ComPtr<__x_ABI_C__FIMap_2_HSTRING_HSTRING>?) -> StringMap? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum ValueSetBridge: AbiBridge {
+        public typealias Swift = ValueSet
+        public typealias CABI = __x_ABI_CWindows_CFoundation_CCollections_CIPropertySet
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CCollections_CIPropertySet>?) -> ValueSet? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
 }

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections+Impl.swift
@@ -124,9 +124,8 @@ public enum __IMPL_Windows_Foundation_Collections {
 
     }
 
-    @_spi(WinRTInternal)
     public enum PropertySetBridge: AbiBridge {
-        public typealias Swift = PropertySet
+        public typealias SwiftProjection = PropertySet
         public typealias CABI = __x_ABI_CWindows_CFoundation_CCollections_CIPropertySet
         public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CCollections_CIPropertySet>?) -> PropertySet? {
             guard let abi = abi else { return nil }
@@ -134,9 +133,8 @@ public enum __IMPL_Windows_Foundation_Collections {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StringMapBridge: AbiBridge {
-        public typealias Swift = StringMap
+        public typealias SwiftProjection = StringMap
         public typealias CABI = __x_ABI_C__FIMap_2_HSTRING_HSTRING
         public static func from(abi: ComPtr<__x_ABI_C__FIMap_2_HSTRING_HSTRING>?) -> StringMap? {
             guard let abi = abi else { return nil }
@@ -144,9 +142,8 @@ public enum __IMPL_Windows_Foundation_Collections {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum ValueSetBridge: AbiBridge {
-        public typealias Swift = ValueSet
+        public typealias SwiftProjection = ValueSet
         public typealias CABI = __x_ABI_CWindows_CFoundation_CCollections_CIPropertySet
         public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CCollections_CIPropertySet>?) -> ValueSet? {
             guard let abi = abi else { return nil }

--- a/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.Collections.swift
@@ -22,12 +22,6 @@ public final class PropertySet : WinRTClass, IObservableMap, IMap, IIterable, IP
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CCollections_CIPropertySet>?) -> PropertySet? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -121,12 +115,6 @@ public final class StringMap : WinRTClass, IMap, IIterable, IObservableMap {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_C__FIMap_2_HSTRING_HSTRING>?) -> StringMap? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -215,12 +203,6 @@ public final class ValueSet : WinRTClass, IObservableMap, IMap, IIterable, IProp
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CCollections_CIPropertySet>?) -> ValueSet? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -21,12 +21,6 @@ public final class Deferral : WinRTClass, IClosable {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIDeferral>?) -> Deferral? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -70,12 +64,6 @@ public final class MemoryBuffer : WinRTClass, IClosable, IMemoryBuffer {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIMemoryBuffer>?) -> MemoryBuffer? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -116,12 +104,6 @@ public final class Uri : WinRTClass, IStringable {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIUriRuntimeClass>?) -> Uri? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -273,12 +255,6 @@ public final class WwwFormUrlDecoder : WinRTClass, IIterable, IVectorView {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass>?) -> WwwFormUrlDecoder? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)

--- a/tests/test_component/Sources/test_component/Windows.Storage+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage+ABI.swift
@@ -1056,7 +1056,7 @@ public enum __ABI_Windows_Storage {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.TryGetChangeTracker(pThis, &resultAbi))
                 }
             }
-            return .from(abi: result)
+            return __IMPL_Windows_Storage.StorageLibraryChangeTrackerBridge.from(abi: result)
         }
 
     }
@@ -1425,7 +1425,7 @@ public enum __ABI_Windows_Storage {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Properties(pThis, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage_FileProperties.StorageItemContentPropertiesBridge.from(abi: value)
         }
 
     }
@@ -1632,7 +1632,7 @@ public enum __ABI_Windows_Storage {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Provider(pThis, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage.StorageProviderBridge.from(abi: value)
         }
 
     }
@@ -1753,7 +1753,7 @@ public enum __ABI_Windows_Storage {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetChangeReader(pThis, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage.StorageLibraryChangeReaderBridge.from(abi: value)
         }
 
         public func Enable() throws {
@@ -1902,7 +1902,7 @@ extension __ABI_Windows_Storage {
         Invoke: {
             do {
                 guard let __unwrapped__instance = StreamedFileDataRequestedHandlerWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-                let stream: test_component.StreamedFileDataRequest? = .from(abi: ComPtr($1))
+                let stream: test_component.StreamedFileDataRequest? = __IMPL_Windows_Storage.StreamedFileDataRequestBridge.from(abi: ComPtr($1))
                 try __unwrapped__instance(stream)
                 return S_OK
             } catch { return failWith(error: error) } 

--- a/tests/test_component/Sources/test_component/Windows.Storage+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage+Impl.swift
@@ -781,4 +781,84 @@ public enum __IMPL_Windows_Storage {
             return handler
         }
     }
+    @_spi(WinRTInternal)
+    public enum StorageFileBridge: AbiBridge {
+        public typealias Swift = StorageFile
+        public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFile
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageFile>?) -> StorageFile? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StorageFolderBridge: AbiBridge {
+        public typealias Swift = StorageFolder
+        public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFolder
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageFolder>?) -> StorageFolder? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StorageLibraryChangeBridge: AbiBridge {
+        public typealias Swift = StorageLibraryChange
+        public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageLibraryChange
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChange>?) -> StorageLibraryChange? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StorageLibraryChangeReaderBridge: AbiBridge {
+        public typealias Swift = StorageLibraryChangeReader
+        public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader>?) -> StorageLibraryChangeReader? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StorageLibraryChangeTrackerBridge: AbiBridge {
+        public typealias Swift = StorageLibraryChangeTracker
+        public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker>?) -> StorageLibraryChangeTracker? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StorageProviderBridge: AbiBridge {
+        public typealias Swift = StorageProvider
+        public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageProvider
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageProvider>?) -> StorageProvider? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StorageStreamTransactionBridge: AbiBridge {
+        public typealias Swift = StorageStreamTransaction
+        public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageStreamTransaction
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageStreamTransaction>?) -> StorageStreamTransaction? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StreamedFileDataRequestBridge: AbiBridge {
+        public typealias Swift = StreamedFileDataRequest
+        public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIOutputStream
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIOutputStream>?) -> StreamedFileDataRequest? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
 }

--- a/tests/test_component/Sources/test_component/Windows.Storage+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage+Impl.swift
@@ -781,9 +781,8 @@ public enum __IMPL_Windows_Storage {
             return handler
         }
     }
-    @_spi(WinRTInternal)
     public enum StorageFileBridge: AbiBridge {
-        public typealias Swift = StorageFile
+        public typealias SwiftProjection = StorageFile
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFile
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageFile>?) -> StorageFile? {
             guard let abi = abi else { return nil }
@@ -791,9 +790,8 @@ public enum __IMPL_Windows_Storage {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StorageFolderBridge: AbiBridge {
-        public typealias Swift = StorageFolder
+        public typealias SwiftProjection = StorageFolder
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFolder
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageFolder>?) -> StorageFolder? {
             guard let abi = abi else { return nil }
@@ -801,9 +799,8 @@ public enum __IMPL_Windows_Storage {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StorageLibraryChangeBridge: AbiBridge {
-        public typealias Swift = StorageLibraryChange
+        public typealias SwiftProjection = StorageLibraryChange
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageLibraryChange
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChange>?) -> StorageLibraryChange? {
             guard let abi = abi else { return nil }
@@ -811,9 +808,8 @@ public enum __IMPL_Windows_Storage {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StorageLibraryChangeReaderBridge: AbiBridge {
-        public typealias Swift = StorageLibraryChangeReader
+        public typealias SwiftProjection = StorageLibraryChangeReader
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader>?) -> StorageLibraryChangeReader? {
             guard let abi = abi else { return nil }
@@ -821,9 +817,8 @@ public enum __IMPL_Windows_Storage {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StorageLibraryChangeTrackerBridge: AbiBridge {
-        public typealias Swift = StorageLibraryChangeTracker
+        public typealias SwiftProjection = StorageLibraryChangeTracker
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker>?) -> StorageLibraryChangeTracker? {
             guard let abi = abi else { return nil }
@@ -831,9 +826,8 @@ public enum __IMPL_Windows_Storage {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StorageProviderBridge: AbiBridge {
-        public typealias Swift = StorageProvider
+        public typealias SwiftProjection = StorageProvider
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageProvider
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageProvider>?) -> StorageProvider? {
             guard let abi = abi else { return nil }
@@ -841,9 +835,8 @@ public enum __IMPL_Windows_Storage {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StorageStreamTransactionBridge: AbiBridge {
-        public typealias Swift = StorageStreamTransaction
+        public typealias SwiftProjection = StorageStreamTransaction
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageStreamTransaction
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageStreamTransaction>?) -> StorageStreamTransaction? {
             guard let abi = abi else { return nil }
@@ -851,9 +844,8 @@ public enum __IMPL_Windows_Storage {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StreamedFileDataRequestBridge: AbiBridge {
-        public typealias Swift = StreamedFileDataRequest
+        public typealias SwiftProjection = StreamedFileDataRequest
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIOutputStream
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIOutputStream>?) -> StreamedFileDataRequest? {
             guard let abi = abi else { return nil }

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+Impl.swift
@@ -45,9 +45,8 @@ public enum __IMPL_Windows_Storage_FileProperties {
 
     }
 
-    @_spi(WinRTInternal)
     public enum BasicPropertiesBridge: AbiBridge {
-        public typealias Swift = BasicProperties
+        public typealias SwiftProjection = BasicProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties>?) -> BasicProperties? {
             guard let abi = abi else { return nil }
@@ -55,9 +54,8 @@ public enum __IMPL_Windows_Storage_FileProperties {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum DocumentPropertiesBridge: AbiBridge {
-        public typealias Swift = DocumentProperties
+        public typealias SwiftProjection = DocumentProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties>?) -> DocumentProperties? {
             guard let abi = abi else { return nil }
@@ -65,9 +63,8 @@ public enum __IMPL_Windows_Storage_FileProperties {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum ImagePropertiesBridge: AbiBridge {
-        public typealias Swift = ImageProperties
+        public typealias SwiftProjection = ImageProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties>?) -> ImageProperties? {
             guard let abi = abi else { return nil }
@@ -75,9 +72,8 @@ public enum __IMPL_Windows_Storage_FileProperties {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum MusicPropertiesBridge: AbiBridge {
-        public typealias Swift = MusicProperties
+        public typealias SwiftProjection = MusicProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties>?) -> MusicProperties? {
             guard let abi = abi else { return nil }
@@ -85,9 +81,8 @@ public enum __IMPL_Windows_Storage_FileProperties {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StorageItemContentPropertiesBridge: AbiBridge {
-        public typealias Swift = StorageItemContentProperties
+        public typealias SwiftProjection = StorageItemContentProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties>?) -> StorageItemContentProperties? {
             guard let abi = abi else { return nil }
@@ -95,9 +90,8 @@ public enum __IMPL_Windows_Storage_FileProperties {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StorageItemThumbnailBridge: AbiBridge {
-        public typealias Swift = StorageItemThumbnail
+        public typealias SwiftProjection = StorageItemThumbnail
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamWithContentType
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamWithContentType>?) -> StorageItemThumbnail? {
             guard let abi = abi else { return nil }
@@ -105,9 +99,8 @@ public enum __IMPL_Windows_Storage_FileProperties {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum VideoPropertiesBridge: AbiBridge {
-        public typealias Swift = VideoProperties
+        public typealias SwiftProjection = VideoProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties>?) -> VideoProperties? {
             guard let abi = abi else { return nil }

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties+Impl.swift
@@ -45,4 +45,74 @@ public enum __IMPL_Windows_Storage_FileProperties {
 
     }
 
+    @_spi(WinRTInternal)
+    public enum BasicPropertiesBridge: AbiBridge {
+        public typealias Swift = BasicProperties
+        public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties>?) -> BasicProperties? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum DocumentPropertiesBridge: AbiBridge {
+        public typealias Swift = DocumentProperties
+        public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties>?) -> DocumentProperties? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum ImagePropertiesBridge: AbiBridge {
+        public typealias Swift = ImageProperties
+        public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties>?) -> ImageProperties? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum MusicPropertiesBridge: AbiBridge {
+        public typealias Swift = MusicProperties
+        public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties>?) -> MusicProperties? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StorageItemContentPropertiesBridge: AbiBridge {
+        public typealias Swift = StorageItemContentProperties
+        public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties>?) -> StorageItemContentProperties? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StorageItemThumbnailBridge: AbiBridge {
+        public typealias Swift = StorageItemThumbnail
+        public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamWithContentType
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamWithContentType>?) -> StorageItemThumbnail? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum VideoPropertiesBridge: AbiBridge {
+        public typealias Swift = VideoProperties
+        public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties>?) -> VideoProperties? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
 }

--- a/tests/test_component/Sources/test_component/Windows.Storage.FileProperties.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.FileProperties.swift
@@ -29,12 +29,6 @@ public final class BasicProperties : WinRTClass, IStorageItemExtraProperties {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties>?) -> BasicProperties? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -90,12 +84,6 @@ public final class DocumentProperties : WinRTClass, IStorageItemExtraProperties 
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties>?) -> DocumentProperties? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -161,12 +149,6 @@ public final class ImageProperties : WinRTClass, IStorageItemExtraProperties {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties>?) -> ImageProperties? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -275,12 +257,6 @@ public final class MusicProperties : WinRTClass, IStorageItemExtraProperties {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties>?) -> MusicProperties? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -416,12 +392,6 @@ public final class StorageItemContentProperties : WinRTClass, IStorageItemExtraP
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties>?) -> StorageItemContentProperties? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -482,12 +452,6 @@ public final class StorageItemThumbnail : WinRTClass, test_component.IClosable, 
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamWithContentType>?) -> StorageItemThumbnail? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -612,12 +576,6 @@ public final class VideoProperties : WinRTClass, IStorageItemExtraProperties {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties>?) -> VideoProperties? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search+ABI.swift
@@ -276,7 +276,7 @@ public enum __ABI_Windows_Storage_Search {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFileQueryOverloadDefault(pThis, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage_Search.StorageFileQueryResultBridge.from(abi: value)
         }
 
         open func CreateFileQuery(_ query: test_component.CommonFileQuery) throws -> test_component.StorageFileQueryResult? {
@@ -285,7 +285,7 @@ public enum __ABI_Windows_Storage_Search {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFileQuery(pThis, query, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage_Search.StorageFileQueryResultBridge.from(abi: value)
         }
 
         open func CreateFileQueryWithOptions(_ queryOptions: test_component.QueryOptions?) throws -> test_component.StorageFileQueryResult? {
@@ -294,7 +294,7 @@ public enum __ABI_Windows_Storage_Search {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFileQueryWithOptions(pThis, RawPointer(queryOptions), &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage_Search.StorageFileQueryResultBridge.from(abi: value)
         }
 
         open func CreateFolderQueryOverloadDefault() throws -> test_component.StorageFolderQueryResult? {
@@ -303,7 +303,7 @@ public enum __ABI_Windows_Storage_Search {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFolderQueryOverloadDefault(pThis, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage_Search.StorageFolderQueryResultBridge.from(abi: value)
         }
 
         open func CreateFolderQuery(_ query: test_component.CommonFolderQuery) throws -> test_component.StorageFolderQueryResult? {
@@ -312,7 +312,7 @@ public enum __ABI_Windows_Storage_Search {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFolderQuery(pThis, query, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage_Search.StorageFolderQueryResultBridge.from(abi: value)
         }
 
         open func CreateFolderQueryWithOptions(_ queryOptions: test_component.QueryOptions?) throws -> test_component.StorageFolderQueryResult? {
@@ -321,7 +321,7 @@ public enum __ABI_Windows_Storage_Search {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFolderQueryWithOptions(pThis, RawPointer(queryOptions), &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage_Search.StorageFolderQueryResultBridge.from(abi: value)
         }
 
         open func CreateItemQuery() throws -> test_component.StorageItemQueryResult? {
@@ -330,7 +330,7 @@ public enum __ABI_Windows_Storage_Search {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateItemQuery(pThis, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage_Search.StorageItemQueryResultBridge.from(abi: value)
         }
 
         open func CreateItemQueryWithOptions(_ queryOptions: test_component.QueryOptions?) throws -> test_component.StorageItemQueryResult? {
@@ -339,7 +339,7 @@ public enum __ABI_Windows_Storage_Search {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateItemQueryWithOptions(pThis, RawPointer(queryOptions), &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage_Search.StorageItemQueryResultBridge.from(abi: value)
         }
 
         open func GetFilesAsync(_ query: test_component.CommonFileQuery, _ startIndex: UInt32, _ maxItemsToRetrieve: UInt32) throws -> test_component.AnyIAsyncOperation<test_component.AnyIVectorView<test_component.StorageFile?>?>? {
@@ -473,7 +473,7 @@ public enum __ABI_Windows_Storage_Search {
         CreateFileQueryWithOptions: {
             do {
                 guard let __unwrapped__instance = IStorageFolderQueryOperationsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-                let queryOptions: test_component.QueryOptions? = .from(abi: ComPtr($1))
+                let queryOptions: test_component.QueryOptions? = __IMPL_Windows_Storage_Search.QueryOptionsBridge.from(abi: ComPtr($1))
                 let value = try __unwrapped__instance.createFileQueryWithOptions(queryOptions)
                 value?.copyTo($2)
                 return S_OK
@@ -502,7 +502,7 @@ public enum __ABI_Windows_Storage_Search {
         CreateFolderQueryWithOptions: {
             do {
                 guard let __unwrapped__instance = IStorageFolderQueryOperationsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-                let queryOptions: test_component.QueryOptions? = .from(abi: ComPtr($1))
+                let queryOptions: test_component.QueryOptions? = __IMPL_Windows_Storage_Search.QueryOptionsBridge.from(abi: ComPtr($1))
                 let value = try __unwrapped__instance.createFolderQueryWithOptions(queryOptions)
                 value?.copyTo($2)
                 return S_OK
@@ -521,7 +521,7 @@ public enum __ABI_Windows_Storage_Search {
         CreateItemQueryWithOptions: {
             do {
                 guard let __unwrapped__instance = IStorageFolderQueryOperationsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-                let queryOptions: test_component.QueryOptions? = .from(abi: ComPtr($1))
+                let queryOptions: test_component.QueryOptions? = __IMPL_Windows_Storage_Search.QueryOptionsBridge.from(abi: ComPtr($1))
                 let value = try __unwrapped__instance.createItemQueryWithOptions(queryOptions)
                 value?.copyTo($2)
                 return S_OK
@@ -591,7 +591,7 @@ public enum __ABI_Windows_Storage_Search {
         AreQueryOptionsSupported: {
             do {
                 guard let __unwrapped__instance = IStorageFolderQueryOperationsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-                let queryOptions: test_component.QueryOptions? = .from(abi: ComPtr($1))
+                let queryOptions: test_component.QueryOptions? = __IMPL_Windows_Storage_Search.QueryOptionsBridge.from(abi: ComPtr($1))
                 let value = try __unwrapped__instance.areQueryOptionsSupported(queryOptions)
                 $2?.initialize(to: .init(from: value))
                 return S_OK
@@ -684,7 +684,7 @@ public enum __ABI_Windows_Storage_Search {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_Folder(pThis, &containerAbi))
                 }
             }
-            return .from(abi: container)
+            return __IMPL_Windows_Storage.StorageFolderBridge.from(abi: container)
         }
 
         open func add_ContentsChanged(_ handler: TypedEventHandler<test_component.AnyIStorageQueryResultBase?, Any?>?) throws -> EventRegistrationToken {
@@ -736,7 +736,7 @@ public enum __ABI_Windows_Storage_Search {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetCurrentQueryOptions(pThis, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage_Search.QueryOptionsBridge.from(abi: value)
         }
 
         open func ApplyNewQueryOptions(_ newQueryOptions: test_component.QueryOptions?) throws {
@@ -845,7 +845,7 @@ public enum __ABI_Windows_Storage_Search {
         ApplyNewQueryOptions: {
             do {
                 guard let __unwrapped__instance = IStorageQueryResultBaseWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-                let newQueryOptions: test_component.QueryOptions? = .from(abi: ComPtr($1))
+                let newQueryOptions: test_component.QueryOptions? = __IMPL_Windows_Storage_Search.QueryOptionsBridge.from(abi: ComPtr($1))
                 try __unwrapped__instance.applyNewQueryOptions(newQueryOptions)
                 return S_OK
             } catch { return failWith(error: error) } 

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
@@ -191,4 +191,44 @@ public enum __IMPL_Windows_Storage_Search {
 
     }
 
+    @_spi(WinRTInternal)
+    public enum QueryOptionsBridge: AbiBridge {
+        public typealias Swift = QueryOptions
+        public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIQueryOptions>?) -> QueryOptions? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StorageFileQueryResultBridge: AbiBridge {
+        public typealias Swift = StorageFileQueryResult
+        public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult>?) -> StorageFileQueryResult? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StorageFolderQueryResultBridge: AbiBridge {
+        public typealias Swift = StorageFolderQueryResult
+        public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult>?) -> StorageFolderQueryResult? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum StorageItemQueryResultBridge: AbiBridge {
+        public typealias Swift = StorageItemQueryResult
+        public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult>?) -> StorageItemQueryResult? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
 }

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
@@ -191,9 +191,8 @@ public enum __IMPL_Windows_Storage_Search {
 
     }
 
-    @_spi(WinRTInternal)
     public enum QueryOptionsBridge: AbiBridge {
-        public typealias Swift = QueryOptions
+        public typealias SwiftProjection = QueryOptions
         public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIQueryOptions>?) -> QueryOptions? {
             guard let abi = abi else { return nil }
@@ -201,9 +200,8 @@ public enum __IMPL_Windows_Storage_Search {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StorageFileQueryResultBridge: AbiBridge {
-        public typealias Swift = StorageFileQueryResult
+        public typealias SwiftProjection = StorageFileQueryResult
         public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult>?) -> StorageFileQueryResult? {
             guard let abi = abi else { return nil }
@@ -211,9 +209,8 @@ public enum __IMPL_Windows_Storage_Search {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StorageFolderQueryResultBridge: AbiBridge {
-        public typealias Swift = StorageFolderQueryResult
+        public typealias SwiftProjection = StorageFolderQueryResult
         public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult>?) -> StorageFolderQueryResult? {
             guard let abi = abi else { return nil }
@@ -221,9 +218,8 @@ public enum __IMPL_Windows_Storage_Search {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum StorageItemQueryResultBridge: AbiBridge {
-        public typealias Swift = StorageItemQueryResult
+        public typealias SwiftProjection = StorageItemQueryResult
         public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult>?) -> StorageItemQueryResult? {
             guard let abi = abi else { return nil }

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
@@ -29,12 +29,6 @@ public final class QueryOptions : WinRTClass {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIQueryOptions>?) -> QueryOptions? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -149,12 +143,6 @@ public final class StorageFileQueryResult : WinRTClass, IStorageQueryResultBase 
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult>?) -> StorageFileQueryResult? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -251,12 +239,6 @@ public final class StorageFolderQueryResult : WinRTClass, IStorageQueryResultBas
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult>?) -> StorageFolderQueryResult? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -343,12 +325,6 @@ public final class StorageItemQueryResult : WinRTClass, IStorageQueryResultBase 
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult>?) -> StorageItemQueryResult? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams+ABI.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams+ABI.swift
@@ -149,7 +149,7 @@ public enum __ABI_Windows_Storage_Streams {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateCopyFromMemoryBuffer(pThis, _input, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Storage_Streams.BufferBridge.from(abi: value)
         }
 
         public func CreateMemoryBufferOverIBuffer(_ input: test_component.AnyIBuffer?) throws -> test_component.MemoryBuffer? {
@@ -160,7 +160,7 @@ public enum __ABI_Windows_Storage_Streams {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateMemoryBufferOverIBuffer(pThis, _input, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_Windows_Foundation.MemoryBufferBridge.from(abi: value)
         }
 
     }

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams+Impl.swift
@@ -400,9 +400,8 @@ public enum __IMPL_Windows_Storage_Streams {
 
     }
 
-    @_spi(WinRTInternal)
     public enum BufferBridge: AbiBridge {
-        public typealias Swift = Buffer
+        public typealias SwiftProjection = Buffer
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIBuffer
         public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?) -> Buffer? {
             guard let abi = abi else { return nil }

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams+Impl.swift
@@ -400,4 +400,14 @@ public enum __IMPL_Windows_Storage_Streams {
 
     }
 
+    @_spi(WinRTInternal)
+    public enum BufferBridge: AbiBridge {
+        public typealias Swift = Buffer
+        public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIBuffer
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?) -> Buffer? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
 }

--- a/tests/test_component/Sources/test_component/Windows.Storage.Streams.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Streams.swift
@@ -21,12 +21,6 @@ public final class Buffer : WinRTClass, IBufferByteAccess, IBuffer {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?) -> Buffer? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }

--- a/tests/test_component/Sources/test_component/Windows.Storage.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.swift
@@ -110,12 +110,6 @@ public final class StorageFile : WinRTClass, IStorageItem, test_component.IRando
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageFile>?) -> StorageFile? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -388,12 +382,6 @@ public final class StorageFolder : WinRTClass, IStorageItem, IStorageFolder, tes
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageFolder>?) -> StorageFolder? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -705,12 +693,6 @@ public final class StorageLibraryChange : WinRTClass {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChange>?) -> StorageLibraryChange? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -759,12 +741,6 @@ public final class StorageLibraryChangeReader : WinRTClass {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader>?) -> StorageLibraryChangeReader? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -795,12 +771,6 @@ public final class StorageLibraryChangeTracker : WinRTClass {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker>?) -> StorageLibraryChangeTracker? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -839,12 +809,6 @@ public final class StorageProvider : WinRTClass {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageProvider>?) -> StorageProvider? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -888,12 +852,6 @@ public final class StorageStreamTransaction : WinRTClass, test_component.IClosab
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageStreamTransaction>?) -> StorageStreamTransaction? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -934,12 +892,6 @@ public final class StreamedFileDataRequest : WinRTClass, test_component.IClosabl
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIOutputStream>?) -> StreamedFileDataRequest? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -252,7 +252,7 @@ public enum __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetPendingAsync(pThis, &resultAbi))
                 }
             }
-            return .from(abi: result)
+            return __IMPL_test_component.AsyncOperationIntBridge.from(abi: result)
         }
 
     }
@@ -391,7 +391,7 @@ public enum __ABI_test_component {
     public class IBaseCollectionProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseCollectionProtectedFactory }
 
-        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.BaseCollection.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IVectorBase {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<__IMPL_test_component.BaseCollectionBridge.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IVectorBase {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -414,7 +414,7 @@ public enum __ABI_test_component {
     public class IBaseNoOverridesProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseNoOverridesProtectedFactory }
 
-        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.BaseNoOverrides.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBaseNoOverrides {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<__IMPL_test_component.BaseNoOverridesBridge.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBaseNoOverrides {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -439,7 +439,7 @@ public enum __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFromString(pThis, _value.get(), &resultAbi))
                 }
             }
-            return .from(abi: result)
+            return __IMPL_test_component.BaseNoOverridesBridge.from(abi: result)
         }
 
     }
@@ -458,7 +458,7 @@ public enum __ABI_test_component {
     public class IBaseProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIBaseProtectedFactory }
 
-        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.Base.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBase {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<__IMPL_test_component.BaseBridge.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IBase {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -483,7 +483,7 @@ public enum __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFromString(pThis, _value.get(), &resultAbi))
                 }
             }
-            return .from(abi: result)
+            return __IMPL_test_component.BaseBridge.from(abi: result)
         }
 
     }
@@ -837,7 +837,7 @@ public enum __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_BaseProperty(pThis, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_test_component.BaseBridge.from(abi: value)
         }
 
         public func put_BaseProperty(_ value: test_component.Base?) throws {
@@ -852,7 +852,7 @@ public enum __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.get_BaseNoOverridesProperty(pThis, &valueAbi))
                 }
             }
-            return .from(abi: value)
+            return __IMPL_test_component.BaseNoOverridesBridge.from(abi: value)
         }
 
         public func put_BaseNoOverridesProperty(_ value: test_component.BaseNoOverrides?) throws {
@@ -1109,7 +1109,7 @@ public enum __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetDeferral(pThis, &resultAbi))
                 }
             }
-            return .from(abi: result)
+            return __IMPL_Windows_Foundation.DeferralBridge.from(abi: result)
         }
 
         public func IncrementCounter() throws {
@@ -1160,7 +1160,7 @@ public enum __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.CreateFromString(pThis, _value.get(), &resultAbi))
                 }
             }
-            return .from(abi: result)
+            return __IMPL_test_component.DerivedBridge.from(abi: result)
         }
 
     }
@@ -1711,7 +1711,7 @@ public enum __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.GetNullClass(pThis, &resultAbi))
                 }
             }
-            return .from(abi: result)
+            return __IMPL_test_component.NoopClosableBridge.from(abi: result)
         }
 
         public func GetNullDelegate() throws -> test_component.VoidToVoidDelegate? {
@@ -2146,7 +2146,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerived2Factory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerived2Factory }
 
-        public func CreateInstance(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived2.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
+        public func CreateInstance(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<__IMPL_test_component.UnsealedDerived2Bridge.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2164,7 +2164,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerived2ProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerived2ProtectedFactory }
 
-        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived2.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<__IMPL_test_component.UnsealedDerived2Bridge.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived2 {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2182,7 +2182,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedFactory }
 
-        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<__IMPL_test_component.UnsealedDerivedBridge.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2195,7 +2195,7 @@ public enum __ABI_test_component {
             return IUnsealedDerived(value!)
         }
 
-        public func CreateInstance2(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
+        public func CreateInstance2(_ prop: Int32, _ baseInterface: UnsealedWinRTClassWrapper<__IMPL_test_component.UnsealedDerivedBridge.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2208,7 +2208,7 @@ public enum __ABI_test_component {
             return IUnsealedDerived(value!)
         }
 
-        public func CreateInstance3(_ prop1: String, _ prop2: test_component.Base?, _ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerived.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
+        public func CreateInstance3(_ prop1: String, _ prop2: test_component.Base?, _ baseInterface: UnsealedWinRTClassWrapper<__IMPL_test_component.UnsealedDerivedBridge.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerived {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _prop1 = try! HString(prop1)
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
@@ -2232,7 +2232,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedFromNoConstructorFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructorFactory }
 
-        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerivedFromNoConstructor.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedFromNoConstructor {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<__IMPL_test_component.UnsealedDerivedFromNoConstructorBridge.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedFromNoConstructor {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2265,7 +2265,7 @@ public enum __ABI_test_component {
     public class IUnsealedDerivedNoOverridesProtectedFactory: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIUnsealedDerivedNoOverridesProtectedFactory }
 
-        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<test_component.UnsealedDerivedNoOverrides.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedNoOverrides {
+        public func CreateInstance(_ baseInterface: UnsealedWinRTClassWrapper<__IMPL_test_component.UnsealedDerivedNoOverridesBridge.Composable>?, _ innerInterface: inout test_component.IInspectable?) throws -> IUnsealedDerivedNoOverrides {
             let (value) = try ComPtrs.initialize { valueAbi in
                 let _baseInterface = baseInterface?.toIInspectableABI { $0 }
                 let (_innerInterface) = try ComPtrs.initialize { _innerInterfaceAbi in
@@ -2641,7 +2641,7 @@ public enum __ABI_test_component {
             _ = val.Value2?.pointee.lpVtbl.pointee.Release(val.Value2)
         }
     }
-    internal typealias IBaseOverridesWrapper = UnsealedWinRTClassWrapper<test_component.Base.IBaseOverrides>
+    internal typealias IBaseOverridesWrapper = UnsealedWinRTClassWrapper<__IMPL_test_component.BaseBridge.IBaseOverrides>
     internal static var IBaseOverridesVTable: __x_ABI_Ctest__component_CIBaseOverridesVtbl = .init(
         QueryInterface: { IBaseOverridesWrapper.queryInterface($0, $1, $2) },
         AddRef: { IBaseOverridesWrapper.addRef($0) },
@@ -2678,7 +2678,7 @@ public enum __ABI_test_component {
             } catch { return failWith(error: error) } 
         }
     )
-    internal typealias IUnsealedDerivedOverridesWrapper = UnsealedWinRTClassWrapper<test_component.UnsealedDerived.IUnsealedDerivedOverrides>
+    internal typealias IUnsealedDerivedOverridesWrapper = UnsealedWinRTClassWrapper<__IMPL_test_component.UnsealedDerivedBridge.IUnsealedDerivedOverrides>
     internal static var IUnsealedDerivedOverridesVTable: __x_ABI_Ctest__component_CIUnsealedDerivedOverridesVtbl = .init(
         QueryInterface: { IUnsealedDerivedOverridesWrapper.queryInterface($0, $1, $2) },
         AddRef: { IUnsealedDerivedOverridesWrapper.addRef($0) },
@@ -2716,7 +2716,7 @@ public enum __ABI_test_component {
             } catch { return failWith(error: error) } 
         }
     )
-    internal typealias IUnsealedDerivedOverloads2Wrapper = UnsealedWinRTClassWrapper<test_component.UnsealedDerived.IUnsealedDerivedOverloads2>
+    internal typealias IUnsealedDerivedOverloads2Wrapper = UnsealedWinRTClassWrapper<__IMPL_test_component.UnsealedDerivedBridge.IUnsealedDerivedOverloads2>
     internal static var IUnsealedDerivedOverloads2VTable: __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2Vtbl = .init(
         QueryInterface: { IUnsealedDerivedOverloads2Wrapper.queryInterface($0, $1, $2) },
         AddRef: { IUnsealedDerivedOverloads2Wrapper.addRef($0) },

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -4515,7 +4515,7 @@ public class IIteratorStorageFile: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage.StorageFileBridge.from(abi: result)
     }
 
     open func get_HasCurrent() throws -> Bool {
@@ -4643,7 +4643,7 @@ public class IIteratorStorageFolder: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage.StorageFolderBridge.from(abi: result)
     }
 
     open func get_HasCurrent() throws -> Bool {
@@ -4771,7 +4771,7 @@ public class IIteratorStorageLibraryChange: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage.StorageLibraryChangeBridge.from(abi: result)
     }
 
     open func get_HasCurrent() throws -> Bool {
@@ -4899,7 +4899,7 @@ public class IIteratorBase: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_test_component.BaseBridge.from(abi: result)
     }
 
     open func get_HasCurrent() throws -> Bool {
@@ -5477,7 +5477,7 @@ public class IKeyValuePairString_Base: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_test_component.BaseBridge.from(abi: result)
     }
 
 }
@@ -6203,7 +6203,7 @@ public class IMapViewString_Base: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Lookup(pThis, _key.get(), &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_test_component.BaseBridge.from(abi: result)
     }
 
     open func get_Size() throws -> UInt32 {
@@ -7023,7 +7023,7 @@ internal var __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseVTable: 
     Insert: {
         guard let __unwrapped__instance = __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
         let key: String = .init(from: $1)
-        let value: test_component.Base? = .from(abi: ComPtr($2))
+        let value: test_component.Base? = __IMPL_test_component.BaseBridge.from(abi: ComPtr($2))
         let result = __unwrapped__instance.insert(key, value)
         $3?.initialize(to: .init(from: result))
         return S_OK
@@ -7053,7 +7053,7 @@ public class IMapString_Base: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.Lookup(pThis, _key.get(), &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_test_component.BaseBridge.from(abi: result)
     }
 
     open func get_Size() throws -> UInt32 {
@@ -9060,7 +9060,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileV
 
     IndexOf: {
         guard let __unwrapped__instance = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        let value: test_component.StorageFile? = .from(abi: ComPtr($1))
+        let value: test_component.StorageFile? = __IMPL_Windows_Storage.StorageFileBridge.from(abi: ComPtr($1))
         var index: UInt32 = 0
         let result = __unwrapped__instance.indexOf(value, &index)
         $2?.initialize(to: index)
@@ -9080,7 +9080,7 @@ public class IVectorViewStorageFile: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage.StorageFileBridge.from(abi: result)
     }
 
     open func get_Size() throws -> UInt32 {
@@ -9220,7 +9220,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolde
 
     IndexOf: {
         guard let __unwrapped__instance = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        let value: test_component.StorageFolder? = .from(abi: ComPtr($1))
+        let value: test_component.StorageFolder? = __IMPL_Windows_Storage.StorageFolderBridge.from(abi: ComPtr($1))
         var index: UInt32 = 0
         let result = __unwrapped__instance.indexOf(value, &index)
         $2?.initialize(to: index)
@@ -9240,7 +9240,7 @@ public class IVectorViewStorageFolder: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage.StorageFolderBridge.from(abi: result)
     }
 
     open func get_Size() throws -> UInt32 {
@@ -9380,7 +9380,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibra
 
     IndexOf: {
         guard let __unwrapped__instance = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        let value: test_component.StorageLibraryChange? = .from(abi: ComPtr($1))
+        let value: test_component.StorageLibraryChange? = __IMPL_Windows_Storage.StorageLibraryChangeBridge.from(abi: ComPtr($1))
         var index: UInt32 = 0
         let result = __unwrapped__instance.indexOf(value, &index)
         $2?.initialize(to: index)
@@ -9400,7 +9400,7 @@ public class IVectorViewStorageLibraryChange: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage.StorageLibraryChangeBridge.from(abi: result)
     }
 
     open func get_Size() throws -> UInt32 {
@@ -9540,7 +9540,7 @@ internal var __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseVTable: _
 
     IndexOf: {
         guard let __unwrapped__instance = __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        let value: test_component.Base? = .from(abi: ComPtr($1))
+        let value: test_component.Base? = __IMPL_test_component.BaseBridge.from(abi: ComPtr($1))
         var index: UInt32 = 0
         let result = __unwrapped__instance.indexOf(value, &index)
         $2?.initialize(to: index)
@@ -9560,7 +9560,7 @@ public class IVectorViewBase: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_test_component.BaseBridge.from(abi: result)
     }
 
     open func get_Size() throws -> UInt32 {
@@ -11090,7 +11090,7 @@ internal var __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_A
 
     IndexOf: {
         guard let __unwrapped__instance = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        let value: test_component.Base? = .from(abi: ComPtr($1))
+        let value: test_component.Base? = __IMPL_test_component.BaseBridge.from(abi: ComPtr($1))
         var index: UInt32 = 0
         let result = __unwrapped__instance.indexOf(value, &index)
         $2?.initialize(to: index)
@@ -11101,7 +11101,7 @@ internal var __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_A
     SetAt: {
         guard let __unwrapped__instance = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
         let index: UInt32 = $1
-        let value: test_component.Base? = .from(abi: ComPtr($2))
+        let value: test_component.Base? = __IMPL_test_component.BaseBridge.from(abi: ComPtr($2))
         __unwrapped__instance.setAt(index, value)
         return S_OK
     },
@@ -11109,7 +11109,7 @@ internal var __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_A
     InsertAt: {
         guard let __unwrapped__instance = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
         let index: UInt32 = $1
-        let value: test_component.Base? = .from(abi: ComPtr($2))
+        let value: test_component.Base? = __IMPL_test_component.BaseBridge.from(abi: ComPtr($2))
         __unwrapped__instance.insertAt(index, value)
         return S_OK
     },
@@ -11123,7 +11123,7 @@ internal var __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseVTable: __x_A
 
     Append: {
         guard let __unwrapped__instance = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-        let value: test_component.Base? = .from(abi: ComPtr($1))
+        let value: test_component.Base? = __IMPL_test_component.BaseBridge.from(abi: ComPtr($1))
         __unwrapped__instance.append(value)
         return S_OK
     },
@@ -11154,7 +11154,7 @@ public class IVectorBase: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_test_component.BaseBridge.from(abi: result)
     }
 
     open func get_Size() throws -> UInt32 {
@@ -14109,7 +14109,7 @@ public class IAsyncOperationBasicProperties: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage_FileProperties.BasicPropertiesBridge.from(abi: result)
     }
 
 }
@@ -14262,7 +14262,7 @@ public class IAsyncOperationDocumentProperties: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage_FileProperties.DocumentPropertiesBridge.from(abi: result)
     }
 
 }
@@ -14415,7 +14415,7 @@ public class IAsyncOperationImageProperties: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage_FileProperties.ImagePropertiesBridge.from(abi: result)
     }
 
 }
@@ -14568,7 +14568,7 @@ public class IAsyncOperationMusicProperties: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage_FileProperties.MusicPropertiesBridge.from(abi: result)
     }
 
 }
@@ -14721,7 +14721,7 @@ public class IAsyncOperationStorageItemThumbnail: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage_FileProperties.StorageItemThumbnailBridge.from(abi: result)
     }
 
 }
@@ -14874,7 +14874,7 @@ public class IAsyncOperationVideoProperties: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage_FileProperties.VideoPropertiesBridge.from(abi: result)
     }
 
 }
@@ -15333,7 +15333,7 @@ public class IAsyncOperationStorageFile: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage.StorageFileBridge.from(abi: result)
     }
 
 }
@@ -15486,7 +15486,7 @@ public class IAsyncOperationStorageFolder: test_component.IInspectable {
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage.StorageFolderBridge.from(abi: result)
     }
 
 }
@@ -15639,7 +15639,7 @@ public class IAsyncOperationStorageStreamTransaction: test_component.IInspectabl
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &resultAbi))
             }
         }
-        return .from(abi: result)
+        return __IMPL_Windows_Storage.StorageStreamTransactionBridge.from(abi: result)
     }
 
 }
@@ -16684,8 +16684,8 @@ internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass_
     Invoke: {
         do {
             guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-            let sender: test_component.Class? = .from(abi: ComPtr($1))
-            let args: test_component.DeferrableEventArgs? = .from(abi: ComPtr($2))
+            let sender: test_component.Class? = __IMPL_test_component.ClassBridge.from(abi: ComPtr($1))
+            let args: test_component.DeferrableEventArgs? = __IMPL_test_component.DeferrableEventArgsBridge.from(abi: ComPtr($2))
             try __unwrapped__instance(sender, args)
             return S_OK
         } catch { return failWith(error: error) } 
@@ -16735,7 +16735,7 @@ internal var __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple
     Invoke: {
         do {
             guard let __unwrapped__instance = __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgsWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
-            let sender: test_component.Simple? = .from(abi: ComPtr($1))
+            let sender: test_component.Simple? = __IMPL_test_component.SimpleBridge.from(abi: ComPtr($1))
             let args: test_component.SimpleEventArgs = .from(abi: $2)
             try __unwrapped__instance(sender, args)
             return S_OK

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -430,4 +430,319 @@ public enum __IMPL_test_component {
             return handler
         }
     }
+    @_spi(WinRTInternal)
+    public enum AsyncOperationIntBridge: AbiBridge {
+        public typealias Swift = AsyncOperationInt
+        public typealias CABI = __x_ABI_Ctest__component_CIAsyncOperationInt
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIAsyncOperationInt>?) -> AsyncOperationInt? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum BaseBridge: ComposableBridge {
+        public typealias Swift = Base
+        public typealias CABI = __x_ABI_Ctest__component_CIBase
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIBase>?) -> Base? {
+            guard let abi = abi else { return nil }
+            return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+        }
+        @_spi(WinRTInternal)
+        public enum IBaseOverrides : ComposableImpl {
+            public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
+            public typealias SwiftABI = __ABI_test_component.IBaseOverrides
+            public typealias Class = Base
+            public typealias SwiftProjection = WinRTClassWeakReference<Class>
+            public enum Default : AbiInterface {
+                public typealias CABI = __x_ABI_Ctest__component_CIBase
+                public typealias SwiftABI = __ABI_test_component.IBase
+            }
+        }
+        @_spi(WinRTInternal)
+        public typealias Composable = IBaseOverrides
+    }
+
+    @_spi(WinRTInternal)
+    public enum BaseCollectionBridge: ComposableBridge {
+        public typealias Swift = BaseCollection
+        public typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase
+        public static func from(abi: ComPtr<__x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase>?) -> BaseCollection? {
+            guard let abi = abi else { return nil }
+            return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+        }
+        @_spi(WinRTInternal)
+        public enum IVectorBase : ComposableImpl {
+            public typealias CABI = C_IInspectable
+            public typealias SwiftABI = test_component.IInspectable
+            public typealias Class = BaseCollection
+            public typealias SwiftProjection = WinRTClassWeakReference<Class>
+            public enum Default : AbiInterface {
+                public typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase
+                public typealias SwiftABI = test_component.IVectorBase
+            }
+        }
+        @_spi(WinRTInternal)
+        public typealias Composable = IVectorBase
+    }
+
+    @_spi(WinRTInternal)
+    public enum BaseMapCollectionBridge: AbiBridge {
+        public typealias Swift = BaseMapCollection
+        public typealias CABI = __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
+        public static func from(abi: ComPtr<__x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase>?) -> BaseMapCollection? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum BaseNoOverridesBridge: ComposableBridge {
+        public typealias Swift = BaseNoOverrides
+        public typealias CABI = __x_ABI_Ctest__component_CIBaseNoOverrides
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIBaseNoOverrides>?) -> BaseNoOverrides? {
+            guard let abi = abi else { return nil }
+            return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+        }
+        @_spi(WinRTInternal)
+        public enum IBaseNoOverrides : ComposableImpl {
+            public typealias CABI = C_IInspectable
+            public typealias SwiftABI = test_component.IInspectable
+            public typealias Class = BaseNoOverrides
+            public typealias SwiftProjection = WinRTClassWeakReference<Class>
+            public enum Default : AbiInterface {
+                public typealias CABI = __x_ABI_Ctest__component_CIBaseNoOverrides
+                public typealias SwiftABI = __ABI_test_component.IBaseNoOverrides
+            }
+        }
+        @_spi(WinRTInternal)
+        public typealias Composable = IBaseNoOverrides
+    }
+
+    @_spi(WinRTInternal)
+    public enum BaseObservableCollectionBridge: AbiBridge {
+        public typealias Swift = BaseObservableCollection
+        public typealias CABI = __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase
+        public static func from(abi: ComPtr<__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase>?) -> BaseObservableCollection? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum ClassBridge: AbiBridge {
+        public typealias Swift = Class
+        public typealias CABI = __x_ABI_Ctest__component_CIClass
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIClass>?) -> Class? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum CollectionTesterBridge: AbiBridge {
+        public typealias Swift = CollectionTester
+        public typealias CABI = __x_ABI_Ctest__component_CICollectionTester
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CICollectionTester>?) -> CollectionTester? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum DeferrableEventArgsBridge: AbiBridge {
+        public typealias Swift = DeferrableEventArgs
+        public typealias CABI = __x_ABI_Ctest__component_CIDeferrableEventArgs
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDeferrableEventArgs>?) -> DeferrableEventArgs? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum DerivedBridge: AbiBridge {
+        public typealias Swift = Derived
+        public typealias CABI = __x_ABI_Ctest__component_CIDerived
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDerived>?) -> Derived? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum DerivedFromNoConstructorBridge: AbiBridge {
+        public typealias Swift = DerivedFromNoConstructor
+        public typealias CABI = __x_ABI_Ctest__component_CIDerivedFromNoConstructor
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDerivedFromNoConstructor>?) -> DerivedFromNoConstructor? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum EventTesterBridge: AbiBridge {
+        public typealias Swift = EventTester
+        public typealias CABI = __x_ABI_Ctest__component_CIEventTester
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIEventTester>?) -> EventTester? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum NoopClosableBridge: AbiBridge {
+        public typealias Swift = NoopClosable
+        public typealias CABI = __x_ABI_CWindows_CFoundation_CIClosable
+        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIClosable>?) -> NoopClosable? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum SimpleBridge: AbiBridge {
+        public typealias Swift = Simple
+        public typealias CABI = __x_ABI_Ctest__component_CISimple
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CISimple>?) -> Simple? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum UnsealedDerivedBridge: ComposableBridge {
+        public typealias Swift = UnsealedDerived
+        public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerived>?) -> UnsealedDerived? {
+            guard let abi = abi else { return nil }
+            return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+        }
+        @_spi(WinRTInternal)
+        public enum IUnsealedDerivedOverloads2 : ComposableImpl {
+            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
+            public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
+            public typealias Class = UnsealedDerived
+            public typealias SwiftProjection = WinRTClassWeakReference<Class>
+            public enum Default : AbiInterface {
+                public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
+                public typealias SwiftABI = __ABI_test_component.IUnsealedDerived
+            }
+        }
+        @_spi(WinRTInternal)
+        public typealias Composable = IUnsealedDerivedOverloads2
+        @_spi(WinRTInternal)
+        public enum IUnsealedDerivedOverrides : ComposableImpl {
+            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverrides
+            public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverrides
+            public typealias Class = UnsealedDerived
+            public typealias SwiftProjection = WinRTClassWeakReference<Class>
+            public enum Default : AbiInterface {
+                public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
+                public typealias SwiftABI = __ABI_test_component.IUnsealedDerived
+            }
+        }
+    }
+
+    @_spi(WinRTInternal)
+    public enum UnsealedDerived2Bridge: ComposableBridge {
+        public typealias Swift = UnsealedDerived2
+        public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived2
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerived2>?) -> UnsealedDerived2? {
+            guard let abi = abi else { return nil }
+            return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+        }
+        @_spi(WinRTInternal)
+        public enum IUnsealedDerivedOverloads2 : ComposableImpl {
+            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
+            public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
+            public typealias Class = UnsealedDerived2
+            public typealias SwiftProjection = WinRTClassWeakReference<Class>
+            public enum Default : AbiInterface {
+                public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived2
+                public typealias SwiftABI = __ABI_test_component.IUnsealedDerived2
+            }
+        }
+        @_spi(WinRTInternal)
+        public typealias Composable = IUnsealedDerivedOverloads2
+    }
+
+    @_spi(WinRTInternal)
+    public enum UnsealedDerivedFromNoConstructorBridge: ComposableBridge {
+        public typealias Swift = UnsealedDerivedFromNoConstructor
+        public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor>?) -> UnsealedDerivedFromNoConstructor? {
+            guard let abi = abi else { return nil }
+            return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+        }
+        @_spi(WinRTInternal)
+        public enum IBaseOverrides : ComposableImpl {
+            public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
+            public typealias SwiftABI = __ABI_test_component.IBaseOverrides
+            public typealias Class = UnsealedDerivedFromNoConstructor
+            public typealias SwiftProjection = WinRTClassWeakReference<Class>
+            public enum Default : AbiInterface {
+                public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor
+                public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedFromNoConstructor
+            }
+        }
+        @_spi(WinRTInternal)
+        public typealias Composable = IBaseOverrides
+    }
+
+    @_spi(WinRTInternal)
+    public enum UnsealedDerivedNoConstructorBridge: ComposableBridge {
+        public typealias Swift = UnsealedDerivedNoConstructor
+        public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor>?) -> UnsealedDerivedNoConstructor? {
+            guard let abi = abi else { return nil }
+            return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+        }
+        @_spi(WinRTInternal)
+        public enum IBaseOverrides : ComposableImpl {
+            public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
+            public typealias SwiftABI = __ABI_test_component.IBaseOverrides
+            public typealias Class = UnsealedDerivedNoConstructor
+            public typealias SwiftProjection = WinRTClassWeakReference<Class>
+            public enum Default : AbiInterface {
+                public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor
+                public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoConstructor
+            }
+        }
+        @_spi(WinRTInternal)
+        public typealias Composable = IBaseOverrides
+    }
+
+    @_spi(WinRTInternal)
+    public enum UnsealedDerivedNoOverridesBridge: ComposableBridge {
+        public typealias Swift = UnsealedDerivedNoOverrides
+        public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides>?) -> UnsealedDerivedNoOverrides? {
+            guard let abi = abi else { return nil }
+            return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
+        }
+        @_spi(WinRTInternal)
+        public enum IUnsealedDerivedNoOverrides : ComposableImpl {
+            public typealias CABI = C_IInspectable
+            public typealias SwiftABI = test_component.IInspectable
+            public typealias Class = UnsealedDerivedNoOverrides
+            public typealias SwiftProjection = WinRTClassWeakReference<Class>
+            public enum Default : AbiInterface {
+                public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides
+                public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoOverrides
+            }
+        }
+        @_spi(WinRTInternal)
+        public typealias Composable = IUnsealedDerivedNoOverrides
+    }
+
+    @_spi(WinRTInternal)
+    public enum WeakReferencerBridge: AbiBridge {
+        public typealias Swift = WeakReferencer
+        public typealias CABI = __x_ABI_Ctest__component_CIWeakReferencer
+        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIWeakReferencer>?) -> WeakReferencer? {
+            guard let abi = abi else { return nil }
+            return .init(fromAbi: test_component.IInspectable(abi))
+        }
+    }
+
 }

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -430,9 +430,8 @@ public enum __IMPL_test_component {
             return handler
         }
     }
-    @_spi(WinRTInternal)
     public enum AsyncOperationIntBridge: AbiBridge {
-        public typealias Swift = AsyncOperationInt
+        public typealias SwiftProjection = AsyncOperationInt
         public typealias CABI = __x_ABI_Ctest__component_CIAsyncOperationInt
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIAsyncOperationInt>?) -> AsyncOperationInt? {
             guard let abi = abi else { return nil }
@@ -440,15 +439,13 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum BaseBridge: ComposableBridge {
-        public typealias Swift = Base
+        public typealias SwiftProjection = Base
         public typealias CABI = __x_ABI_Ctest__component_CIBase
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIBase>?) -> Base? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }
-        @_spi(WinRTInternal)
         public enum IBaseOverrides : ComposableImpl {
             public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
             public typealias SwiftABI = __ABI_test_component.IBaseOverrides
@@ -463,15 +460,13 @@ public enum __IMPL_test_component {
         public typealias Composable = IBaseOverrides
     }
 
-    @_spi(WinRTInternal)
     public enum BaseCollectionBridge: ComposableBridge {
-        public typealias Swift = BaseCollection
+        public typealias SwiftProjection = BaseCollection
         public typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase
         public static func from(abi: ComPtr<__x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase>?) -> BaseCollection? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }
-        @_spi(WinRTInternal)
         public enum IVectorBase : ComposableImpl {
             public typealias CABI = C_IInspectable
             public typealias SwiftABI = test_component.IInspectable
@@ -486,9 +481,8 @@ public enum __IMPL_test_component {
         public typealias Composable = IVectorBase
     }
 
-    @_spi(WinRTInternal)
     public enum BaseMapCollectionBridge: AbiBridge {
-        public typealias Swift = BaseMapCollection
+        public typealias SwiftProjection = BaseMapCollection
         public typealias CABI = __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
         public static func from(abi: ComPtr<__x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase>?) -> BaseMapCollection? {
             guard let abi = abi else { return nil }
@@ -496,15 +490,13 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum BaseNoOverridesBridge: ComposableBridge {
-        public typealias Swift = BaseNoOverrides
+        public typealias SwiftProjection = BaseNoOverrides
         public typealias CABI = __x_ABI_Ctest__component_CIBaseNoOverrides
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIBaseNoOverrides>?) -> BaseNoOverrides? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }
-        @_spi(WinRTInternal)
         public enum IBaseNoOverrides : ComposableImpl {
             public typealias CABI = C_IInspectable
             public typealias SwiftABI = test_component.IInspectable
@@ -519,9 +511,8 @@ public enum __IMPL_test_component {
         public typealias Composable = IBaseNoOverrides
     }
 
-    @_spi(WinRTInternal)
     public enum BaseObservableCollectionBridge: AbiBridge {
-        public typealias Swift = BaseObservableCollection
+        public typealias SwiftProjection = BaseObservableCollection
         public typealias CABI = __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase
         public static func from(abi: ComPtr<__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase>?) -> BaseObservableCollection? {
             guard let abi = abi else { return nil }
@@ -529,9 +520,8 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum ClassBridge: AbiBridge {
-        public typealias Swift = Class
+        public typealias SwiftProjection = Class
         public typealias CABI = __x_ABI_Ctest__component_CIClass
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIClass>?) -> Class? {
             guard let abi = abi else { return nil }
@@ -539,9 +529,8 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum CollectionTesterBridge: AbiBridge {
-        public typealias Swift = CollectionTester
+        public typealias SwiftProjection = CollectionTester
         public typealias CABI = __x_ABI_Ctest__component_CICollectionTester
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CICollectionTester>?) -> CollectionTester? {
             guard let abi = abi else { return nil }
@@ -549,9 +538,8 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum DeferrableEventArgsBridge: AbiBridge {
-        public typealias Swift = DeferrableEventArgs
+        public typealias SwiftProjection = DeferrableEventArgs
         public typealias CABI = __x_ABI_Ctest__component_CIDeferrableEventArgs
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDeferrableEventArgs>?) -> DeferrableEventArgs? {
             guard let abi = abi else { return nil }
@@ -559,9 +547,8 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum DerivedBridge: AbiBridge {
-        public typealias Swift = Derived
+        public typealias SwiftProjection = Derived
         public typealias CABI = __x_ABI_Ctest__component_CIDerived
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDerived>?) -> Derived? {
             guard let abi = abi else { return nil }
@@ -569,9 +556,8 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum DerivedFromNoConstructorBridge: AbiBridge {
-        public typealias Swift = DerivedFromNoConstructor
+        public typealias SwiftProjection = DerivedFromNoConstructor
         public typealias CABI = __x_ABI_Ctest__component_CIDerivedFromNoConstructor
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDerivedFromNoConstructor>?) -> DerivedFromNoConstructor? {
             guard let abi = abi else { return nil }
@@ -579,9 +565,8 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum EventTesterBridge: AbiBridge {
-        public typealias Swift = EventTester
+        public typealias SwiftProjection = EventTester
         public typealias CABI = __x_ABI_Ctest__component_CIEventTester
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIEventTester>?) -> EventTester? {
             guard let abi = abi else { return nil }
@@ -589,9 +574,8 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum NoopClosableBridge: AbiBridge {
-        public typealias Swift = NoopClosable
+        public typealias SwiftProjection = NoopClosable
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIClosable
         public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIClosable>?) -> NoopClosable? {
             guard let abi = abi else { return nil }
@@ -599,9 +583,8 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum SimpleBridge: AbiBridge {
-        public typealias Swift = Simple
+        public typealias SwiftProjection = Simple
         public typealias CABI = __x_ABI_Ctest__component_CISimple
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CISimple>?) -> Simple? {
             guard let abi = abi else { return nil }
@@ -609,15 +592,13 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum UnsealedDerivedBridge: ComposableBridge {
-        public typealias Swift = UnsealedDerived
+        public typealias SwiftProjection = UnsealedDerived
         public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerived>?) -> UnsealedDerived? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }
-        @_spi(WinRTInternal)
         public enum IUnsealedDerivedOverloads2 : ComposableImpl {
             public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
             public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
@@ -630,7 +611,6 @@ public enum __IMPL_test_component {
         }
         @_spi(WinRTInternal)
         public typealias Composable = IUnsealedDerivedOverloads2
-        @_spi(WinRTInternal)
         public enum IUnsealedDerivedOverrides : ComposableImpl {
             public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverrides
             public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverrides
@@ -643,15 +623,13 @@ public enum __IMPL_test_component {
         }
     }
 
-    @_spi(WinRTInternal)
     public enum UnsealedDerived2Bridge: ComposableBridge {
-        public typealias Swift = UnsealedDerived2
+        public typealias SwiftProjection = UnsealedDerived2
         public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived2
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerived2>?) -> UnsealedDerived2? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }
-        @_spi(WinRTInternal)
         public enum IUnsealedDerivedOverloads2 : ComposableImpl {
             public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
             public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
@@ -666,15 +644,13 @@ public enum __IMPL_test_component {
         public typealias Composable = IUnsealedDerivedOverloads2
     }
 
-    @_spi(WinRTInternal)
     public enum UnsealedDerivedFromNoConstructorBridge: ComposableBridge {
-        public typealias Swift = UnsealedDerivedFromNoConstructor
+        public typealias SwiftProjection = UnsealedDerivedFromNoConstructor
         public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor>?) -> UnsealedDerivedFromNoConstructor? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }
-        @_spi(WinRTInternal)
         public enum IBaseOverrides : ComposableImpl {
             public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
             public typealias SwiftABI = __ABI_test_component.IBaseOverrides
@@ -689,15 +665,13 @@ public enum __IMPL_test_component {
         public typealias Composable = IBaseOverrides
     }
 
-    @_spi(WinRTInternal)
     public enum UnsealedDerivedNoConstructorBridge: ComposableBridge {
-        public typealias Swift = UnsealedDerivedNoConstructor
+        public typealias SwiftProjection = UnsealedDerivedNoConstructor
         public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor>?) -> UnsealedDerivedNoConstructor? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }
-        @_spi(WinRTInternal)
         public enum IBaseOverrides : ComposableImpl {
             public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
             public typealias SwiftABI = __ABI_test_component.IBaseOverrides
@@ -712,15 +686,13 @@ public enum __IMPL_test_component {
         public typealias Composable = IBaseOverrides
     }
 
-    @_spi(WinRTInternal)
     public enum UnsealedDerivedNoOverridesBridge: ComposableBridge {
-        public typealias Swift = UnsealedDerivedNoOverrides
+        public typealias SwiftProjection = UnsealedDerivedNoOverrides
         public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides>?) -> UnsealedDerivedNoOverrides? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }
-        @_spi(WinRTInternal)
         public enum IUnsealedDerivedNoOverrides : ComposableImpl {
             public typealias CABI = C_IInspectable
             public typealias SwiftABI = test_component.IInspectable
@@ -735,9 +707,8 @@ public enum __IMPL_test_component {
         public typealias Composable = IUnsealedDerivedNoOverrides
     }
 
-    @_spi(WinRTInternal)
     public enum WeakReferencerBridge: AbiBridge {
-        public typealias Swift = WeakReferencer
+        public typealias SwiftProjection = WeakReferencer
         public typealias CABI = __x_ABI_Ctest__component_CIWeakReferencer
         public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIWeakReferencer>?) -> WeakReferencer? {
             guard let abi = abi else { return nil }

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -38,12 +38,6 @@ public final class AsyncOperationInt : WinRTClass, IAsyncOperationInt, IAsyncOpe
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIAsyncOperationInt>?) -> AsyncOperationInt? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -110,12 +104,6 @@ open class Base : WinRTClass {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIBase>?) -> Base? {
-        guard let abi = abi else { return nil }
-        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -140,7 +128,7 @@ open class Base : WinRTClass {
 
     override public init() {
         super.init()
-        MakeComposed(composing: Self.Composable.self, self) { baseInterface, innerInterface in 
+        MakeComposed(composing: __IMPL_test_component.BaseBridge.Composable.self, self) { baseInterface, innerInterface in 
             try! Self._IBaseProtectedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
@@ -159,19 +147,6 @@ open class Base : WinRTClass {
         try _IBaseOverrides.OnDoTheThing()
     }
 
-    @_spi(WinRTInternal)
-        public enum IBaseOverrides : ComposableImpl {
-        public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
-        public typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        public typealias Class = Base
-        public typealias SwiftProjection = WinRTClassWeakReference<Class>
-        public enum Default : AbiInterface {
-            public typealias CABI = __x_ABI_Ctest__component_CIBase
-            public typealias SwiftABI = __ABI_test_component.IBase
-        }
-    }
-    @_spi(WinRTInternal)
-    public typealias Composable = IBaseOverrides
     deinit {
         _default = nil
         _IBaseOverrides = nil
@@ -189,12 +164,6 @@ open class BaseCollection : WinRTClass, IVector, IIterable {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase>?) -> BaseCollection? {
-        guard let abi = abi else { return nil }
-        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
     }
 
     @_spi(WinRTInternal)
@@ -217,7 +186,7 @@ open class BaseCollection : WinRTClass, IVector, IIterable {
 
     override public init() {
         super.init()
-        MakeComposed(composing: Self.Composable.self, self) { baseInterface, innerInterface in 
+        MakeComposed(composing: __IMPL_test_component.BaseCollectionBridge.Composable.self, self) { baseInterface, innerInterface in 
             try! Self._IBaseCollectionProtectedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
@@ -298,19 +267,6 @@ open class BaseCollection : WinRTClass, IVector, IIterable {
         try! _IIterable.First()
     }
 
-    @_spi(WinRTInternal)
-        public enum IVectorBase : ComposableImpl {
-        public typealias CABI = C_IInspectable
-        public typealias SwiftABI = test_component.IInspectable
-        public typealias Class = BaseCollection
-        public typealias SwiftProjection = WinRTClassWeakReference<Class>
-        public enum Default : AbiInterface {
-            public typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase
-            public typealias SwiftABI = test_component.IVectorBase
-        }
-    }
-    @_spi(WinRTInternal)
-    public typealias Composable = IVectorBase
     deinit {
         _default = nil
         _IIterable = nil
@@ -330,12 +286,6 @@ public final class BaseMapCollection : WinRTClass, IMap, IIterable {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase>?) -> BaseMapCollection? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -398,12 +348,6 @@ open class BaseNoOverrides : WinRTClass {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIBaseNoOverrides>?) -> BaseNoOverrides? {
-        guard let abi = abi else { return nil }
-        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -423,7 +367,7 @@ open class BaseNoOverrides : WinRTClass {
 
     override public init() {
         super.init()
-        MakeComposed(composing: Self.Composable.self, self) { baseInterface, innerInterface in 
+        MakeComposed(composing: __IMPL_test_component.BaseNoOverridesBridge.Composable.self, self) { baseInterface, innerInterface in 
             try! Self._IBaseNoOverridesProtectedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
@@ -433,19 +377,6 @@ open class BaseNoOverrides : WinRTClass {
         return try _IBaseNoOverridesStatics.CreateFromString(value)
     }
 
-    @_spi(WinRTInternal)
-        public enum IBaseNoOverrides : ComposableImpl {
-        public typealias CABI = C_IInspectable
-        public typealias SwiftABI = test_component.IInspectable
-        public typealias Class = BaseNoOverrides
-        public typealias SwiftProjection = WinRTClassWeakReference<Class>
-        public enum Default : AbiInterface {
-            public typealias CABI = __x_ABI_Ctest__component_CIBaseNoOverrides
-            public typealias SwiftABI = __ABI_test_component.IBaseNoOverrides
-        }
-    }
-    @_spi(WinRTInternal)
-    public typealias Composable = IBaseNoOverrides
     deinit {
         _default = nil
     }
@@ -462,12 +393,6 @@ public final class BaseObservableCollection : WinRTClass, IObservableVector, IVe
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase>?) -> BaseObservableCollection? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -592,12 +517,6 @@ public final class Class : WinRTClass, IBasic {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIClass>?) -> Class? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -832,12 +751,6 @@ public final class CollectionTester : WinRTClass {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CICollectionTester>?) -> CollectionTester? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -898,12 +811,6 @@ public final class DeferrableEventArgs : WinRTClass {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDeferrableEventArgs>?) -> DeferrableEventArgs? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi)
     }
@@ -934,12 +841,6 @@ public final class Derived : test_component.Base {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDerived>?) -> Derived? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     override public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi: fromAbi)
     }
@@ -959,19 +860,6 @@ public final class Derived : test_component.Base {
         set { try! _default.put_Prop(newValue) }
     }
 
-    @_spi(WinRTInternal)
-        public enum IBaseOverrides : ComposableImpl {
-        public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
-        public typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        public typealias Class = Derived
-        public typealias SwiftProjection = WinRTClassWeakReference<Class>
-        public enum Default : AbiInterface {
-            public typealias CABI = __x_ABI_Ctest__component_CIDerived
-            public typealias SwiftABI = __ABI_test_component.IDerived
-        }
-    }
-    @_spi(WinRTInternal)
-    public typealias Composable = IBaseOverrides
     deinit {
         _default = nil
     }
@@ -990,12 +878,6 @@ public final class DerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDerivedFromNoConstructor>?) -> DerivedFromNoConstructor? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
-    }
-
-    @_spi(WinRTInternal)
     override public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi: fromAbi)
     }
@@ -1004,19 +886,6 @@ public final class DerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
         try _default.Method()
     }
 
-    @_spi(WinRTInternal)
-        public enum IBaseOverrides : ComposableImpl {
-        public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
-        public typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        public typealias Class = DerivedFromNoConstructor
-        public typealias SwiftProjection = WinRTClassWeakReference<Class>
-        public enum Default : AbiInterface {
-            public typealias CABI = __x_ABI_Ctest__component_CIDerivedFromNoConstructor
-            public typealias SwiftABI = __ABI_test_component.IDerivedFromNoConstructor
-        }
-    }
-    @_spi(WinRTInternal)
-    public typealias Composable = IBaseOverrides
     deinit {
         _default = nil
     }
@@ -1032,12 +901,6 @@ public final class EventTester : WinRTClass {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIEventTester>?) -> EventTester? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -1081,12 +944,6 @@ public final class NoopClosable : WinRTClass, test_component.IClosable {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIClosable>?) -> NoopClosable? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -1165,12 +1022,6 @@ public final class Simple : WinRTClass {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CISimple>?) -> Simple? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)
@@ -1334,12 +1185,6 @@ open class UnsealedDerived : test_component.Base {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerived>?) -> UnsealedDerived? {
-        guard let abi = abi else { return nil }
-        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
-    }
-
-    @_spi(WinRTInternal)
     override public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi: fromAbi)
     }
@@ -1365,19 +1210,19 @@ open class UnsealedDerived : test_component.Base {
     private static var _IUnsealedDerivedFactory : __ABI_test_component.IUnsealedDerivedFactory =  try! RoGetActivationFactory("test_component.UnsealedDerived")
 
     override public init() {
-        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+        super.init(composing: __IMPL_test_component.UnsealedDerivedBridge.Composable.self) { baseInterface, innerInterface in 
             try! Self._IUnsealedDerivedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
 
     public init(_ prop: Int32) {
-        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+        super.init(composing: __IMPL_test_component.UnsealedDerivedBridge.Composable.self) { baseInterface, innerInterface in 
             try! Self._IUnsealedDerivedFactory.CreateInstance2(prop, baseInterface, &innerInterface)
         }
     }
 
     public init(_ prop1: String, _ prop2: Base!) {
-        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+        super.init(composing: __IMPL_test_component.UnsealedDerivedBridge.Composable.self) { baseInterface, innerInterface in 
             try! Self._IUnsealedDerivedFactory.CreateInstance3(prop1, prop2, baseInterface, &innerInterface)
         }
     }
@@ -1392,35 +1237,11 @@ open class UnsealedDerived : test_component.Base {
         try _IUnsealedDerivedOverloads2.OnAfterDoTheThing()
     }
 
-    @_spi(WinRTInternal)
-        public enum IUnsealedDerivedOverloads2 : ComposableImpl {
-        public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
-        public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
-        public typealias Class = UnsealedDerived
-        public typealias SwiftProjection = WinRTClassWeakReference<Class>
-        public enum Default : AbiInterface {
-            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
-            public typealias SwiftABI = __ABI_test_component.IUnsealedDerived
-        }
-    }
-    @_spi(WinRTInternal)
-    public typealias Composable = IUnsealedDerivedOverloads2
     private lazy var _IUnsealedDerivedOverrides: __ABI_test_component.IUnsealedDerivedOverrides! = getInterfaceForCaching()
     open func onBeforeDoTheThing() throws {
         try _IUnsealedDerivedOverrides.OnBeforeDoTheThing()
     }
 
-    @_spi(WinRTInternal)
-        public enum IUnsealedDerivedOverrides : ComposableImpl {
-        public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverrides
-        public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverrides
-        public typealias Class = UnsealedDerived
-        public typealias SwiftProjection = WinRTClassWeakReference<Class>
-        public enum Default : AbiInterface {
-            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
-            public typealias SwiftABI = __ABI_test_component.IUnsealedDerived
-        }
-    }
     deinit {
         _default = nil
         _IUnsealedDerivedOverloads2 = nil
@@ -1441,12 +1262,6 @@ open class UnsealedDerived2 : test_component.UnsealedDerived {
     }
 
     @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerived2>?) -> UnsealedDerived2? {
-        guard let abi = abi else { return nil }
-        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
-    }
-
-    @_spi(WinRTInternal)
     override public init(fromAbi: test_component.IInspectable) {
         super.init(fromAbi: fromAbi)
     }
@@ -1464,7 +1279,7 @@ open class UnsealedDerived2 : test_component.UnsealedDerived {
     private static var _IUnsealedDerived2Factory : __ABI_test_component.IUnsealedDerived2Factory =  try! RoGetActivationFactory("test_component.UnsealedDerived2")
 
     override public init(_ prop: Int32) {
-        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+        super.init(composing: __IMPL_test_component.UnsealedDerived2Bridge.Composable.self) { baseInterface, innerInterface in 
             try! Self._IUnsealedDerived2Factory.CreateInstance(prop, baseInterface, &innerInterface)
         }
     }
@@ -1472,7 +1287,7 @@ open class UnsealedDerived2 : test_component.UnsealedDerived {
     private static var _IUnsealedDerived2ProtectedFactory : __ABI_test_component.IUnsealedDerived2ProtectedFactory =  try! RoGetActivationFactory("test_component.UnsealedDerived2")
 
     override public init() {
-        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+        super.init(composing: __IMPL_test_component.UnsealedDerived2Bridge.Composable.self) { baseInterface, innerInterface in 
             try! Self._IUnsealedDerived2ProtectedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
@@ -1481,19 +1296,6 @@ open class UnsealedDerived2 : test_component.UnsealedDerived {
         try _default.Method()
     }
 
-    @_spi(WinRTInternal)
-        public enum IUnsealedDerivedOverloads2 : ComposableImpl {
-        public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedOverloads2
-        public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedOverloads2
-        public typealias Class = UnsealedDerived2
-        public typealias SwiftProjection = WinRTClassWeakReference<Class>
-        public enum Default : AbiInterface {
-            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived2
-            public typealias SwiftABI = __ABI_test_component.IUnsealedDerived2
-        }
-    }
-    @_spi(WinRTInternal)
-    public typealias Composable = IUnsealedDerivedOverloads2
     deinit {
         _default = nil
     }
@@ -1509,12 +1311,6 @@ open class UnsealedDerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor>?) -> UnsealedDerivedFromNoConstructor? {
-        guard let abi = abi else { return nil }
-        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
     }
 
     @_spi(WinRTInternal)
@@ -1535,24 +1331,11 @@ open class UnsealedDerivedFromNoConstructor : test_component.UnsealedDerivedNoCo
     private static var _IUnsealedDerivedFromNoConstructorFactory : __ABI_test_component.IUnsealedDerivedFromNoConstructorFactory =  try! RoGetActivationFactory("test_component.UnsealedDerivedFromNoConstructor")
 
     public init() {
-        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+        super.init(composing: __IMPL_test_component.UnsealedDerivedFromNoConstructorBridge.Composable.self) { baseInterface, innerInterface in 
             try! Self._IUnsealedDerivedFromNoConstructorFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
 
-    @_spi(WinRTInternal)
-        public enum IBaseOverrides : ComposableImpl {
-        public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
-        public typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        public typealias Class = UnsealedDerivedFromNoConstructor
-        public typealias SwiftProjection = WinRTClassWeakReference<Class>
-        public enum Default : AbiInterface {
-            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor
-            public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedFromNoConstructor
-        }
-    }
-    @_spi(WinRTInternal)
-    public typealias Composable = IBaseOverrides
     deinit {
         _default = nil
     }
@@ -1568,12 +1351,6 @@ open class UnsealedDerivedNoConstructor : test_component.Base {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor>?) -> UnsealedDerivedNoConstructor? {
-        guard let abi = abi else { return nil }
-        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
     }
 
     @_spi(WinRTInternal)
@@ -1593,19 +1370,6 @@ open class UnsealedDerivedNoConstructor : test_component.Base {
     }
     private static var _IUnsealedDerivedNoConstructorFactory : __ABI_test_component.IUnsealedDerivedNoConstructorFactory =  try! RoGetActivationFactory("test_component.UnsealedDerivedNoConstructor")
 
-    @_spi(WinRTInternal)
-        public enum IBaseOverrides : ComposableImpl {
-        public typealias CABI = __x_ABI_Ctest__component_CIBaseOverrides
-        public typealias SwiftABI = __ABI_test_component.IBaseOverrides
-        public typealias Class = UnsealedDerivedNoConstructor
-        public typealias SwiftProjection = WinRTClassWeakReference<Class>
-        public enum Default : AbiInterface {
-            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor
-            public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoConstructor
-        }
-    }
-    @_spi(WinRTInternal)
-    public typealias Composable = IBaseOverrides
     deinit {
         _default = nil
     }
@@ -1621,12 +1385,6 @@ open class UnsealedDerivedNoOverrides : test_component.BaseNoOverrides {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides>?) -> UnsealedDerivedNoOverrides? {
-        guard let abi = abi else { return nil }
-        return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
     }
 
     @_spi(WinRTInternal)
@@ -1647,24 +1405,11 @@ open class UnsealedDerivedNoOverrides : test_component.BaseNoOverrides {
     private static var _IUnsealedDerivedNoOverridesProtectedFactory : __ABI_test_component.IUnsealedDerivedNoOverridesProtectedFactory =  try! RoGetActivationFactory("test_component.UnsealedDerivedNoOverrides")
 
     override public init() {
-        super.init(composing: Self.Composable.self) { baseInterface, innerInterface in 
+        super.init(composing: __IMPL_test_component.UnsealedDerivedNoOverridesBridge.Composable.self) { baseInterface, innerInterface in 
             try! Self._IUnsealedDerivedNoOverridesProtectedFactory.CreateInstance(baseInterface, &innerInterface)
         }
     }
 
-    @_spi(WinRTInternal)
-        public enum IUnsealedDerivedNoOverrides : ComposableImpl {
-        public typealias CABI = C_IInspectable
-        public typealias SwiftABI = test_component.IInspectable
-        public typealias Class = UnsealedDerivedNoOverrides
-        public typealias SwiftProjection = WinRTClassWeakReference<Class>
-        public enum Default : AbiInterface {
-            public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides
-            public typealias SwiftABI = __ABI_test_component.IUnsealedDerivedNoOverrides
-        }
-    }
-    @_spi(WinRTInternal)
-    public typealias Composable = IUnsealedDerivedNoOverrides
     deinit {
         _default = nil
     }
@@ -1680,12 +1425,6 @@ public final class WeakReferencer : WinRTClass {
             return RawPointer(_default)
         }
         return super._getABI()
-    }
-
-    @_spi(WinRTInternal)
-    public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIWeakReferencer>?) -> WeakReferencer? {
-        guard let abi = abi else { return nil }
-        return .init(fromAbi: test_component.IInspectable(abi))
     }
 
     @_spi(WinRTInternal)


### PR DESCRIPTION
This PR moves the WinRTClass to use the `AbiBridge` pattern for converting to/from the ABI. This makes the API more similar to the way interfaces work, and is a pre-cursor to array support

the bridge/contract pattern is required for classes/interfaces because they can not simply specify their abi convergence on the type themselves. as this would fail when trying to implement multiple interfaces or when using composable classes