### PR TITLE
move generic writers

### DIFF
--- a/swiftwinrt/CMakeLists.txt
+++ b/swiftwinrt/CMakeLists.txt
@@ -66,6 +66,7 @@ target_sources(swiftwinrt PUBLIC
     types/typedef_base.cpp
     code_writers/enum_writers.cpp
     code_writers/interface_writers.cpp
+    code_writers/generic_writers.cpp
     code_writers/delegate_writers.cpp
     code_writers/class_writers.cpp
     code_writers/type_writers.cpp

--- a/swiftwinrt/code_writers.h
+++ b/swiftwinrt/code_writers.h
@@ -4,3 +4,4 @@
 #include "code_writers/delegate_writers.h"
 #include "code_writers/class_writers.h"
 #include "code_writers/struct_writers.h"
+#include "code_writers/generic_writers.h"

--- a/swiftwinrt/code_writers/generic_writers.cpp
+++ b/swiftwinrt/code_writers/generic_writers.cpp
@@ -1,0 +1,214 @@
+#include "generic_writers.h"
+
+#include "writer_helpers.h"
+#include "interface_writers.h"
+#include "utility/swift_codegen_utils.h"
+
+namespace swiftwinrt
+{
+    void write_guid_generic(writer& w, generic_inst const& type)
+    {
+        auto abi_guard = w.push_mangled_names(true);
+
+        static constexpr std::uint8_t namespaceGuidBytes[] =
+        {
+            0x11, 0xf4, 0x7a, 0xd5,
+            0x7b, 0x73,
+            0x42, 0xc0,
+            0xab, 0xae, 0x87, 0x8b, 0x1e, 0x16, 0xad, 0xee
+        };
+        sha1 signatureHash;
+        signatureHash.append(namespaceGuidBytes, std::size(namespaceGuidBytes));
+        type.append_signature(signatureHash);
+        auto iidHash = signatureHash.finalize();
+        iidHash[6] = (iidHash[6] & 0x0F) | 0x50;
+        iidHash[8] = (iidHash[8] & 0x3F) | 0x80;
+        auto format = R"(private var IID_%: %.IID {
+    .init(%)// %
+}
+
+)";
+
+        w.write(format,
+            type.mangled_name(),
+            w.support,
+            bind<write_guid_value_hash>(iidHash),
+            bind<write_guid_comment_hash>(iidHash));
+    }
+
+    void write_generic_declaration(writer& w, generic_inst const& type)
+    {
+        auto push_param_guard = w.push_generic_params(type);
+        w.write("internal var %VTable: %Vtbl = .init(\n",
+            type.mangled_name(),
+            type.mangled_name());
+
+        const bool is_delegate_instance = type.generic_type()->category() == category::delegate_type;
+        {
+            auto indent = w.push_indent();
+            write_iunknown_methods(w, type);
+            separator s{ w, ",\n\n" };
+
+            if (!is_delegate_instance)
+            {
+                write_iinspectable_methods(w, type, type.required_interfaces);
+                s();
+            }
+
+            for (auto&& method : type.functions)
+            {
+                s();
+                write_vtable_method(w, method, type);
+            }
+        }
+
+        w.write(R"(
+)
+)");
+
+        if (is_winrt_ireference(type))
+        {
+            w.write("typealias % = ReferenceWrapperBase<%>\n",
+                bind_wrapper_name(type),
+                bind_bridge_fullname(type));
+        }
+        else
+        {
+            w.write("typealias % = InterfaceWrapperBase<%>\n",
+                bind_wrapper_name(type),
+                bind_bridge_fullname(type));
+        }
+    }
+
+    void write_interface_generic(writer& w, generic_inst const& type)
+    {
+        write_generic_declaration(w, type);
+
+        if (!is_winrt_ireference(type))
+        {
+            auto generic_params = w.push_generic_params(type);
+            do_write_interface_abi(w, *type.generic_type(), type.functions);
+        }
+    }
+
+    void write_ireference_init_extension(writer& w, generic_inst const& type)
+    {
+        if (!is_winrt_ireference(type)) return;
+        auto generic_param = type.generic_params()[0];
+        w.add_depends(*generic_param);
+
+        auto impl_names = w.push_impl_names(true);
+
+        w.write(R"(internal enum %: ReferenceBridge {
+    typealias CABI = %
+    typealias SwiftProjection = %
+    static var IID: %.IID { IID_% }
+
+    static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        guard let val = abi else { return nil }
+        var result: %%
+        try! CHECKED(val.get().pointee.lpVtbl.pointee.get_Value(val.get(), &result))
+        return %
+    }
+
+    static func makeAbi() -> CABI {
+        let vtblPtr = withUnsafeMutablePointer(to: &%VTable) { $0 }
+        return .init(lpVtbl: vtblPtr)
+    }
+}
+)", bind_bridge_name(type),
+    type.mangled_name(),
+    get_full_swift_type_name(w, generic_param),
+    w.support,
+    type.mangled_name(),
+    bind<write_type>(*generic_param, write_type_params::c_abi),
+    bind<write_default_init_assignment>(*generic_param, projection_layer::c_abi),
+    bind<write_consume_type>(generic_param, "result", true),
+    type.mangled_name());
+    }
+
+    void write_generic_extension(writer& w, generic_inst const& inst)
+    {
+        if (is_winrt_ireference(inst))
+        {
+            write_ireference_init_extension(w, inst);
+        }
+        else if (is_delegate(inst))
+        {
+            auto guard{ w.push_generic_params(inst) };
+            write_delegate_extension(w, inst, inst.functions[0]);
+        }
+    }
+
+    void write_generic_delegate_wrapper(writer& w, generic_inst const& generic)
+    {
+        write_delegate_wrapper(w, generic);
+    }
+
+    void write_generic_interface_implementation(writer& w, generic_inst const& type)
+    {
+        write_interface_bridge(w, type);
+
+        w.write("fileprivate class % : %, AbiInterfaceImpl {\n",
+            bind_impl_name(type), type.generic_type_abi_name());
+
+        auto indent_guard = w.push_indent();
+
+        write_generic_typealiases(w, type);
+
+
+        w.write("typealias Bridge = %\n", bind_bridge_name(type));
+        w.write("let _default: Bridge.SwiftABI\n");
+
+        w.write("init(_ fromAbi: ComPtr<Bridge.CABI>) {\n");
+        w.write("    _default = Bridge.SwiftABI(fromAbi)\n");
+        w.write("}\n\n");
+
+        interface_info info{ &type };
+        info.is_default = true; // mark as default so we use the name "_default"
+
+        // Due to https://linear.app/the-browser-company/issue/WIN-148/investigate-possible-compiler-bug-crash-when-generating-collection
+        // we have to generate the protocol conformance for the Collection protocol (see "// MARK: Collection" below). We shouldn't have to
+        // do this because we define an extension on the protocol which does this.
+        write_collection_protocol_conformance(w, info);
+
+        for (const auto& method : type.functions)
+        {
+            write_class_impl_func(w, method, info, *type.generic_type());
+        }
+        for (const auto& prop : type.properties)
+        {
+            write_class_impl_property(w, prop, info, *type.generic_type());
+        }
+        for (const auto& event : type.events)
+        {
+            write_class_impl_event(w, event, info, *type.generic_type());
+        }
+
+        for (const auto& [interface_name, iface_info] : type.required_interfaces)
+        {
+            if (!can_write(w, iface_info.type)) { continue; }
+
+            write_interface_impl_members(w, iface_info, *type.generic_type());
+        }
+
+        w.write("public func queryInterface(_ iid: %.IID) -> IUnknownRef? { nil }\n", w.support);
+        indent_guard.end();
+        w.write("}\n\n");
+    }
+
+    void write_generic_implementation(writer& w, generic_inst const& type)
+    {
+        auto generics_guard = w.push_generic_params(type);
+        if (is_delegate(type))
+        {
+            auto delegate_method = type.functions[0];
+            do_write_delegate_implementation(w, type, delegate_method);
+        }
+        else if (!is_winrt_ireference(type))
+        {
+            write_generic_interface_implementation(w, type);
+        }
+    }
+}
+

