### PR TITLE
Provide better message when the Windows Sdk is not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ tests/test_component/Sources/CWinRT/include
 
 swiftwinrt.log
 resources.aps
+
+CMakeFiles/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(swiftwinrt LANGUAGES C CXX)
 option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
 
 if(NOT EXISTS "$ENV{WindowsSdkBinPath}${CMAKE_SYSTEM_VERSION}")
-    message(FATAL_ERROR "Windows SDK Version ${CMAKE_SYSTEM_VERSION} appears not to be installed")
+    message(FATAL_ERROR "Windows SDK Version appears not to be installed:\n  Missing folder: $ENV{WindowsSdkBinPath}${CMAKE_SYSTEM_VERSION}")
 endif()
 
 add_subdirectory(swiftwinrt)


### PR DESCRIPTION
When trying to build on my system, the varaible `CMAKE_SYSTEM_VERSION` defaults to `10.0.26100`, notice the missing `.0` at the end of the version number.
In my system the Windows Sdk is installed in `C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100.0` and not in `C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100`

So, while I try to understand why the default behaves like this, I modify the error to give the user a missing location:
```
CMake Error at CMakeLists.txt:7 (message):
  Windows SDK Version appears not to be installed:
    Missing folder: C:\Program Files (x86)\Windows Kits\10\bin\10.0.26100
```

Side Note: Visual Studio, AdoDevOps and GitHub actions have started to gradually migrate away from VS components to NuGet packages.
This also applies for the Windows Sdk, instead of depending on the Windows Sdk component, we should depend on the [Windows Sdk Nuget](https://www.nuget.org/packages/Microsoft.Windows.SDK.CPP)
