### PR TITLE
Fix WinGet install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,10 @@ git submodule init
 git submodule update --recursive
 ```
 
-Install the required version of the Windows SDK if you don't already have it (currently 10.0.17763):
+Install the required version of the Windows SDK if you don't already have it, currently `10.0.17763`. Note that the WinGet package id for that version of the Windows SDK incorrectly uses `10.0.17736` as the version number.
+
 ```
-winget install --id Microsoft.WindowsSDK.10.0.17763
+winget install --id Microsoft.WindowsSDK.10.0.17736
 ```
 
 ### Integrated Build with CMake


### PR DESCRIPTION
The WinGet package name for the 17763 version of the Windows SDK is 17736, erroneously. Specify it in the instructions.

Fixes #191