### PR TITLE
Cache type-specific factories

### DIFF
--- a/swiftwinrt/Resources/Support/IInspectable+Swift.swift
+++ b/swiftwinrt/Resources/Support/IInspectable+Swift.swift
@@ -45,7 +45,7 @@ struct SwiftTypeName {
 extension IInspectable {
   // maps the namespace to a swift module. needs to be kept in sync with
   // get_swift_module defined in swift_codegen_utils.cpp in the code generator
-  private func GetSwiftModule(from ns: String) -> String {
+  static func GetSwiftModule(from ns: String) -> String {
     if ns.starts(with: "Windows.Foundation") {
        return "SUPPORT_MODULE"
     } else if ns.starts(with: "Microsoft.UI.Xaml") || ns.starts(with: "Windows.UI.Xaml") {
@@ -65,13 +65,16 @@ extension IInspectable {
     return String(ns.prefix(upTo: topLevelNSIndex))
   }
 
-
   func GetSwiftTypeName() throws -> SwiftTypeName {
     let className = try String(hString: GetRuntimeClassName())
-    let lastNsIndex = className.lastIndex(of: ".")
-    guard let lastNsIndex = lastNsIndex else {
+    guard let typeName = IInspectable.GetSwiftTypeName(from: className) else {
       throw InvalidRuntimeClassName(className: className)
     }
+    return typeName
+  }
+
+  static func GetSwiftTypeName(from className: String) -> SwiftTypeName? {
+    guard let lastNsIndex = className.lastIndex(of: ".") else { return nil }
     let ns = className.prefix(upTo: lastNsIndex)
     let lastNsIndexPlus1 = className.index(after: lastNsIndex)
     let typeName = className.suffix(from: lastNsIndexPlus1)

--- a/swiftwinrt/Resources/Support/MakeFromAbi.swift
+++ b/swiftwinrt/Resources/Support/MakeFromAbi.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WinSDK
 
 // Not strongly typed, we lose the type safety of the associatedtype anyways
 // when we cast to `any MakeFromAbi`, plus that requires a lot more exported
@@ -15,15 +16,63 @@ func make(typeName: SwiftTypeName, from abi: SUPPORT_MODULE.IInspectable) -> Any
     return makerType.from(abi: abi)
 }
 
+/// Cached result of resolving a WinRT runtime class name to its Swift factory type.
+///
+/// We cache both positive and negative results so that class names with no corresponding
+/// Swift projection (e.g. internal WinRT types) don't repeatedly pay the cost of
+/// namespace parsing, string interpolation, and `NSClassFromString` on every crossing.
+///
+private enum FactoryCacheEntry {
+    case factory(any MakeFromAbi.Type)
+
+    /// The class name has no corresponding Swift factory type.
+    ///
+    /// This is normal for:
+    /// - Exclusive-to interfaces: private to a specific class (e.g. `IButtonFactory`), not projected
+    /// - Filtered-out types: exist in metadata but excluded by the projection's type filters
+    /// - Generic interfaces: the code generator skips `MakeFromAbi` for open generic types
+    /// - Aggregated derived types: app-implemented subclasses whose runtime class name has no Maker
+    ///
+    case noFactory
+}
+
+private var factoryCache: [String: FactoryCacheEntry] = [:]
+private var factoryCacheLock = SRWLock()
+
 func makeFrom(abi: SUPPORT_MODULE.IInspectable) -> Any? {
     // When creating a swift class which represents this type, we want to get the class name that we're trying to create
     // via GetRuntimeClassName so that we can create the proper derived type. For example, the API may return UIElement,
     // but we want to return a Button type.
 
     // Note that we'll *never* be trying to create an app implemented object at this point
-    guard let className = try? abi.GetSwiftTypeName() else { return nil }
+    guard let className = try? String(hString: abi.GetRuntimeClassName()) else { return nil }
 
-    return make(typeName: className, from: abi)
+    let cached = factoryCacheLock.withLock(.shared) { factoryCache[className] }
+
+    if let cached {
+        switch cached {
+        case .factory(let factory):
+            return factory.from(abi: abi)
+        case .noFactory:
+            return nil
+        }
+    }
+
+    // Note: Because we read-then-write without holding the lock across both, concurrent threads
+    // may redundantly resolve the same type. This is harmless (the result is identical) and
+    // lets us use shared reader locking on the hot path.
+
+    let factory: (any MakeFromAbi.Type)?
+    if let typeName = IInspectable.GetSwiftTypeName(from: className) {
+        factory = NSClassFromString("\(typeName.module).\(typeName.typeName)Maker") as? any MakeFromAbi.Type
+    } else {
+        factory = nil
+    }
+
+    let entry: FactoryCacheEntry = factory.map { .factory($0) } ?? .noFactory
+    factoryCacheLock.withLock(.exclusive) { factoryCache[className] = entry }
+
+    return factory?.from(abi: abi)
 }
 
 func make<T:AnyObject>(type: T.Type, from abi: SUPPORT_MODULE.IInspectable) -> T? {

--- a/swiftwinrt/Resources/Support/SRWLock.swift
+++ b/swiftwinrt/Resources/Support/SRWLock.swift
@@ -1,0 +1,29 @@
+import WinSDK
+
+/// A lightweight reader-writer lock wrapping the Win32 `SRWLOCK`.
+internal struct SRWLock: ~Copyable {
+    enum Mode {
+        case shared
+        case exclusive
+    }
+
+    /// SRWLOCK_INIT is {0}, and Swift zero-initializes imported C structs (SE-0189),
+    /// so `SRWLock()` is ready to use without calling `InitializeSRWLock`. The Swift
+    /// stdlib's `Synchronization.Mutex` uses the same pattern on Windows.
+    private var lock = SRWLOCK()
+
+    init() {}
+
+    mutating func withLock<Result>(_ mode: Mode, _ body: () throws -> Result) rethrows -> Result {
+        switch mode {
+        case .shared:
+            AcquireSRWLockShared(&lock)
+            defer { ReleaseSRWLockShared(&lock) }
+            return try body()
+        case .exclusive:
+            AcquireSRWLockExclusive(&lock)
+            defer { ReleaseSRWLockExclusive(&lock) }
+            return try body()
+        }
+    }
+}

--- a/swiftwinrt/resources.rc
+++ b/swiftwinrt/resources.rc
@@ -27,6 +27,7 @@ MakeFromAbi RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\MakeFromAbi.sw
 Marshaler RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\Marshaler.swift"
 RawTyped RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\RawTyped.swift"
 Runtime+Swift RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\Runtime+Swift.swift"
+SRWLock RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\SRWLock.swift"
 Swift+Extensions RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\Swift+Extensions.swift"
 TrustLevel+Swift RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\TrustLevel+Swift.swift"
 IWeakReference RESOURCE_TYPE_SWIFT_SUPPORT_FILE "Resources\\Support\\IWeakReference.swift"

--- a/tests/test_component/Sources/WindowsFoundation/Support/iinspectable+swift.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/iinspectable+swift.swift
@@ -45,7 +45,7 @@ struct SwiftTypeName {
 extension IInspectable {
   // maps the namespace to a swift module. needs to be kept in sync with
   // get_swift_module defined in swift_codegen_utils.cpp in the code generator
-  private func GetSwiftModule(from ns: String) -> String {
+  static func GetSwiftModule(from ns: String) -> String {
     if ns.starts(with: "Windows.Foundation") {
        return "WindowsFoundation"
     } else if ns.starts(with: "Microsoft.UI.Xaml") || ns.starts(with: "Windows.UI.Xaml") {
@@ -65,13 +65,16 @@ extension IInspectable {
     return String(ns.prefix(upTo: topLevelNSIndex))
   }
 
-
   func GetSwiftTypeName() throws -> SwiftTypeName {
     let className = try String(hString: GetRuntimeClassName())
-    let lastNsIndex = className.lastIndex(of: ".")
-    guard let lastNsIndex = lastNsIndex else {
+    guard let typeName = IInspectable.GetSwiftTypeName(from: className) else {
       throw InvalidRuntimeClassName(className: className)
     }
+    return typeName
+  }
+
+  static func GetSwiftTypeName(from className: String) -> SwiftTypeName? {
+    guard let lastNsIndex = className.lastIndex(of: ".") else { return nil }
     let ns = className.prefix(upTo: lastNsIndex)
     let lastNsIndexPlus1 = className.index(after: lastNsIndex)
     let typeName = className.suffix(from: lastNsIndexPlus1)

--- a/tests/test_component/Sources/WindowsFoundation/Support/makefromabi.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/makefromabi.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WinSDK
 
 // Not strongly typed, we lose the type safety of the associatedtype anyways
 // when we cast to `any MakeFromAbi`, plus that requires a lot more exported
@@ -15,15 +16,63 @@ func make(typeName: SwiftTypeName, from abi: WindowsFoundation.IInspectable) -> 
     return makerType.from(abi: abi)
 }
 
+/// Cached result of resolving a WinRT runtime class name to its Swift factory type.
+///
+/// We cache both positive and negative results so that class names with no corresponding
+/// Swift projection (e.g. internal WinRT types) don't repeatedly pay the cost of
+/// namespace parsing, string interpolation, and `NSClassFromString` on every crossing.
+///
+private enum FactoryCacheEntry {
+    case factory(any MakeFromAbi.Type)
+
+    /// The class name has no corresponding Swift factory type.
+    ///
+    /// This is normal for:
+    /// - Exclusive-to interfaces: private to a specific class (e.g. `IButtonFactory`), not projected
+    /// - Filtered-out types: exist in metadata but excluded by the projection's type filters
+    /// - Generic interfaces: the code generator skips `MakeFromAbi` for open generic types
+    /// - Aggregated derived types: app-implemented subclasses whose runtime class name has no Maker
+    ///
+    case noFactory
+}
+
+private var factoryCache: [String: FactoryCacheEntry] = [:]
+private var factoryCacheLock = SRWLock()
+
 func makeFrom(abi: WindowsFoundation.IInspectable) -> Any? {
     // When creating a swift class which represents this type, we want to get the class name that we're trying to create
     // via GetRuntimeClassName so that we can create the proper derived type. For example, the API may return UIElement,
     // but we want to return a Button type.
 
     // Note that we'll *never* be trying to create an app implemented object at this point
-    guard let className = try? abi.GetSwiftTypeName() else { return nil }
+    guard let className = try? String(hString: abi.GetRuntimeClassName()) else { return nil }
 
-    return make(typeName: className, from: abi)
+    let cached = factoryCacheLock.withLock(.shared) { factoryCache[className] }
+
+    if let cached {
+        switch cached {
+        case .factory(let factory):
+            return factory.from(abi: abi)
+        case .noFactory:
+            return nil
+        }
+    }
+
+    // Note: Because we read-then-write without holding the lock across both, concurrent threads
+    // may redundantly resolve the same type. This is harmless (the result is identical) and
+    // lets us use shared reader locking on the hot path.
+
+    let factory: (any MakeFromAbi.Type)?
+    if let typeName = IInspectable.GetSwiftTypeName(from: className) {
+        factory = NSClassFromString("\(typeName.module).\(typeName.typeName)Maker") as? any MakeFromAbi.Type
+    } else {
+        factory = nil
+    }
+
+    let entry: FactoryCacheEntry = factory.map { .factory($0) } ?? .noFactory
+    factoryCacheLock.withLock(.exclusive) { factoryCache[className] = entry }
+
+    return factory?.from(abi: abi)
 }
 
 func make<T:AnyObject>(type: T.Type, from abi: WindowsFoundation.IInspectable) -> T? {

--- a/tests/test_component/Sources/WindowsFoundation/Support/srwlock.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/srwlock.swift
@@ -1,0 +1,29 @@
+import WinSDK
+
+/// A lightweight reader-writer lock wrapping the Win32 `SRWLOCK`.
+internal struct SRWLock: ~Copyable {
+    enum Mode {
+        case shared
+        case exclusive
+    }
+
+    /// SRWLOCK_INIT is {0}, and Swift zero-initializes imported C structs (SE-0189),
+    /// so `SRWLock()` is ready to use without calling `InitializeSRWLock`. The Swift
+    /// stdlib's `Synchronization.Mutex` uses the same pattern on Windows.
+    private var lock = SRWLOCK()
+
+    init() {}
+
+    mutating func withLock<Result>(_ mode: Mode, _ body: () throws -> Result) rethrows -> Result {
+        switch mode {
+        case .shared:
+            AcquireSRWLockShared(&lock)
+            defer { ReleaseSRWLockShared(&lock) }
+            return try body()
+        case .exclusive:
+            AcquireSRWLockExclusive(&lock)
+            defer { ReleaseSRWLockExclusive(&lock) }
+            return try body()
+        }
+    }
+}


### PR DESCRIPTION
Updates the `makeFrom(abi:)` function to cache the derived `MakeFromAbi.Type`, keyed by class name, so we only have to perform the expensive resolution once per type.

This is an extremely hot path in profiling traces due to its usage in `AnyWrapper.unwrapFrom(abi:)`.

Because we project the `Object` type as `Any` in Swift, this code path is hit any time an `Object` instance crosses the ABI boundary into Swift. This allows the usage of "regular" Swift casting, instead of requiring calls to `QueryInterface`, but comes at a significant cost.

Updating the generators to project `Object` as `IInspectable` would be a more fundamental, API-breaking change. This caching is intended to reduce the overhead of this `AnyWrapper` usage, rather than remove it completely.

In the context of a WinUI XAML application, all "routed" events (e.g. click handlers, pointer event handlers, etc.) come with a sender argument of type `Object`, so we currently incur this overhead for every event handler execution.

I set up a local benchmarking harness, with some benchmarks for event handler execution, and these changes decreased execution time for handling a simulated routed event in Swift by ~60%.