--- a/swiftwinrt/code_writers/generic_writers.h
+++ b/swiftwinrt/code_writers/generic_writers.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "types/generic_inst.h"
+
+namespace swiftwinrt
+{
+    struct writer;
+
+    void write_guid_generic(writer& w, generic_inst const& type);
+    void write_interface_generic(writer& w, generic_inst const& type);
+    void write_generic_extension(writer& w, generic_inst const& inst);
+    void write_generic_implementation(writer& w, generic_inst const& type);
+
+    void write_ireference_init_extension(writer& w, generic_inst const& type);
+    void write_generic_delegate_wrapper(writer& w, generic_inst const& generic);
+    void write_generic_interface_implementation(writer& w, generic_inst const& type);
+    void write_generic_declaration(writer& w, generic_inst const& type);
+}
+

--- a/swiftwinrt/code_writers/interface_writers.h
+++ b/swiftwinrt/code_writers/interface_writers.h
@@ -4,13 +4,9 @@
 namespace swiftwinrt
 {
     void write_guid(writer& w, typedef_base const& type);
-    void write_guid_generic(writer& w, generic_inst const& type);
     void write_interface_proto(writer& w, interface_type const& type);
     void write_interface_abi(writer& w, interface_type const& type);
     void write_interface_impl(writer& w, interface_type const& type);
     void write_make_from_abi(writer& w, metadata_type const& type);
-    void write_interface_generic(writer& w, generic_inst const& type);
-    void write_generic_extension(writer& w, generic_inst const& inst);
-    void write_generic_implementation(writer& w, generic_inst const& type);
     void write_eventsource_invoke_extension(writer& w, metadata_type const* event_type);
 }

