### PR TITLE
Create WinRTBridgeable protocol for simple converting to/from the ABI

### DIFF
--- a/swiftwinrt/Resources/Support/GUID.swift
+++ b/swiftwinrt/Resources/Support/GUID.swift
@@ -70,8 +70,8 @@ extension Foundation.UUID: WinRTBridgeable {
         .init(from: abi)
     }
 
-    public func toAbi() -> GUID {
-        .init(from: swift)
+    public func toABI() -> GUID {
+        .init(from: self)
     }
 }
 

--- a/swiftwinrt/Resources/Support/GUID.swift
+++ b/swiftwinrt/Resources/Support/GUID.swift
@@ -63,6 +63,18 @@ public extension Foundation.UUID {
     }
 }
 
+@_spi(WinRTInternal)
+extension Foundation.UUID: WinRTBridgeable {
+    public typealias ABI = GUID
+    public static func from(abi: GUID) -> Foundation.UUID {
+        .init(from: abi)
+    }
+
+    public func toAbi() -> GUID {
+        .init(from: swift)
+    }
+}
+
 public extension GUID {
     init(from uuid: Foundation.UUID) {
         self.init(

--- a/swiftwinrt/Resources/Support/HString.swift
+++ b/swiftwinrt/Resources/Support/HString.swift
@@ -10,25 +10,7 @@ final public class HString {
   internal private(set) var hString: HSTRING?
   
   public init(_ string: String) throws {
-    let codeUnitCount = string.utf16.count
-    var pointer: UnsafeMutablePointer<UInt16>? = nil
-    var hStringBuffer: HSTRING_BUFFER? = nil
-
-    // Note: Methods like String.withCString are not used here because they do a copy to create a null
-    // terminated string, and requires an additional copy to create an HSTRING. Instead, a single copy is
-    // done by using WindowsPreallocateStringBuffer to allocate a buffer and directly copying the string into it.
-    try CHECKED(WindowsPreallocateStringBuffer(UInt32(codeUnitCount), &pointer, &hStringBuffer));
-    guard let pointer else { throw Error(hr: E_FAIL) }
-      _ = UnsafeMutableBufferPointer(start: pointer, count: codeUnitCount).initialize(from: string.utf16)
-    
-    do {
-      var hString: HSTRING? = nil
-      try CHECKED(WindowsPromoteStringBuffer(hStringBuffer, &hString));
-      self.hString = hString
-    } catch {
-      WindowsDeleteStringBuffer(hStringBuffer)
-      throw error
-    }
+    self.hString = try string.toABI()
   }
 
   public init(_ hString: HSTRING?) throws {
@@ -58,4 +40,3 @@ final public class HString {
     try! CHECKED(WindowsDeleteString(self.hString))
   }
 }
-

--- a/swiftwinrt/Resources/Support/Swift+Extensions.swift
+++ b/swiftwinrt/Resources/Support/Swift+Extensions.swift
@@ -43,10 +43,10 @@ extension StaticString {
 }
 
 @_spi(WinRTInternal)
-public extension String: WinRTBridgeable {
+extension String: WinRTBridgeable {
     public typealias ABI = HSTRING?
     public func toABI() throws -> HSTRING? {
-        let codeUnitCount = string.utf16.count
+        let codeUnitCount = utf16.count
         var pointer: UnsafeMutablePointer<UInt16>? = nil
         var hStringBuffer: HSTRING_BUFFER? = nil
 
@@ -55,15 +55,12 @@ public extension String: WinRTBridgeable {
         // done by using WindowsPreallocateStringBuffer to allocate a buffer and directly copying the string into it.
         try CHECKED(WindowsPreallocateStringBuffer(UInt32(codeUnitCount), &pointer, &hStringBuffer));
         guard let pointer else { throw Error(hr: E_FAIL) }
-        _ = UnsafeMutableBufferPointer(start: pointer, count: codeUnitCount).initialize(from: string.utf16)
+        _ = UnsafeMutableBufferPointer(start: pointer, count: codeUnitCount).initialize(from: utf16)
         
         do {
             var hString: HSTRING? = nil
             try CHECKED(WindowsPromoteStringBuffer(hStringBuffer, &hString));
-            guard let hstring else {
-                throw Error(hr: E_OUTOFMEMORY)
-            }
-            return hstring
+            return hString
         } catch {
             WindowsDeleteStringBuffer(hStringBuffer)
             throw error

--- a/swiftwinrt/Resources/Support/Swift+Extensions.swift
+++ b/swiftwinrt/Resources/Support/Swift+Extensions.swift
@@ -42,10 +42,56 @@ extension StaticString {
      }
 }
 
+@_spi(WinRTInternal)
+public extension String: WinRTBridgeable {
+    public typealias ABI = HSTRING?
+    public func toABI() throws -> HSTRING? {
+        let codeUnitCount = string.utf16.count
+        var pointer: UnsafeMutablePointer<UInt16>? = nil
+        var hStringBuffer: HSTRING_BUFFER? = nil
+
+        // Note: Methods like String.withCString are not used here because they do a copy to create a null
+        // terminated string, and requires an additional copy to create an HSTRING. Instead, a single copy is
+        // done by using WindowsPreallocateStringBuffer to allocate a buffer and directly copying the string into it.
+        try CHECKED(WindowsPreallocateStringBuffer(UInt32(codeUnitCount), &pointer, &hStringBuffer));
+        guard let pointer else { throw Error(hr: E_FAIL) }
+        _ = UnsafeMutableBufferPointer(start: pointer, count: codeUnitCount).initialize(from: string.utf16)
+        
+        do {
+            var hString: HSTRING? = nil
+            try CHECKED(WindowsPromoteStringBuffer(hStringBuffer, &hString));
+            guard let hstring else {
+                throw Error(hr: E_OUTOFMEMORY)
+            }
+            return hstring
+        } catch {
+            WindowsDeleteStringBuffer(hStringBuffer)
+            throw error
+        }
+    }
+
+    public static func from(abi: HSTRING?) -> String {
+        String(from: abi)
+    }
+}
+
 extension Bool {
   public init(from val: boolean) {
     self.init(booleanLiteral: val != 0)
   }
+}
+
+@_spi(WinRTInternal)
+extension Bool: WinRTBridgeable {
+    public typealias ABI = boolean
+    
+    public func toABI() -> boolean {
+        return .init(from: self)
+    }
+    
+    public static func from(abi: boolean) -> Bool {
+        return .init(from: abi)
+    }
 }
 
 extension Character {
@@ -56,6 +102,19 @@ extension Character {
       self.init("")
     }
   }
+}
+
+@_spi(WinRTInternal)
+extension Character: WinRTBridgeable {
+    public typealias ABI = WCHAR
+    
+    public func toABI() -> WCHAR {
+        return WCHAR(self.unicodeScalars.first?.value ?? 0)
+    }
+    
+    public static func from(abi: WCHAR) -> Character {
+        return Character(from: abi)
+    }
 }
 
 extension UnsafeMutableRawPointer {

--- a/swiftwinrt/Resources/Support/WinRTBridgeable.swift
+++ b/swiftwinrt/Resources/Support/WinRTBridgeable.swift
@@ -7,7 +7,7 @@ public protocol ToAbi {
 @_spi(WinRTInternal)
 public protocol FromAbi {
     associatedtype ABI
-    static func from(abi: ABI) throws -> Self
+    static func from(abi: ABI) -> Self
 }
 
 @_spi(WinRTInternal)

--- a/swiftwinrt/Resources/Support/WinRTBridgeable.swift
+++ b/swiftwinrt/Resources/Support/WinRTBridgeable.swift
@@ -1,0 +1,14 @@
+@_spi(WinRTInternal)
+public protocol ToAbi {
+    associatedtype ABI
+    func toABI() throws -> ABI
+}
+
+@_spi(WinRTInternal)
+public protocol FromAbi {
+    associatedtype ABI
+    static func from(abi: ABI) throws -> Self
+}
+
+@_spi(WinRTInternal)
+public typealias WinRTBridgeable = ToAbi & FromAbi

--- a/swiftwinrt/code_writers/struct_writers.cpp
+++ b/swiftwinrt/code_writers/struct_writers.cpp
@@ -98,8 +98,12 @@ namespace swiftwinrt
             }
             w.write("}\n");
 
-            w.write("public static func from(abi: %) -> % {\n",
-                bind_type_mangled(type), type);
+        w.write("@_spi(WinRTInternal)\n");
+        w.write("extension %: WinRTBridgeable {\n", type);
+        {
+            auto indent_guard1 = w.push_indent();
+            w.write("public typealias ABI = %\n", bind_type_mangled(type));
+            w.write("public static func from(abi: ABI) -> Self {\n");
             {
                 auto from_body_indent = w.push_indent();
 
@@ -118,6 +122,20 @@ namespace swiftwinrt
                     }
                 }
                 w.write(")\n");
+            }
+            w.write("}\n");
+
+            w.write("public func toABI() -> ABI {\n");
+            {
+                auto from_body_indent = w.push_indent();
+                if (is_struct_blittable(type))
+                {
+                    w.write(".from(swift: self)\n");
+                }
+                else
+                {
+                     w.write("%._ABI_%(from: self).detach()\n", abi_namespace(type), type.swift_type_name());
+                }
             }
             w.write("}\n");
         }

--- a/swiftwinrt/code_writers/struct_writers.cpp
+++ b/swiftwinrt/code_writers/struct_writers.cpp
@@ -97,7 +97,12 @@ namespace swiftwinrt
                 }
             }
             w.write("}\n");
+        }
+        w.write("}\n\n");
+    }
 
+    void write_struct_bridgeable(writer& w, struct_type const& type)
+    {
         w.write("@_spi(WinRTInternal)\n");
         w.write("extension %: WinRTBridgeable {\n", type);
         {

--- a/swiftwinrt/code_writers/struct_writers.h
+++ b/swiftwinrt/code_writers/struct_writers.h
@@ -6,4 +6,5 @@ namespace swiftwinrt
     void write_struct_initializer_params(writer& w, struct_type const& type);
     void write_struct_init_extension(writer& w, struct_type const& type);
     void write_struct(writer& w, struct_type const& type);
+    void write_struct_bridgeable(writer& w, struct_type const& type);
 }

--- a/swiftwinrt/file_writers.h
+++ b/swiftwinrt/file_writers.h
@@ -234,6 +234,9 @@ namespace swiftwinrt
             w.write("%", w.filter.bind_each<write_delegate_implementation>(members.delegates));
             w.write("%", w.filter.bind_each<write_class_bridge>(members.classes));
         }
+
+        w.write("%", w.filter.bind_each<write_struct_bridgeable>(members.structs));
+
         w.swap();
         write_preamble(w, /* swift_code: */ true);
 

--- a/swiftwinrt/resources.rc
+++ b/swiftwinrt/resources.rc
@@ -33,6 +33,7 @@ WinRTWrapperBase RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\WinRTWrap
 WinSDK+Extensions RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\WinSDK+Extensions.swift"
 PropertyValue RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\PropertyValue.swift"
 PropertyValue+ABI RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\PropertyValue+ABI.swift"
+WinRTBridgeable RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\WinRTBridgeable.swift"
 WinRTProtocols RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\WinRTProtocols.swift"
 Event RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\Events\\Event.swift"
 EventHandlerSubscription RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\Events\\EventHandlerSubscription.swift"

--- a/tests/test_component/Sources/test_component/Windows.Data.Text+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Data.Text+Impl.swift
@@ -6,3 +6,14 @@ import Ctest_component
 @_spi(WinRTInternal)
 public enum __IMPL_Windows_Data_Text {
 }
+@_spi(WinRTInternal)
+extension TextSegment: WinRTBridgeable {
+    public typealias ABI = __x_ABI_CWindows_CData_CText_CTextSegment
+    public static func from(abi: ABI) -> Self {
+        .init(startPosition: abi.StartPosition, length: abi.Length)
+    }
+    public func toABI() -> ABI {
+        .from(swift: self)
+    }
+}
+

--- a/tests/test_component/Sources/test_component/Windows.Data.Text.swift
+++ b/tests/test_component/Sources/test_component/Windows.Data.Text.swift
@@ -14,8 +14,5 @@ public struct TextSegment: Hashable, Codable, Sendable {
         self.startPosition = startPosition
         self.length = length
     }
-    public static func from(abi: __x_ABI_CWindows_CData_CText_CTextSegment) -> TextSegment {
-        .init(startPosition: abi.StartPosition, length: abi.Length)
-    }
 }
 

--- a/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation+Impl.swift
@@ -462,3 +462,58 @@ public enum __IMPL_Windows_Foundation {
     }
 
 }
