### PR TITLE
dont use IOUs in array properties

### DIFF
--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -1445,11 +1445,8 @@ vtable);
             {
                 if (!can_write(w, prop)) continue;
                 auto full_type_name = w.push_full_type_names(true);
-                auto propertyType = w.write_temp("%", bind<write_type>(*prop.getter->return_type->type, swift_write_type_params_for(type)));
-                if (prop.is_array())
-                {
-                    propertyType = w.write_temp("[%]", propertyType);
-                }
+                auto format = prop.is_array() ? "[%]" : "%";
+                auto propertyType = w.write_temp(format, bind<write_type>(*prop.getter->return_type->type, swift_write_type_params_for(type, prop.is_array())));
                 write_documentation_comment(w, type, prop.def.Name());
                 w.write("var %: % { get% }\n",
                     get_swift_name(prop),

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -2367,11 +2367,8 @@ public init<Composable: ComposableImpl>(
 
         if (prop.getter)
         {
-            auto propertyType = w.write_temp("%", bind<write_type>(*prop.getter->return_type->type, swift_write_type_params_for(*iface.type)));
-            if (prop.is_array())
-            {
-                propertyType = w.write_temp("[%]", propertyType);
-            }
+            auto format = prop.is_array() ? "[%]" : "%";
+            auto propertyType = w.write_temp(format, bind<write_type>(*prop.getter->return_type->type, swift_write_type_params_for(*iface.type, prop.is_array())));
             w.write("%var % : % {\n",
                 modifier_for(type_definition, iface),
                 get_swift_name(prop),

--- a/swiftwinrt/code_writers/type_writers.cpp
+++ b/swiftwinrt/code_writers/type_writers.cpp
@@ -324,12 +324,12 @@ void swiftwinrt::write_default_init_assignment(writer& w, metadata_type const& s
     }
 }
 
-write_type_params swiftwinrt::swift_write_type_params_for(metadata_type const& type)
+write_type_params swiftwinrt::swift_write_type_params_for(metadata_type const& type, bool is_array)
 {
     // When implementing a generic interface,
     // we cannot use implicit unwrapping, because of Swift limitations:
     // typename Element must be Base? and not Base!,
     // and declaring GetAt(_: UInt32) -> Base! would not bind to GetAt(_: UInt32) -> Element.
-    auto is_generic = is_generic_def(type) || is_generic_inst(type);
+    auto is_generic = is_generic_def(type) || is_generic_inst(type) ||  is_array;
     return is_generic ? write_type_params::swift : write_type_params::swift_allow_implicit_unwrap;
 }

--- a/swiftwinrt/code_writers/type_writers.h
+++ b/swiftwinrt/code_writers/type_writers.h
@@ -49,5 +49,5 @@ namespace swiftwinrt
     void write_default_value(writer& w, metadata_type const& sig, projection_layer layer);
     void write_default_init_assignment(writer& w, metadata_type const& sig, projection_layer layer);
 
-    write_type_params swift_write_type_params_for(metadata_type const& type);
+    write_type_params swift_write_type_params_for(metadata_type const& type, bool is_array = false);
 }

--- a/tests/test_component/Sources/CWinRT/include/test_component.h
+++ b/tests/test_component/Sources/CWinRT/include/test_component.h
@@ -42,6 +42,12 @@ typedef interface __x_ABI_Ctest__component_CIVoidToVoidDelegate __x_ABI_Ctest__c
 
 #endif // ____x_ABI_Ctest__component_CIArrayScenarios_FWD_DEFINED__
 
+#ifndef ____x_ABI_Ctest__component_CIArrayShouldBuild_FWD_DEFINED__
+#define ____x_ABI_Ctest__component_CIArrayShouldBuild_FWD_DEFINED__
+    typedef interface __x_ABI_Ctest__component_CIArrayShouldBuild __x_ABI_Ctest__component_CIArrayShouldBuild;
+
+#endif // ____x_ABI_Ctest__component_CIArrayShouldBuild_FWD_DEFINED__
+
 #ifndef ____x_ABI_Ctest__component_CIAsyncMethodsStatics_FWD_DEFINED__
 #define ____x_ABI_Ctest__component_CIAsyncMethodsStatics_FWD_DEFINED__
     typedef interface __x_ABI_Ctest__component_CIAsyncMethodsStatics __x_ABI_Ctest__component_CIAsyncMethodsStatics;
@@ -2859,6 +2865,40 @@ struct __x_ABI_Ctest__component_CStructWithIReference
     
     EXTERN_C const IID IID___x_ABI_Ctest__component_CIArrayScenarios;
 #endif /* !defined(____x_ABI_Ctest__component_CIArrayScenarios_INTERFACE_DEFINED__) */
+    
+#if !defined(____x_ABI_Ctest__component_CIArrayShouldBuild_INTERFACE_DEFINED__)
+    #define ____x_ABI_Ctest__component_CIArrayShouldBuild_INTERFACE_DEFINED__
+    typedef struct __x_ABI_Ctest__component_CIArrayShouldBuildVtbl
+    {
+        BEGIN_INTERFACE
+
+        HRESULT (STDMETHODCALLTYPE* QueryInterface)(__x_ABI_Ctest__component_CIArrayShouldBuild* This,
+            REFIID riid,
+            void** ppvObject);
+        ULONG (STDMETHODCALLTYPE* AddRef)(__x_ABI_Ctest__component_CIArrayShouldBuild* This);
+        ULONG (STDMETHODCALLTYPE* Release)(__x_ABI_Ctest__component_CIArrayShouldBuild* This);
+        HRESULT (STDMETHODCALLTYPE* GetIids)(__x_ABI_Ctest__component_CIArrayShouldBuild* This,
+            ULONG* iidCount,
+            IID** iids);
+        HRESULT (STDMETHODCALLTYPE* GetRuntimeClassName)(__x_ABI_Ctest__component_CIArrayShouldBuild* This,
+            HSTRING* className);
+        HRESULT (STDMETHODCALLTYPE* GetTrustLevel)(__x_ABI_Ctest__component_CIArrayShouldBuild* This,
+            TrustLevel* trustLevel);
+        HRESULT (STDMETHODCALLTYPE* get_Scenarios)(__x_ABI_Ctest__component_CIArrayShouldBuild* This,
+        UINT32* valueLength,
+        __x_ABI_Ctest__component_CIArrayScenarios*** value);
+
+        END_INTERFACE
+    } __x_ABI_Ctest__component_CIArrayShouldBuildVtbl;
+
+    interface __x_ABI_Ctest__component_CIArrayShouldBuild
+    {
+        CONST_VTBL struct __x_ABI_Ctest__component_CIArrayShouldBuildVtbl* lpVtbl;
+    };
+
+    
+    EXTERN_C const IID IID___x_ABI_Ctest__component_CIArrayShouldBuild;
+#endif /* !defined(____x_ABI_Ctest__component_CIArrayShouldBuild_INTERFACE_DEFINED__) */
     
 #if !defined(____x_ABI_Ctest__component_CIAsyncMethodsStatics_INTERFACE_DEFINED__)
     #define ____x_ABI_Ctest__component_CIAsyncMethodsStatics_INTERFACE_DEFINED__

--- a/tests/test_component/Sources/test_component/test_component+ABI.swift
+++ b/tests/test_component/Sources/test_component/test_component+ABI.swift
@@ -11,6 +11,10 @@ private var IID___x_ABI_Ctest__component_CIArrayScenarios: test_component.IID {
     .init(Data1: 0x56558D36, Data2: 0xC35F, Data3: 0x5624, Data4: ( 0xB3,0xB1,0xF3,0xF3,0x65,0x26,0x57,0xA3 ))// 56558D36-C35F-5624-B3B1-F3F3652657A3
 }
 
+private var IID___x_ABI_Ctest__component_CIArrayShouldBuild: test_component.IID {
+    .init(Data1: 0xA0DB5CFD, Data2: 0xD277, Data3: 0x585A, Data4: ( 0xA0,0xAC,0xC2,0x18,0x5C,0x18,0xE9,0x72 ))// A0DB5CFD-D277-585A-A0AC-C2185C18E972
+}
+
 private var IID___x_ABI_Ctest__component_CIAsyncMethodsStatics: test_component.IID {
     .init(Data1: 0x5FAAD8F4, Data2: 0x29D7, Data3: 0x5C26, Data4: ( 0xA8,0x72,0x35,0x42,0xE3,0xE1,0x86,0x7A ))// 5FAAD8F4-29D7-5C26-A872-3542E3E1867A
 }
@@ -802,6 +806,59 @@ public enum __ABI_test_component {
     )
 
     public typealias IArrayScenariosWrapper = InterfaceWrapperBase<__IMPL_test_component.IArrayScenariosBridge>
+    public class IArrayShouldBuild: test_component.IInspectable {
+        override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIArrayShouldBuild }
+
+        open func get_Scenarios() throws -> [test_component.AnyIArrayScenarios?] {
+            var value: WinRTArrayAbi<UnsafeMutablePointer<__x_ABI_Ctest__component_CIArrayScenarios>?> = (0, nil)
+            _ = try perform(as: __x_ABI_Ctest__component_CIArrayShouldBuild.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.get_Scenarios(pThis, &value.count, &value.start))
+            }
+            defer { CoTaskMemFree(value.start) }
+            return .from(abiBridge: __IMPL_test_component.IArrayScenariosBridge.self, abi: value)
+
+        }
+
+    }
+
+    internal static var IArrayShouldBuildVTable: __x_ABI_Ctest__component_CIArrayShouldBuildVtbl = .init(
+        QueryInterface: { IArrayShouldBuildWrapper.queryInterface($0, $1, $2) },
+        AddRef: { IArrayShouldBuildWrapper.addRef($0) },
+        Release: { IArrayShouldBuildWrapper.release($0) },
+        GetIids: {
+            let size = MemoryLayout<test_component.IID>.size
+            let iids = CoTaskMemAlloc(UInt64(size) * 3).assumingMemoryBound(to: test_component.IID.self)
+            iids[0] = IUnknown.IID
+            iids[1] = IInspectable.IID
+            iids[2] = __ABI_test_component.IArrayShouldBuildWrapper.IID
+            $1!.pointee = 3
+            $2!.pointee = iids
+            return S_OK
+        },
+
+        GetRuntimeClassName: {
+            _ = $0
+            let hstring = try! HString("test_component.IArrayShouldBuild").detach()
+            $1!.pointee = hstring
+            return S_OK
+        },
+
+        GetTrustLevel: {
+            _ = $0
+            $1!.pointee = TrustLevel(rawValue: 0)
+            return S_OK
+        },
+
+        get_Scenarios: {
+            guard let __unwrapped__instance = IArrayShouldBuildWrapper.tryUnwrapFrom(raw: $0) else { return E_INVALIDARG }
+            let value = __unwrapped__instance.scenarios
+            $1?.initialize(to: UInt32(value.count))
+            value.fill(abi: $2, abiBridge: __IMPL_test_component.IArrayScenariosBridge.self)
+            return S_OK
+        }
+    )
+
+    public typealias IArrayShouldBuildWrapper = InterfaceWrapperBase<__IMPL_test_component.IArrayShouldBuildBridge>
     public class IAsyncMethodsStatics: test_component.IInspectable {
         override public class var IID: test_component.IID { IID___x_ABI_Ctest__component_CIAsyncMethodsStatics }
 

--- a/tests/test_component/Sources/test_component/test_component+Impl.swift
+++ b/tests/test_component/Sources/test_component/test_component+Impl.swift
@@ -71,6 +71,35 @@ public enum __IMPL_test_component {
 
     }
 
+    public enum IArrayShouldBuildBridge : AbiInterfaceBridge {
+        public typealias CABI = __x_ABI_Ctest__component_CIArrayShouldBuild
+        public typealias SwiftABI = __ABI_test_component.IArrayShouldBuild
+        public typealias SwiftProjection = AnyIArrayShouldBuild
+        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+            guard let abi = abi else { return nil }
+            return IArrayShouldBuildImpl(abi)
+        }
+
+        public static func makeAbi() -> CABI {
+            let vtblPtr = withUnsafeMutablePointer(to: &__ABI_test_component.IArrayShouldBuildVTable) { $0 }
+            return .init(lpVtbl: vtblPtr)
+        }
+    }
+
+    fileprivate class IArrayShouldBuildImpl: IArrayShouldBuild, WinRTAbiImpl {
+        fileprivate typealias Bridge = IArrayShouldBuildBridge
+        fileprivate let _default: Bridge.SwiftABI
+        fileprivate var thisPtr: test_component.IInspectable { _default }
+        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+            _default = Bridge.SwiftABI(fromAbi)
+        }
+
+        fileprivate var scenarios : [AnyIArrayScenarios?] {
+            get { try! _default.get_Scenarios() }
+        }
+
+    }
+
     public enum IAsyncMethodsWithProgressBridge : AbiInterfaceBridge {
         public typealias CABI = __x_ABI_Ctest__component_CIAsyncMethodsWithProgress
         public typealias SwiftABI = __ABI_test_component.IAsyncMethodsWithProgress
@@ -869,6 +898,14 @@ public class IArrayScenariosMaker: MakeFromAbi {
     public static func from(abi: test_component.IInspectable) -> SwiftType {
         let swiftAbi: __ABI_test_component.IArrayScenarios = try! abi.QueryInterface()
         return __IMPL_test_component.IArrayScenariosBridge.from(abi: RawPointer(swiftAbi))!
+    }
+}
+@_spi(WinRTInternal)
+public class IArrayShouldBuildMaker: MakeFromAbi {
+    public typealias SwiftType = AnyIArrayShouldBuild
+    public static func from(abi: test_component.IInspectable) -> SwiftType {
+        let swiftAbi: __ABI_test_component.IArrayShouldBuild = try! abi.QueryInterface()
+        return __IMPL_test_component.IArrayShouldBuildBridge.from(abi: RawPointer(swiftAbi))!
     }
 }
 @_spi(WinRTInternal)

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -1686,6 +1686,22 @@ extension IArrayScenarios {
 }
 public typealias AnyIArrayScenarios = any IArrayScenarios
 
+public protocol IArrayShouldBuild : WinRTInterface {
+    var scenarios: [test_component.AnyIArrayScenarios!] { get }
+}
+
+extension IArrayShouldBuild {
+    public func queryInterface(_ iid: test_component.IID) -> IUnknownRef? {
+        switch iid {
+            case __ABI_test_component.IArrayShouldBuildWrapper.IID:
+                let wrapper = __ABI_test_component.IArrayShouldBuildWrapper(self)
+                return wrapper!.queryInterface(iid)
+            default: return nil
+        }
+    }
+}
+public typealias AnyIArrayShouldBuild = any IArrayShouldBuild
+
 public protocol IAsyncMethodsWithProgress : WinRTInterface {
     func operationWithProgress(_ value: test_component.DateTime) throws -> test_component.AnyIAsyncOperationWithProgress<Int32, Double>!
 }

--- a/tests/test_component/Sources/test_component/test_component.swift
+++ b/tests/test_component/Sources/test_component/test_component.swift
@@ -1687,7 +1687,7 @@ extension IArrayScenarios {
 public typealias AnyIArrayScenarios = any IArrayScenarios
 
 public protocol IArrayShouldBuild : WinRTInterface {
-    var scenarios: [test_component.AnyIArrayScenarios!] { get }
+    var scenarios: [test_component.AnyIArrayScenarios?] { get }
 }
 
 extension IArrayShouldBuild {

--- a/tests/test_component/cpp/ArrayTester.idl
+++ b/tests/test_component/cpp/ArrayTester.idl
@@ -58,4 +58,9 @@ namespace test_component
         void InAndRefNonBlittable(Int32[] value, ref Boolean[] results);
         Int32[] InAndReturn(Int32[] value);
     }
+
+    interface IArrayShouldBuild
+    {
+        IArrayScenarios[] Scenarios { get; };
+    }
 }


### PR DESCRIPTION
properties of Array types were using IOUs in the defintion leading to compile errors. this pr fixes that

## Changes
1. update `swift_write_type_params_for` to include an optional `is_array` boolean 
2. added a test interface which now compiles