--- a/swiftwinrt/code_writers/writer_helpers.h
+++ b/swiftwinrt/code_writers/writer_helpers.h
@@ -456,42 +456,6 @@ bind<write_abi_args>(function));
     static void write_implementable_interface(writer& w, interface_type const& type);
 
 
-    static void write_ireference_init_extension(writer& w, generic_inst const& type)
-    {
-        if (!is_winrt_ireference(type)) return;
-        auto generic_param = type.generic_params()[0];
-        w.add_depends(*generic_param);
-
-        auto impl_names = w.push_impl_names(true);
-
-        w.write(R"(internal enum %: ReferenceBridge {
-    typealias CABI = %
-    typealias SwiftProjection = %
-    static var IID: %.IID { IID_% }
-
-    static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
-        guard let val = abi else { return nil }
-        var result: %%
-        try! CHECKED(val.get().pointee.lpVtbl.pointee.get_Value(val.get(), &result))
-        return %
-    }
-
-    static func makeAbi() -> CABI {
-        let vtblPtr = withUnsafeMutablePointer(to: &%VTable) { $0 }
-        return .init(lpVtbl: vtblPtr)
-    }
-}
-)", bind_bridge_name(type),
-    type.mangled_name(),
-    get_full_swift_type_name(w, generic_param),
-    w.support,
-    type.mangled_name(),
-    bind<write_type>(*generic_param, write_type_params::c_abi),
-    bind<write_default_init_assignment>(*generic_param, projection_layer::c_abi),
-    bind<write_consume_type>(generic_param, "result", true),
-    type.mangled_name());
-    }
-
     static void write_class_func_body(writer& w, function_def const& function, interface_info const& iface, bool is_noexcept);
     static void write_comma_param_names(writer& w, std::vector<function_param> const& params);
     template <typename T>
@@ -529,14 +493,6 @@ typealias % = InterfaceWrapperBase<%>
 )";
         w.write(format, wrapper_name, impl_name);
     }