+@_spi(WinRTInternal)
+extension DateTime: WinRTBridgeable {
+    public typealias ABI = __x_ABI_CWindows_CFoundation_CDateTime
+    public static func from(abi: ABI) -> Self {
+        .init(universalTime: abi.UniversalTime)
+    }
+    public func toABI() -> ABI {
+        .from(swift: self)
+    }
+}
+
+@_spi(WinRTInternal)
+extension Point: WinRTBridgeable {
+    public typealias ABI = __x_ABI_CWindows_CFoundation_CPoint
+    public static func from(abi: ABI) -> Self {
+        .init(x: abi.X, y: abi.Y)
+    }
+    public func toABI() -> ABI {
+        .from(swift: self)
+    }
+}
+
+@_spi(WinRTInternal)
+extension Rect: WinRTBridgeable {
+    public typealias ABI = __x_ABI_CWindows_CFoundation_CRect
+    public static func from(abi: ABI) -> Self {
+        .init(x: abi.X, y: abi.Y, width: abi.Width, height: abi.Height)
+    }
+    public func toABI() -> ABI {
+        .from(swift: self)
+    }
+}
+
+@_spi(WinRTInternal)
+extension Size: WinRTBridgeable {
+    public typealias ABI = __x_ABI_CWindows_CFoundation_CSize
+    public static func from(abi: ABI) -> Self {
+        .init(width: abi.Width, height: abi.Height)
+    }
+    public func toABI() -> ABI {
+        .from(swift: self)
+    }
+}
+
+@_spi(WinRTInternal)
+extension TimeSpan: WinRTBridgeable {
+    public typealias ABI = __x_ABI_CWindows_CFoundation_CTimeSpan
+    public static func from(abi: ABI) -> Self {
+        .init(duration: abi.Duration)
+    }
+    public func toABI() -> ABI {
+        .from(swift: self)
+    }
+}
+

