### PR TITLE
Fix ref cycle in `EventSource`

### DIFF
--- a/swiftwinrt/Resources/Support/Events/EventSource.swift
+++ b/swiftwinrt/Resources/Support/Events/EventSource.swift
@@ -10,8 +10,8 @@ import CWinRT
 
     public init() {
         event = .init(
-          add: { self.handlers.append($0) },
-          remove: { self.handlers.remove(token: $0) }
+          add: { [weak self] in self?.handlers.append($0) ?? .init() },
+          remove: { [weak self] in self?.handlers.remove(token: $0) }
         )
     }
 

--- a/tests/test_component/Sources/WindowsFoundation/Support/eventsource.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/eventsource.swift
@@ -10,8 +10,8 @@ import CWinRT
 
     public init() {
         event = .init(
-          add: { self.handlers.append($0) },
-          remove: { self.handlers.remove(token: $0) }
+          add: { [weak self] in self?.handlers.append($0) ?? .init() },
+          remove: { [weak self] in self?.handlers.remove(token: $0) }
         )
     }
 


### PR DESCRIPTION
This fixes a reference cycle `EventSource` creates with itself by capturing `self` weakly in its `Event`'s closures.