-
-    static void write_generic_delegate_wrapper(writer& w, generic_inst const& generic)
-    {
-        write_delegate_wrapper(w, generic);
-    }
-
-
-
 
     static void write_convert_vtable_params(writer& w, function_def const& signature)
     {
@@ -1079,59 +1035,6 @@ bind_bridge_fullname(type));
 
 
     void write_interface_bridge(writer& w, metadata_type const& type);
-
-    static void write_generic_interface_implementation(writer& w, generic_inst const& type)
-    {
-        write_interface_bridge(w, type);
-
-        w.write("fileprivate class % : %, AbiInterfaceImpl {\n",
-            bind_impl_name(type), type.generic_type_abi_name());
-
-        auto indent_guard = w.push_indent();
-
-        write_generic_typealiases(w, type);
-
-
-        w.write("typealias Bridge = %\n", bind_bridge_name(type));
-        w.write("let _default: Bridge.SwiftABI\n");
-
-        w.write("init(_ fromAbi: ComPtr<Bridge.CABI>) {\n");
-        w.write("    _default = Bridge.SwiftABI(fromAbi)\n");
-        w.write("}\n\n");
-
-        interface_info info{ &type };
-        info.is_default = true; // mark as default so we use the name "_default"
-
-        // Due to https://linear.app/the-browser-company/issue/WIN-148/investigate-possible-compiler-bug-crash-when-generating-collection
-        // we have to generate the protocol conformance for the Collection protocol (see "// MARK: Collection" below). We shouldn't have to
-        // do this because we define an extension on the protocol which does this.
-        write_collection_protocol_conformance(w, info);
-
-        for (const auto& method : type.functions)
-        {
-            write_class_impl_func(w, method, info, *type.generic_type());
-        }
-        for (const auto& prop : type.properties)
-        {
-            write_class_impl_property(w, prop, info, *type.generic_type());
-        }
-        for (const auto& event : type.events)
-        {
-            write_class_impl_event(w, event, info, *type.generic_type());
-        }
-
-        for (const auto& [interface_name, info] : type.required_interfaces)
-        {
-            if (!can_write(w, info.type)) { continue; }
-
-            write_interface_impl_members(w, info, *type.generic_type());
-        }
-
-        w.write("public func queryInterface(_ iid: %.IID) -> IUnknownRef? { nil }\n", w.support);
-        indent_guard.end();
-        w.write("}\n\n");
-    }
-
 
     static void write_param_names(writer& w, std::vector<function_param> const& params, std::string_view format)
     {
@@ -2017,11 +1920,6 @@ public init<Composable: ComposableImpl>(
     return S_OK
 })"
 );
-    }
-
-    static void write_iinspectable_methods(writer& w, generic_inst const& type)
-    {
-        write_iinspectable_methods(w, type, type.required_interfaces);
     }
 
     // assigns return or out parameters in vtable methods

--- a/swiftwinrt/types/element_type.h
+++ b/swiftwinrt/types/element_type.h
@@ -70,10 +70,6 @@ namespace swiftwinrt
 
         void write_c_abi_param(writer& w) const override;
 
-        void write_swift_declaration(writer&) const override
-        {
-        }
-
         bool is_experimental() const override
         {
             return false;

--- a/swiftwinrt/types/generic_inst.cpp
+++ b/swiftwinrt/types/generic_inst.cpp
@@ -127,51 +127,6 @@ namespace swiftwinrt
         w.end_declaration(m_mangled_name);
     }
 