--- a/tests/test_component/Sources/test_component/Windows.Foundation.swift
+++ b/tests/test_component/Sources/test_component/Windows.Foundation.swift
@@ -341,9 +341,6 @@ public struct DateTime: Hashable, Codable, Sendable {
     public init(universalTime: Int64) {
         self.universalTime = universalTime
     }
-    public static func from(abi: __x_ABI_CWindows_CFoundation_CDateTime) -> DateTime {
-        .init(universalTime: abi.UniversalTime)
-    }
 }
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.point)
@@ -356,9 +353,6 @@ public struct Point: Hashable, Codable, Sendable {
     public init(x: Float, y: Float) {
         self.x = x
         self.y = y
-    }
-    public static func from(abi: __x_ABI_CWindows_CFoundation_CPoint) -> Point {
-        .init(x: abi.X, y: abi.Y)
     }
 }
 
@@ -379,9 +373,6 @@ public struct Rect: Hashable, Codable, Sendable {
         self.width = width
         self.height = height
     }
-    public static func from(abi: __x_ABI_CWindows_CFoundation_CRect) -> Rect {
-        .init(x: abi.X, y: abi.Y, width: abi.Width, height: abi.Height)
-    }
 }
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.size)
@@ -395,9 +386,6 @@ public struct Size: Hashable, Codable, Sendable {
         self.width = width
         self.height = height
     }
