### PR TITLE
Remove multi-return ComPtrs.initialize overloads

### DIFF
--- a/swiftwinrt/Resources/Support/ComPtr.swift
+++ b/swiftwinrt/Resources/Support/ComPtr.swift
@@ -90,37 +90,4 @@ public struct ComPtrs {
         return (ComPtr(takingOwnership: ptr))
     }
 
-    public static func initialize<I1, I2>(_ body: (inout UnsafeMutablePointer<I1>?, inout UnsafeMutablePointer<I2>?) throws -> ()) rethrows -> (ComPtr<I1>?, ComPtr<I2>?) {
-        var ptr1: UnsafeMutablePointer<I1>?
-        var ptr2: UnsafeMutablePointer<I2>?
-        try body(&ptr1, &ptr2)
-        return (ComPtr(takingOwnership: ptr1), ComPtr(takingOwnership: ptr2))
-    }
-
-    public static func initialize<I1, I2, I3>(_ body: (inout UnsafeMutablePointer<I1>?, inout UnsafeMutablePointer<I2>?, inout UnsafeMutablePointer<I3>?) throws -> ()) rethrows -> (ComPtr<I1>?, ComPtr<I2>?, ComPtr<I3>?) {
-        var ptr1: UnsafeMutablePointer<I1>?
-        var ptr2: UnsafeMutablePointer<I2>?
-        var ptr3: UnsafeMutablePointer<I3>?
-        try body(&ptr1, &ptr2, &ptr3)
-        return (ComPtr(takingOwnership: ptr1), ComPtr(takingOwnership: ptr2), ComPtr(takingOwnership: ptr3))
-    }
-
-    public static func initialize<I1, I2, I3, I4>(_ body: (inout UnsafeMutablePointer<I1>?, inout UnsafeMutablePointer<I2>?, inout UnsafeMutablePointer<I3>?, inout UnsafeMutablePointer<I4>?) throws -> ()) rethrows -> (ComPtr<I1>?, ComPtr<I2>?, ComPtr<I3>?, ComPtr<I4>?) {
-        var ptr1: UnsafeMutablePointer<I1>?
-        var ptr2: UnsafeMutablePointer<I2>?
-        var ptr3: UnsafeMutablePointer<I3>?
-        var ptr4: UnsafeMutablePointer<I4>?
-        try body(&ptr1, &ptr2, &ptr3, &ptr4)
-        return (ComPtr(takingOwnership: ptr1), ComPtr(takingOwnership: ptr2), ComPtr(takingOwnership: ptr3), ComPtr(takingOwnership: ptr4))
-    }
-
-    public static func initialize<I1, I2, I3, I4, I5>(_ body: (inout UnsafeMutablePointer<I1>?, inout UnsafeMutablePointer<I2>?, inout UnsafeMutablePointer<I3>?, inout UnsafeMutablePointer<I4>?, inout UnsafeMutablePointer<I5>?) throws -> ()) rethrows -> (ComPtr<I1>?, ComPtr<I2>?, ComPtr<I3>?, ComPtr<I4>?, ComPtr<I5>?) {
-        var ptr1: UnsafeMutablePointer<I1>?
-        var ptr2: UnsafeMutablePointer<I2>?
-        var ptr3: UnsafeMutablePointer<I3>?
-        var ptr4: UnsafeMutablePointer<I4>?
-        var ptr5: UnsafeMutablePointer<I5>?
-        try body(&ptr1, &ptr2, &ptr3, &ptr4, &ptr5)
-        return (ComPtr(takingOwnership: ptr1), ComPtr(takingOwnership: ptr2), ComPtr(takingOwnership: ptr3), ComPtr(takingOwnership: ptr4), ComPtr(takingOwnership: ptr5))
-    }
 }

--- a/swiftwinrt/code_writers/writer_helpers.h
+++ b/swiftwinrt/code_writers/writer_helpers.h
@@ -687,15 +687,6 @@ namespace swiftwinrt
         }
     }
 
-    static void write_param_names(writer& w, std::vector<function_param> const& params, std::string_view format)
-    {
-        separator s{ w };
-        for (const auto& param : params)
-        {
-            s();
-            w.write(format, local_swift_param_name(get_swift_name(param)));
-        }
-    }
 
     // When converting from Swift <-> C we put some local variables on the stack in order to help facilitate
     // converting between the two worlds. This method will returns a scope guard which will write any necessary