-    void generic_inst::write_swift_declaration(writer& w) const
-    {
-        auto push_param_guard = w.push_generic_params(*this);
-        w.write("internal var %VTable: %Vtbl = .init(\n",
-            mangled_name(),
-            mangled_name());
-
-        const bool is_delegate_instance = generic_type()->category() == category::delegate_type;
-        {
-            auto indent = w.push_indent();
-            write_iunknown_methods(w, *this);
-            separator s{ w, ",\n\n" };
-
-            if (!is_delegate_instance)
-            {
-                write_iinspectable_methods(w, *this);
-                s();
-            }
-
-            for (auto&& method : functions)
-            {
-                s();
-                write_vtable_method(w, method, *this);
-            }
-        }
-
-        w.write(R"(
-)
-)");
-
-        if (is_winrt_ireference(*this))
-        {
-            w.write("typealias % = ReferenceWrapperBase<%>\n",
-                bind_wrapper_name(*this),
-                bind_bridge_fullname(*this));
-        }
-        else
-        {
-            w.write("typealias % = InterfaceWrapperBase<%>\n",
-                bind_wrapper_name(*this),
-                bind_bridge_fullname(*this));
-            return;
-        }
-    }
-
     void generic_inst::write_c_abi_param(writer& w) const
     {
         w.write("%*", m_mangled_name);

--- a/swiftwinrt/types/generic_inst.h
+++ b/swiftwinrt/types/generic_inst.h
@@ -60,8 +60,6 @@ namespace swiftwinrt
         void append_signature(sha1& hash) const override;
         void write_c_forward_declaration(writer& w) const override;
         void write_c_abi_param(writer& w) const override;
-        void write_swift_declaration(writer& w) const override;
-
         bool is_experimental() const override;
 
         typedef_base const* generic_type() const noexcept

--- a/swiftwinrt/types/generic_type_parameter.h
+++ b/swiftwinrt/types/generic_type_parameter.h
@@ -70,10 +70,6 @@ namespace swiftwinrt
             return false;
         }
 
-        void write_swift_declaration(writer&) const override
-        {
-        }
-
     private:
         std::string_view m_param_name;
     };

--- a/swiftwinrt/types/mapped_type.h
+++ b/swiftwinrt/types/mapped_type.h
@@ -68,10 +68,6 @@ namespace swiftwinrt
 
         void write_c_abi_param(writer& w) const override;
 
-        void write_swift_declaration(writer&) const override
-        {
-        }
-
         bool is_experimental() const override
         {
             return false;

--- a/swiftwinrt/types/metadata_type.h
+++ b/swiftwinrt/types/metadata_type.h
@@ -44,8 +44,6 @@ namespace swiftwinrt
         virtual void write_c_forward_declaration(writer& w) const = 0;
         virtual void write_c_abi_param(writer& w) const = 0;
 
-        virtual void write_swift_declaration(writer& w) const = 0;
-
         virtual bool is_experimental() const = 0;
 
         virtual std::optional<std::size_t> contract_index(std::string_view /*typeName*/, std::size_t /*version*/) const

--- a/swiftwinrt/types/system_type.h
+++ b/swiftwinrt/types/system_type.h
@@ -70,10 +70,6 @@ namespace swiftwinrt
 
         void write_c_abi_param(writer& w) const override;
 
-        void write_swift_declaration(writer&) const override
-        {
-        }
-
         bool is_experimental() const override
         {
             return false;

--- a/swiftwinrt/types/typedef_base.h
+++ b/swiftwinrt/types/typedef_base.h
@@ -72,10 +72,6 @@ namespace swiftwinrt
             return get_category(m_type);
         }
 
-        void write_swift_declaration(writer&) const override
-        {
-        }
-
         std::vector<generic_type_parameter> generic_params;
 
     protected:


### PR DESCRIPTION
### TL;DR

Refactored generic type handling by moving generic-specific code into dedicated files.

### What changed?

- Created new files `generic_writers.h` and `generic_writers.cpp` to contain all generic-related code
- Moved generic-specific functions from `interface_writers.cpp` to the new files
- Removed the unused `write_swift_declaration` virtual method from the type hierarchy
- Updated includes and CMakeLists.txt to reference the new files
- Reorganized code to improve separation of concerns between interface and generic type handling

### How to test?

Compile the project and verify that generic types are still properly generated. The functionality should remain unchanged as this is purely a code organization refactoring.

### Why make this change?

This change improves code organization by separating generic type handling into dedicated files, making the codebase more maintainable. The previous implementation had generic-related code mixed with interface code, which made it harder to understand and maintain. This refactoring provides better separation of concerns and makes the code structure more logical.