-    public static func from(abi: __x_ABI_CWindows_CFoundation_CSize) -> Size {
-        .init(width: abi.Width, height: abi.Height)
-    }
 }
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.foundation.timespan)
@@ -407,9 +395,6 @@ public struct TimeSpan: Hashable, Codable, Sendable {
     public init() {}
     public init(duration: Int64) {
         self.duration = duration
-    }
-    public static func from(abi: __x_ABI_CWindows_CFoundation_CTimeSpan) -> TimeSpan {
-        .init(duration: abi.Duration)
     }
 }
 

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search+Impl.swift
@@ -228,3 +228,14 @@ public enum __IMPL_Windows_Storage_Search {
     }
 
 }
+@_spi(WinRTInternal)
+extension SortEntry: WinRTBridgeable {
+    public typealias ABI = __x_ABI_CWindows_CStorage_CSearch_CSortEntry
+    public static func from(abi: ABI) -> Self {
+        .init(propertyName: .init(from: abi.PropertyName), ascendingOrder: .init(from: abi.AscendingOrder))
+    }
+    public func toABI() -> ABI {
+        __ABI_Windows_Storage_Search._ABI_SortEntry(from: self).detach()
+    }
+}
+

--- a/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
+++ b/tests/test_component/Sources/test_component/Windows.Storage.Search.swift
@@ -414,9 +414,6 @@ public struct SortEntry: Hashable, Codable, Sendable {
         self.propertyName = propertyName
         self.ascendingOrder = ascendingOrder
     }
