### PR TITLE
Fix some UTF-16 String/HSTRING issues

### DIFF
--- a/swiftwinrt/Resources/Support/Swift+Extensions.swift
+++ b/swiftwinrt/Resources/Support/Swift+Extensions.swift
@@ -20,7 +20,7 @@ extension String {
     try self.withCString(encodedAs: UTF16.self) {
       var hString: HSTRING?
       var header: HSTRING_HEADER = .init()
-      try CHECKED(WindowsCreateStringReference($0, UInt32(self.count), &header, &hString))
+      try CHECKED(WindowsCreateStringReference($0, UInt32(wcslen($0)), &header, &hString))
       try body(hString)
     }
   }
@@ -31,12 +31,12 @@ extension StaticString {
       var buffer: CWinRT.StaticWCharArray_512 = .init()
       try withUnsafeMutableBytes(of: &buffer.Data) { (bytes:UnsafeMutableRawBufferPointer) in
           let bytesPtr = bytes.assumingMemoryBound(to: WCHAR.self)
-          self.withUTF8Buffer { utf8buffer in
-              try! CHECKED(MultiByteToWideChar(UInt32(CP_UTF8), 0, utf8buffer.baseAddress, Int32(utf8buffer.count), bytesPtr.baseAddress, Int32(bytes.count)))
+          let wcharCount = self.withUTF8Buffer { utf8buffer in
+              MultiByteToWideChar(UInt32(CP_UTF8), 0, utf8buffer.baseAddress, Int32(utf8buffer.count), bytesPtr.baseAddress, Int32(bytesPtr.count))
           }
           var hString: HSTRING?
           var header: HSTRING_HEADER = .init()
-          try CHECKED(WindowsCreateStringReference(bytesPtr.baseAddress, UINT32(self.utf8CodeUnitCount), &header, &hString))
+          try CHECKED(WindowsCreateStringReference(bytesPtr.baseAddress, UINT32(wcharCount), &header, &hString))
           try body(hString)
         }
      }

--- a/tests/test_app/StringTests.swift
+++ b/tests/test_app/StringTests.swift
@@ -1,0 +1,141 @@
+import CWinRT
+import XCTest
+import test_component
+@_spi(WinRTInternal) import WindowsFoundation
+
+class StringTests : XCTestCase {
+
+    // MARK: - String.init(from:)
+
+    // WinRT APIs return null HSTRING to represent empty strings.
+    // String.init(from:) must handle nil by producing "".
+    public func testStringFromNilHString() {
+        let result = String(from: nil as HSTRING?)
+        XCTAssertEqual(result, "")
+    }
+
+    // MARK: - String.withHStringRef
+
+    // ASCII strings have equal grapheme cluster and UTF-16 code unit counts,
+    // so this validates the basic withHStringRef round-trip path.
+    public func testWithHStringRefAscii() throws {
+        let s = "Hello, World!"
+        s.withHStringRef { hstring in
+            let result = String(from: hstring)
+            XCTAssertEqual(result, s)
+        }
+    }
+
+    // Emoji like 😀 (U+1F600) encode as a UTF-16 surrogate pair (2 code units)
+    // but are a single grapheme cluster. This verifies that withHStringRef passes
+    // the UTF-16 code unit count, not the grapheme cluster count, to
+    // WindowsCreateStringReference.
+    public func testWithHStringRefEmoji() throws {
+        let s = "Hello 😀"
+        s.withHStringRef { hstring in
+            let result = String(from: hstring)
+            XCTAssertEqual(result, s)
+        }
+    }
+
+    // "e\u{0301}" (e + combining acute accent) is a single grapheme cluster but
+    // 2 UTF-16 code units. This is a BMP-only case where grapheme cluster count
+    // diverges from UTF-16 code unit count, distinct from the surrogate pair case.
+    public func testWithHStringRefCombiningCharacter() throws {
+        let s = "e\u{0301}vent"
+        s.withHStringRef { hstring in
+            let result = String(from: hstring)
+            XCTAssertEqual(result, s)
+        }
+    }
+
+    // Verify withHStringRef handles zero-length strings.
+    public func testWithHStringRefEmpty() throws {
+        let s = ""
+        s.withHStringRef { hstring in
+            let result = String(from: hstring)
+            XCTAssertEqual(result, s)
+        }
+    }
+
+    // MARK: - StaticString.withHStringRef
+
+    // ASCII static strings have equal UTF-8 byte and UTF-16 code unit counts,
+    // so this validates the basic StaticString.withHStringRef round-trip through
+    // MultiByteToWideChar.
+    public func testStaticStringWithHStringRefAscii() throws {
+        let s: StaticString = "Hello"
+        s.withHStringRef { hstring in
+            let result = String(from: hstring)
+            XCTAssertEqual(result, "Hello")
+        }
+    }
+
+    // "café" has 5 UTF-8 bytes (é is 2 bytes) but only 4 UTF-16 code units.
+    // This verifies that StaticString.withHStringRef uses the actual
+    // MultiByteToWideChar conversion result as the HSTRING length, not the
+    // UTF-8 byte count.
+    public func testStaticStringWithHStringRefNonAscii() throws {
+        let s: StaticString = "café"
+        s.withHStringRef { hstring in
+            let result = String(from: hstring)
+            XCTAssertEqual(result, "café")
+        }
+    }
+
+    // Verify StaticString.withHStringRef handles zero-length strings through
+    // the MultiByteToWideChar path.
+    public func testStaticStringWithHStringRefEmpty() throws {
+        let s: StaticString = ""
+        s.withHStringRef { hstring in
+            let result = String(from: hstring)
+            XCTAssertEqual(result, "")
+        }
+    }
+
+    // MARK: - String.toABI / String.from round-trip
+
+    // Verify toABI/from round-trip for a basic ASCII string.
+    public func testToAbiRoundTripAscii() throws {
+        let s = "Hello, World!"
+        let hstring = try s.toABI()
+        defer { WindowsDeleteString(hstring) }
+        let result = String.from(abi: hstring)
+        XCTAssertEqual(result, s)
+    }
+
+    // Verify toABI/from round-trip for a string containing emoji (surrogate
+    // pairs in UTF-16).
+    public func testToAbiRoundTripEmoji() throws {
+        let s = "Hello 😀 World"
+        let hstring = try s.toABI()
+        defer { WindowsDeleteString(hstring) }
+        let result = String.from(abi: hstring)
+        XCTAssertEqual(result, s)
+    }
+
+    // Verify toABI/from round-trip for an empty string.
+    public func testToAbiRoundTripEmpty() throws {
+        let s = ""
+        let hstring = try s.toABI()
+        defer { WindowsDeleteString(hstring) }
+        let result = String.from(abi: hstring)
+        XCTAssertEqual(result, s)
+    }
+}
+
+var stringTests: [XCTestCaseEntry] = [
+    testCase([
+        ("testStringFromNilHString", StringTests.testStringFromNilHString),
+        ("testWithHStringRefAscii", StringTests.testWithHStringRefAscii),
+        ("testWithHStringRefEmoji", StringTests.testWithHStringRefEmoji),
+        ("testWithHStringRefCombiningCharacter", StringTests.testWithHStringRefCombiningCharacter),
+        ("testWithHStringRefEmpty", StringTests.testWithHStringRefEmpty),
+        ("testStaticStringWithHStringRefAscii", StringTests.testStaticStringWithHStringRefAscii),
+        ("testStaticStringWithHStringRefNonAscii", StringTests.testStaticStringWithHStringRefNonAscii),
+        ("testStaticStringWithHStringRefEmpty", StringTests.testStaticStringWithHStringRefEmpty),
+        ("testToAbiRoundTripAscii", StringTests.testToAbiRoundTripAscii),
+        ("testToAbiRoundTripEmoji", StringTests.testToAbiRoundTripEmoji),
+        ("testToAbiRoundTripEmpty", StringTests.testToAbiRoundTripEmpty),
+    ])
+]

--- a/tests/test_app/main.swift
+++ b/tests/test_app/main.swift
@@ -480,7 +480,7 @@ var tests: [XCTestCaseEntry] = [
 
 // Have to start adding tests in different lines, otherwise we get the following error:
 //  error: the compiler is unable to type-check this expression in reasonable time; try breaking up the expression into distinct sub-expressions
-tests += arrayTests
+tests += arrayTests + stringTests
 
 RoInitialize(RO_INIT_MULTITHREADED)
 XCTMain(tests)

--- a/tests/test_component/Sources/WindowsFoundation/Support/swift+extensions.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/swift+extensions.swift
@@ -20,7 +20,7 @@ extension String {
     try self.withCString(encodedAs: UTF16.self) {
       var hString: HSTRING?
       var header: HSTRING_HEADER = .init()
-      try CHECKED(WindowsCreateStringReference($0, UInt32(self.count), &header, &hString))
+      try CHECKED(WindowsCreateStringReference($0, UInt32(wcslen($0)), &header, &hString))
       try body(hString)
     }
   }
@@ -31,12 +31,12 @@ extension StaticString {
       var buffer: CWinRT.StaticWCharArray_512 = .init()
       try withUnsafeMutableBytes(of: &buffer.Data) { (bytes:UnsafeMutableRawBufferPointer) in
           let bytesPtr = bytes.assumingMemoryBound(to: WCHAR.self)
-          self.withUTF8Buffer { utf8buffer in
-              try! CHECKED(MultiByteToWideChar(UInt32(CP_UTF8), 0, utf8buffer.baseAddress, Int32(utf8buffer.count), bytesPtr.baseAddress, Int32(bytes.count)))
+          let wcharCount = self.withUTF8Buffer { utf8buffer in
+              MultiByteToWideChar(UInt32(CP_UTF8), 0, utf8buffer.baseAddress, Int32(utf8buffer.count), bytesPtr.baseAddress, Int32(bytesPtr.count))
           }
           var hString: HSTRING?
           var header: HSTRING_HEADER = .init()
-          try CHECKED(WindowsCreateStringReference(bytesPtr.baseAddress, UINT32(self.utf8CodeUnitCount), &header, &hString))
+          try CHECKED(WindowsCreateStringReference(bytesPtr.baseAddress, UINT32(wcharCount), &header, &hString))
           try body(hString)
         }
      }


### PR DESCRIPTION
Fixes some `String`/`HSTRING` interop issues related to `HSTRING`'s UTF-16 encoding.

## Changes
- In `String.withHStringRef(_:)` we were using `self.count`, which counts grapheme clusters instead of UTF-16 code units, with `WindowsCreateStringReference`. Since we already have the UTF-16 buffer available, I replaced this with `wcslen` instead of `self.utf16.count`.
-  In `StaticString.withHStringRef(_:)`: 
    - `MultiByteToWideChar` returns the number of `WCHAR`s written, which we were wrapping in a `try! CHECKED`; but when `MultiByteToWideChar` fails, it returns 0, which `CHECKED` considers a success. I've just removed the `CHECKED` and captured the return value in a local variable.
    - We were using the _byte_ count of the output buffer, instead of the UTF-16 code unit count, with `MultiByteToWideChar`.
    - We were using the UTF-8 code unit count instead of the UTF-16 code unit count with `WindowsCreateStringReference`; I've updated it to use the return value of `MultiByteToWideChar`.

## Testing

I added a `StringTests` test suite, since I couldn't find any existing test coverage for this. After these changes, all the tests pass.