@@ -704,7 +695,6 @@ namespace swiftwinrt
     {
         write_scope_guard guard{ w, w.swift_module };
 
-        std::vector<function_param> com_ptr_initialize;
         for (auto& param : params)
         {
             TypeDef signature_type{};
@@ -825,30 +815,12 @@ namespace swiftwinrt
                 }
                 else if (needs_wrapper(category))
                 {
-                    com_ptr_initialize.push_back(param);
+                    w.write("var %Abi: %\n",
+                        local_param_name,
+                        bind<write_type>(*param.type, write_type_params::c_abi));
+                    guard.push("% = %\n", param_name,
+                        bind<write_consume_type>(param.type, w.write_temp("%Abi", local_param_name), false));
                 }
-            }
-        }
-
-        // At initial writing, ComPtrs.initialize only has overloads for 5 parameters. If we have more than 5
-        // then the generated code won't compile. Rather than check for the number here, just let generated
-        // code not compile so that we can add the overload to ComPtrs.initialize later on. This would also
-        // in theory let someone add a new overload to ComPtrs.initialize with a different number of parameters
-        // on their own as a way to unblock themselves
-        if (!com_ptr_initialize.empty())
-        {
-            w.write("let (%) = try ComPtrs.initialize { (%) in\n",
-                bind<write_param_names>(com_ptr_initialize, "%"),
-                bind<write_param_names>(com_ptr_initialize, "%Abi"));
-            guard.push("}\n");
-            guard.push_indent();
-
-            for (const auto& param : com_ptr_initialize)
-            {
-                auto param_name = get_swift_name(param);
-                auto local_param_name = local_swift_param_name(param_name);
-                guard.push("% = %\n", param_name,
-                    bind<write_consume_type>(param.type, local_param_name, true));
             }
         }
 

--- a/tests/test_component/Sources/UWP/UWP+Generics.swift
+++ b/tests/test_component/Sources/UWP/UWP+Generics.swift
@@ -4798,13 +4798,13 @@ public class IMapViewString_Any: WindowsFoundation.IInspectable {
     }
 
     open func Split(_ first: inout WindowsFoundation.AnyIMapView<String, Any?>?, _ second: inout WindowsFoundation.AnyIMapView<String, Any?>?) throws {
-        let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
-            _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
-                try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
-            }
+        var _firstAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING_IInspectable>?
+        var _secondAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING_IInspectable>?
+        _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
         }
-        first = UWP.__x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: _first)
-        second = UWP.__x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: _second)
+        first = UWP.__x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: ComPtr(_firstAbi))
+        second = UWP.__x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: ComPtr(_secondAbi))
     }
 
 }
@@ -4965,13 +4965,13 @@ public class IMapViewString_IVectorViewTextSegment: WindowsFoundation.IInspectab
     }
 
     open func Split(_ first: inout WindowsFoundation.AnyIMapView<String, WindowsFoundation.AnyIVectorView<UWP.TextSegment>?>?, _ second: inout WindowsFoundation.AnyIMapView<String, WindowsFoundation.AnyIVectorView<UWP.TextSegment>?>?) throws {
-        let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
-            _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
-                try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
-            }
+        var _firstAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment>?
+        var _secondAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment>?
+        _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
         }
-        first = UWP.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: _first)
-        second = UWP.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: _second)
+        first = UWP.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: ComPtr(_firstAbi))
+        second = UWP.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentWrapper.unwrapFrom(abi: ComPtr(_secondAbi))
     }
 
 }

--- a/tests/test_component/Sources/WindowsFoundation/Support/comptr.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/comptr.swift
@@ -90,37 +90,4 @@ public struct ComPtrs {
         return (ComPtr(takingOwnership: ptr))
     }
 