-    public static func from(abi: __x_ABI_CWindows_CStorage_CSearch_CSortEntry) -> SortEntry {
-        .init(propertyName: .init(from: abi.PropertyName), ascendingOrder: .init(from: abi.AscendingOrder))
-    }
 }
 
 /// [Open Microsoft documentation](https://learn.microsoft.com/uwp/api/windows.storage.search.istoragefolderqueryoperations)

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -717,3 +717,69 @@ public enum __IMPL_test_component {
     }
 
 }
+@_spi(WinRTInternal)
+extension BlittableStruct: WinRTBridgeable {
+    public typealias ABI = __x_ABI_Ctest__component_CBlittableStruct
+    public static func from(abi: ABI) -> Self {
+        .init(first: abi.First, second: abi.Second)
+    }
+    public func toABI() -> ABI {
+        .from(swift: self)
+    }
+}
+
+@_spi(WinRTInternal)
+extension NonBlittableBoolStruct: WinRTBridgeable {
+    public typealias ABI = __x_ABI_Ctest__component_CNonBlittableBoolStruct
+    public static func from(abi: ABI) -> Self {
+        .init(first: .init(from: abi.First), second: .init(from: abi.Second), third: .init(from: abi.Third), fourth: .init(from: abi.Fourth))
+    }
+    public func toABI() -> ABI {
+        __ABI_test_component._ABI_NonBlittableBoolStruct(from: self).detach()
+    }
+}
+
+@_spi(WinRTInternal)
+extension NonBlittableStruct: WinRTBridgeable {
+    public typealias ABI = __x_ABI_Ctest__component_CNonBlittableStruct
+    public static func from(abi: ABI) -> Self {
+        .init(first: .init(from: abi.First), second: .init(from: abi.Second), third: abi.Third, fourth: .init(from: abi.Fourth))
+    }
+    public func toABI() -> ABI {
+        __ABI_test_component._ABI_NonBlittableStruct(from: self).detach()
+    }
+}
+
+@_spi(WinRTInternal)
+extension SimpleEventArgs: WinRTBridgeable {
+    public typealias ABI = __x_ABI_Ctest__component_CSimpleEventArgs
+    public static func from(abi: ABI) -> Self {
+        .init(value: abi.Value)
+    }
+    public func toABI() -> ABI {
+        .from(swift: self)
+    }
+}
+
+@_spi(WinRTInternal)
+extension StructWithEnum: WinRTBridgeable {
+    public typealias ABI = __x_ABI_Ctest__component_CStructWithEnum
+    public static func from(abi: ABI) -> Self {
+        .init(names: abi.Names)
+    }
+    public func toABI() -> ABI {
+        .from(swift: self)
+    }
+}
+
+@_spi(WinRTInternal)
+extension StructWithIReference: WinRTBridgeable {
+    public typealias ABI = __x_ABI_Ctest__component_CStructWithIReference
+    public static func from(abi: ABI) -> Self {
+        .init(value1: test_component.__x_ABI_C__FIReference_1_intWrapper.unwrapFrom(abi: ComPtr(abi.Value1)), value2: test_component.__x_ABI_C__FIReference_1_intWrapper.unwrapFrom(abi: ComPtr(abi.Value2)))
+    }
+    public func toABI() -> ABI {
+        __ABI_test_component._ABI_StructWithIReference(from: self).detach()
+    }
+}
+

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -1456,9 +1456,6 @@ public struct BlittableStruct: Hashable, Codable, Sendable {
         self.first = first
         self.second = second
     }
