### PR TITLE
Pin the Windows SDK to one compatible with our Swift toolchain

### DIFF
--- a/.github/actions/windows-build/action.yml
+++ b/.github/actions/windows-build/action.yml
@@ -23,12 +23,6 @@ runs:
       release-tag-name: 20231025.2
       release-asset-name: installer-amd64.exe
 
-#  - name: Install Swift
-#    uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main as of 2024-11-12
-#    with:
-#      branch: swift-6.0-release
-#      tag: 6.0-RELEASE
-
   - name: Configure CMake
     shell: cmd
     run: cmake --preset ${{ inputs.config }}

--- a/.github/actions/windows-build/action.yml
+++ b/.github/actions/windows-build/action.yml
@@ -17,9 +17,9 @@ runs:
 
   - name: Install Swift
     uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main as of 2024-11-12
-      with:
-        branch: swift-6.0-release
-        tag: 6.0-RELEASE
+    with:
+      branch: swift-6.0-release
+      tag: 6.0-RELEASE
 
   - name: Configure CMake
     shell: cmd

--- a/.github/actions/windows-build/action.yml
+++ b/.github/actions/windows-build/action.yml
@@ -15,11 +15,19 @@ runs:
       arch: amd64
       winsdk: "10.0.22621.0" # GitHub runners have 10.0.26100.0 which regresses Swift's ucrt module
 
-  - name: Install Swift
-    uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main as of 2024-11-12
+  - name: Install private Swift toolchain
+    uses: compnerd/gha-setup-swift@81f383b35a86e6e966de139be25b451d4f7dd953
     with:
-      branch: swift-6.0-release
-      tag: 6.0-RELEASE
+      github-repo: thebrowsercompany/swift-build
+      github-token: ${{ inputs.GITHUB_TOKEN }}
+      release-tag-name: 20231025.2
+      release-asset-name: installer-amd64.exe
+
+#  - name: Install Swift
+#    uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main as of 2024-11-12
+#    with:
+#      branch: swift-6.0-release
+#      tag: 6.0-RELEASE
 
   - name: Configure CMake
     shell: cmd

--- a/.github/actions/windows-build/action.yml
+++ b/.github/actions/windows-build/action.yml
@@ -10,17 +10,16 @@ runs:
 
   steps:
   - name: Configure VC++ build for amd64
-    uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557
+    uses: compnerd/gha-setup-vsdevenv@f1ba60d553a3216ce1b89abe0201213536bc7557 # main as of 2024-11-12
     with:
       arch: amd64
+      winsdk: "10.0.22621.0" # GitHub runners have 10.0.26100.0 which regresses Swift's ucrt module
 
-  - name: Install private Swift toolchain
-    uses: compnerd/gha-setup-swift@81f383b35a86e6e966de139be25b451d4f7dd953
-    with:
-      github-repo: thebrowsercompany/swift-build
-      github-token: ${{ inputs.GITHUB_TOKEN }}
-      release-tag-name: 20231025.2
-      release-asset-name: installer-amd64.exe
+  - name: Install Swift
+    uses: compnerd/gha-setup-swift@b6c5fc1ed5b5439ada8e7661985acb09ad8c3ba2 # main as of 2024-11-12
+      with:
+        branch: swift-6.0-release
+        tag: 6.0-RELEASE
 
   - name: Configure CMake
     shell: cmd


### PR DESCRIPTION
Newer GitHub runners default to a Windows SDK that is not compatible with the Swift toolchain we use in the build.