-    public static func initialize<I1, I2>(_ body: (inout UnsafeMutablePointer<I1>?, inout UnsafeMutablePointer<I2>?) throws -> ()) rethrows -> (ComPtr<I1>?, ComPtr<I2>?) {
-        var ptr1: UnsafeMutablePointer<I1>?
-        var ptr2: UnsafeMutablePointer<I2>?
-        try body(&ptr1, &ptr2)
-        return (ComPtr(takingOwnership: ptr1), ComPtr(takingOwnership: ptr2))
-    }
-
-    public static func initialize<I1, I2, I3>(_ body: (inout UnsafeMutablePointer<I1>?, inout UnsafeMutablePointer<I2>?, inout UnsafeMutablePointer<I3>?) throws -> ()) rethrows -> (ComPtr<I1>?, ComPtr<I2>?, ComPtr<I3>?) {
-        var ptr1: UnsafeMutablePointer<I1>?
-        var ptr2: UnsafeMutablePointer<I2>?
-        var ptr3: UnsafeMutablePointer<I3>?
-        try body(&ptr1, &ptr2, &ptr3)
-        return (ComPtr(takingOwnership: ptr1), ComPtr(takingOwnership: ptr2), ComPtr(takingOwnership: ptr3))
-    }
-
-    public static func initialize<I1, I2, I3, I4>(_ body: (inout UnsafeMutablePointer<I1>?, inout UnsafeMutablePointer<I2>?, inout UnsafeMutablePointer<I3>?, inout UnsafeMutablePointer<I4>?) throws -> ()) rethrows -> (ComPtr<I1>?, ComPtr<I2>?, ComPtr<I3>?, ComPtr<I4>?) {
-        var ptr1: UnsafeMutablePointer<I1>?
-        var ptr2: UnsafeMutablePointer<I2>?
-        var ptr3: UnsafeMutablePointer<I3>?
-        var ptr4: UnsafeMutablePointer<I4>?
-        try body(&ptr1, &ptr2, &ptr3, &ptr4)
-        return (ComPtr(takingOwnership: ptr1), ComPtr(takingOwnership: ptr2), ComPtr(takingOwnership: ptr3), ComPtr(takingOwnership: ptr4))
-    }
-
-    public static func initialize<I1, I2, I3, I4, I5>(_ body: (inout UnsafeMutablePointer<I1>?, inout UnsafeMutablePointer<I2>?, inout UnsafeMutablePointer<I3>?, inout UnsafeMutablePointer<I4>?, inout UnsafeMutablePointer<I5>?) throws -> ()) rethrows -> (ComPtr<I1>?, ComPtr<I2>?, ComPtr<I3>?, ComPtr<I4>?, ComPtr<I5>?) {
-        var ptr1: UnsafeMutablePointer<I1>?
-        var ptr2: UnsafeMutablePointer<I2>?
-        var ptr3: UnsafeMutablePointer<I3>?
-        var ptr4: UnsafeMutablePointer<I4>?
-        var ptr5: UnsafeMutablePointer<I5>?
-        try body(&ptr1, &ptr2, &ptr3, &ptr4, &ptr5)
-        return (ComPtr(takingOwnership: ptr1), ComPtr(takingOwnership: ptr2), ComPtr(takingOwnership: ptr3), ComPtr(takingOwnership: ptr4), ComPtr(takingOwnership: ptr5))
-    }
 }

--- a/tests/test_component/Sources/WindowsFoundation/WindowsFoundation+Generics.swift
+++ b/tests/test_component/Sources/WindowsFoundation/WindowsFoundation+Generics.swift
@@ -1140,13 +1140,13 @@ public class IMapViewString_Any: WindowsFoundation.IInspectable {
     }
 
     open func Split(_ first: inout WindowsFoundation.AnyIMapView<String, Any?>?, _ second: inout WindowsFoundation.AnyIMapView<String, Any?>?) throws {
-        let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
-            _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
-                try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
-            }
+        var _firstAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING_IInspectable>?
+        var _secondAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING_IInspectable>?
+        _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_IInspectable.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
         }
-        first = WindowsFoundation.__x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: _first)
-        second = WindowsFoundation.__x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: _second)
+        first = WindowsFoundation.__x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: ComPtr(_firstAbi))
+        second = WindowsFoundation.__x_ABI_C__FIMapView_2_HSTRING_IInspectableWrapper.unwrapFrom(abi: ComPtr(_secondAbi))
     }
 
 }
@@ -1305,13 +1305,13 @@ public class IMapViewString_String: WindowsFoundation.IInspectable {
     }
 
     open func Split(_ first: inout WindowsFoundation.AnyIMapView<String, String>?, _ second: inout WindowsFoundation.AnyIMapView<String, String>?) throws {
-        let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
-            _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
-                try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
-            }
+        var _firstAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING_HSTRING>?
+        var _secondAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING_HSTRING>?
+        _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
         }
-        first = WindowsFoundation.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: _first)
-        second = WindowsFoundation.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: _second)
+        first = WindowsFoundation.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: ComPtr(_firstAbi))
+        second = WindowsFoundation.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: ComPtr(_secondAbi))
     }
 
 }

--- a/tests/test_component/Sources/test_component/test_component+Class.swift
+++ b/tests/test_component/Sources/test_component/test_component+Class.swift
@@ -384,21 +384,19 @@ extension __ABI_test_component {
         }
 
         public func OutObject(_ value: inout Any?) throws {
-            let (_value) = try ComPtrs.initialize { (_valueAbi) in
-                _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
-                    try CHECKED(pThis.pointee.lpVtbl.pointee.OutObject(pThis, &_valueAbi))
-                }
+            var _valueAbi: UnsafeMutablePointer<C_IInspectable>?
+            _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.OutObject(pThis, &_valueAbi))
             }