-    public static func from(abi: __x_ABI_Ctest__component_CBlittableStruct) -> BlittableStruct {
-        .init(first: abi.First, second: abi.Second)
-    }
 }
 
 public struct NonBlittableBoolStruct: Hashable, Codable, Sendable {
@@ -1472,9 +1469,6 @@ public struct NonBlittableBoolStruct: Hashable, Codable, Sendable {
         self.second = second
         self.third = third
         self.fourth = fourth
-    }
-    public static func from(abi: __x_ABI_Ctest__component_CNonBlittableBoolStruct) -> NonBlittableBoolStruct {
-        .init(first: .init(from: abi.First), second: .init(from: abi.Second), third: .init(from: abi.Third), fourth: .init(from: abi.Fourth))
     }
 }
 
@@ -1490,9 +1484,6 @@ public struct NonBlittableStruct: Hashable, Codable, Sendable {
         self.third = third
         self.fourth = fourth
     }
-    public static func from(abi: __x_ABI_Ctest__component_CNonBlittableStruct) -> NonBlittableStruct {
-        .init(first: .init(from: abi.First), second: .init(from: abi.Second), third: abi.Third, fourth: .init(from: abi.Fourth))
-    }
 }
 
 public struct SimpleEventArgs: Hashable, Codable, Sendable {
@@ -1501,9 +1492,6 @@ public struct SimpleEventArgs: Hashable, Codable, Sendable {
     public init(value: Int32) {
         self.value = value
     }
-    public static func from(abi: __x_ABI_Ctest__component_CSimpleEventArgs) -> SimpleEventArgs {
-        .init(value: abi.Value)
-    }
 }
 
 public struct StructWithEnum: Hashable, Codable, Sendable {
@@ -1511,9 +1499,6 @@ public struct StructWithEnum: Hashable, Codable, Sendable {
     public init() {}
     public init(names: SwiftifiableNames) {
         self.names = names
-    }
-    public static func from(abi: __x_ABI_Ctest__component_CStructWithEnum) -> StructWithEnum {
-        .init(names: abi.Names)
     }
 }
 
@@ -1524,9 +1509,6 @@ public struct StructWithIReference: Hashable, Codable, Sendable {
     public init(value1: Int32?, value2: Int32?) {
         self.value1 = value1
         self.value2 = value2
-    }
-    public static func from(abi: __x_ABI_Ctest__component_CStructWithIReference) -> StructWithIReference {
-        .init(value1: test_component.__x_ABI_C__FIReference_1_intWrapper.unwrapFrom(abi: ComPtr(abi.Value1)), value2: test_component.__x_ABI_C__FIReference_1_intWrapper.unwrapFrom(abi: ComPtr(abi.Value2)))
     }
 }
 


### PR DESCRIPTION
This creates a `WinRTBridgeable` protocol to be used when converting arrays from Swift to WinRT. Could also be useful in other places, but currently no major code changes have been made. The existing `.from` method on the swift struct was moved to the extension which adheres to the `WinRTBridgeable` type