### PR TITLE
Remove unnecessary `QueryInterface()` in `thisPtr`

### DIFF
--- a/swiftwinrt/Resources/Support/WinRTProtocols.swift
+++ b/swiftwinrt/Resources/Support/WinRTProtocols.swift
@@ -56,7 +56,7 @@ public func ==<T: WinRTClass>(_ lhs: T, _ rhs: T) -> Bool {
 }
 
 extension WinRTClass: IWinRTObject {
-    public var thisPtr: SUPPORT_MODULE.IInspectable { try! _inner.QueryInterface() }
+    public var thisPtr: SUPPORT_MODULE.IInspectable { _inner }
 }
 
 @_spi(WinRTInternal)

--- a/tests/test_component/Sources/WindowsFoundation/Support/winrtprotocols.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/winrtprotocols.swift
@@ -56,7 +56,7 @@ public func ==<T: WinRTClass>(_ lhs: T, _ rhs: T) -> Bool {
 }
 
 extension WinRTClass: IWinRTObject {
-    public var thisPtr: WindowsFoundation.IInspectable { try! _inner.QueryInterface() }
+    public var thisPtr: WindowsFoundation.IInspectable { _inner }
 }
 
 @_spi(WinRTInternal)


### PR DESCRIPTION
Removes the unnecessary call to `_inner.QueryInterface()` in `WinRTClass.thisPtr`.

`_inner` is already `IInspectable`, so this call is unnecessary, and has non-trivial overhead, including an `AddRef`/`Release` pair. This is a hot path during usage in Arc for equality and identity checks. Returning `_inner` directly is safe because `thisPtr` is only used for pointer comparison and identity, never to extend the object's lifetime.