-            value = __ABI_.AnyWrapper.unwrapFrom(abi: _value)
+            value = __ABI_.AnyWrapper.unwrapFrom(abi: ComPtr(_valueAbi))
         }
 
         public func OutStringable(_ value: inout WindowsFoundation.AnyIStringable?) throws {
-            let (_value) = try ComPtrs.initialize { (_valueAbi) in
-                _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
-                    try CHECKED(pThis.pointee.lpVtbl.pointee.OutStringable(pThis, &_valueAbi))
-                }
+            var _valueAbi: UnsafeMutablePointer<__x_ABI_CWindows_CFoundation_CIStringable>?
+            _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.OutStringable(pThis, &_valueAbi))
             }
-            value = __ABI_Windows_Foundation.IStringableWrapper.unwrapFrom(abi: _value)
+            value = __ABI_Windows_Foundation.IStringableWrapper.unwrapFrom(abi: ComPtr(_valueAbi))
         }
 
         public func OutBlittableStruct(_ value: inout test_component.BlittableStruct) throws {

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -2148,13 +2148,13 @@ public class IMapViewString_String: WindowsFoundation.IInspectable {
     }
 
     open func Split(_ first: inout WindowsFoundation.AnyIMapView<String, String>?, _ second: inout WindowsFoundation.AnyIMapView<String, String>?) throws {
-        let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
-            _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
-                try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
-            }
+        var _firstAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING_HSTRING>?
+        var _secondAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING_HSTRING>?
+        _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
         }
-        first = test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: _first)
-        second = test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: _second)
+        first = test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: ComPtr(_firstAbi))
+        second = test_component.__x_ABI_C__FIMapView_2_HSTRING_HSTRINGWrapper.unwrapFrom(abi: ComPtr(_secondAbi))
     }
 
 }
@@ -2314,13 +2314,13 @@ public class IMapViewString_Base: WindowsFoundation.IInspectable {
     }
 
     open func Split(_ first: inout WindowsFoundation.AnyIMapView<String, test_component.Base?>?, _ second: inout WindowsFoundation.AnyIMapView<String, test_component.Base?>?) throws {
-        let (_first, _second) = try ComPtrs.initialize { (_firstAbi, _secondAbi) in
-            _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
-                try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
-            }
+        var _firstAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase>?
+        var _secondAbi: UnsafeMutablePointer<__x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase>?
+        _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
+            try CHECKED(pThis.pointee.lpVtbl.pointee.Split(pThis, &_firstAbi, &_secondAbi))
         }
-        first = test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.unwrapFrom(abi: _first)
-        second = test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.unwrapFrom(abi: _second)
+        first = test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.unwrapFrom(abi: ComPtr(_firstAbi))
+        second = test_component.__x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseWrapper.unwrapFrom(abi: ComPtr(_secondAbi))
     }
 
 }

--- a/tests/test_component/Sources/test_component/test_component+IIAmImplementable.swift
+++ b/tests/test_component/Sources/test_component/test_component+IIAmImplementable.swift
@@ -235,12 +235,11 @@ extension __ABI_test_component {
         }
 
         open func OutObject(_ value: inout Any?) throws {
-            let (_value) = try ComPtrs.initialize { (_valueAbi) in
-                _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
-                    try CHECKED(pThis.pointee.lpVtbl.pointee.OutObject(pThis, &_valueAbi))
-                }
+            var _valueAbi: UnsafeMutablePointer<C_IInspectable>?
+            _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
+                try CHECKED(pThis.pointee.lpVtbl.pointee.OutObject(pThis, &_valueAbi))
             }
-            value = __ABI_.AnyWrapper.unwrapFrom(abi: _value)
+            value = __ABI_.AnyWrapper.unwrapFrom(abi: ComPtr(_valueAbi))
         }
 
         open func OutBlittableStruct(_ value: inout test_component.BlittableStruct) throws {


### PR DESCRIPTION
Removes the multi-parameter `ComPtrs.initialize` overloads, in preparation for making `ComPtr` a non-copyable struct.

# Context

Upstack in #243 I convert `ComPtr` to a non-copyable struct. The reference counting Swift does on the `ComPtr` class instances itself is a hot path in application code performance traces. Converting it to be a non-copyable struct removes this additional Swift reference counting (on top of the COM pointer reference counting), and shows meaningful improvements across much of my local benchmarking suite due to `ComPtr`s fundamental role. 

Evidently (based on observed compiler behavior) tuples with non-copyable elements are not supported yet, so we need to remove these `ComPtrs.initialize` overloads. These are only used in generated code, so we can just update the generator code to manually initialize the COM pointers instead of using a `ComPtrs` helper.

# Changes
- Updates the `write_local_param_wrappers` function in `writer_helpers.h` to replace its usage of the `ComPtrs.initialize` helpers.
- Removes the helpers themselves in `ComPtr.swift`.