### PR TITLE
Add ownership annotations to `ComPtr` parameters

### DIFF
--- a/swiftwinrt/Resources/Support/Aggregation.swift
+++ b/swiftwinrt/Resources/Support/Aggregation.swift
@@ -105,7 +105,7 @@ public class UnsealedWinRTClassWrapper<Composable: ComposableImpl> : WinRTAbiBri
         super.init(abi, Composable.SwiftProjection(impl))
     }
 
-    public static func unwrapFrom(base: ComPtr<Composable.Default.CABI>) -> Composable.Class? {
+    public static func unwrapFrom(base: borrowing ComPtr<Composable.Default.CABI>) -> Composable.Class? {
         let overrides: Composable.SwiftABI = try! base.queryInterface()
         if let weakRef = tryUnwrapFrom(abi: RawPointer(overrides)) { return weakRef.instance }
         guard let instance = makeFrom(abi: overrides) else {
@@ -127,7 +127,7 @@ public class UnsealedWinRTClassWrapper<Composable: ComposableImpl> : WinRTAbiBri
 }
 
 public extension ComposableImpl {
-    static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         return nil
     }
 }

--- a/swiftwinrt/Resources/Support/ComPtr.swift
+++ b/swiftwinrt/Resources/Support/ComPtr.swift
@@ -24,7 +24,7 @@ public class ComPtr<CInterface> {
         self.init(ptr)
     }
 
-    fileprivate init?(takingOwnership ptr: UnsafeMutablePointer<CInterface>?) {
+    init?(consuming ptr: UnsafeMutablePointer<CInterface>?) {
         guard let ptr else { return nil }
         self.pUnk = ptr
     }
@@ -81,13 +81,13 @@ public struct ComPtrs {
     public static func initialize<I>(to: I.Type, _ body: (inout UnsafeMutableRawPointer?) throws -> ()) rethrows -> (ComPtr<I>?) {
         var ptrRaw: UnsafeMutableRawPointer?
         try body(&ptrRaw)
-        return (ComPtr(takingOwnership: ptrRaw?.assumingMemoryBound(to: I.self)))
+        return (ComPtr(consuming: ptrRaw?.assumingMemoryBound(to: I.self)))
     }
 
     public static func initialize<I>(_ body: (inout UnsafeMutablePointer<I>?) throws -> ()) rethrows -> (ComPtr<I>?) {
         var ptr: UnsafeMutablePointer<I>?
         try body(&ptr)
-        return (ComPtr(takingOwnership: ptr))
+        return (ComPtr(consuming: ptr))
     }
 
 }

--- a/swiftwinrt/Resources/Support/IBufferByteAccess.swift
+++ b/swiftwinrt/Resources/Support/IBufferByteAccess.swift
@@ -34,7 +34,7 @@ public enum IBufferByteAccessBridge: AbiInterfaceBridge {
         return CABI(lpVtbl: &IBufferByteAccessVTable)
     }
 
-    public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         // This code path is not actually reachable since IBufferByteAccess is not a WinRT interface.
         // It is a COM interface which is implemented by any object which implements the IBuffer interface.
         // And the IBufferImpl object will correctly have the implementation of this interface, so this isn't needed

--- a/swiftwinrt/Resources/Support/IInspectable.swift
+++ b/swiftwinrt/Resources/Support/IInspectable.swift
@@ -66,7 +66,7 @@ public enum __ABI_ {
             return try super.toABI(body)
         }
       }
-      public static func unwrapFrom(abi: ComPtr<C_IInspectable>?) -> Any? {
+      public static func unwrapFrom(abi: consuming ComPtr<C_IInspectable>?) -> Any? {
         guard let abi = abi else { return nil }
         if let instance = tryUnwrapFrom(abi: abi) {
           if let weakRef = instance as? AnyObjectWrapper { return weakRef.obj }
@@ -151,7 +151,7 @@ public enum __IMPL_ {
             return .init(lpVtbl: vtblPtr)
         }
 
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi else { return nil }
             let ref = IInspectable(abi)
             return makeFrom(abi: ref) ?? ref

--- a/swiftwinrt/Resources/Support/IMemoryBufferByteAccess.swift
+++ b/swiftwinrt/Resources/Support/IMemoryBufferByteAccess.swift
@@ -39,7 +39,7 @@ public enum IMemoryBufferByteAccessBridge: AbiInterfaceBridge {
         return CABI(lpVtbl: &IMemoryBufferByteAccessVTable)
     }
 
-    public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         // This code path is not actually reachable since IMemoryBufferByteAccess is not a WinRT interface.
         // It is a COM interface which is implemented by any object which implements the IMemoryBufferReference interface.
         // And the IMemoryBufferReferenceImpl object will correctly have the implementation of this interface, so this isn't needed

--- a/swiftwinrt/Resources/Support/IUnknown.swift
+++ b/swiftwinrt/Resources/Support/IUnknown.swift
@@ -11,7 +11,7 @@ open class IUnknown : HasIID {
 
   open class var IID: SUPPORT_MODULE.IID { IID_IUnknown }
 
-  public required init<CInterface>(_ pointer: ComPtr<CInterface>) {
+  public required init<CInterface>(_ pointer: consuming ComPtr<CInterface>) {
     self.pUnk = .init(pointer)
   }
 

--- a/swiftwinrt/Resources/Support/IUnknownRef.swift
+++ b/swiftwinrt/Resources/Support/IUnknownRef.swift
@@ -5,10 +5,9 @@
 public final class IUnknownRef {
   private var pUnk: ComPtr<C_IUnknown>
 
-  init<C_Interface>(_ pUnk: ComPtr<C_Interface>) {
-    let pointer: UnsafeMutablePointer<C_IUnknown> =
-        UnsafeMutableRawPointer(pUnk.get()).bindMemory(to: C_IUnknown.self, capacity: 1)
-    self.pUnk = .init(pointer)
+  init<C_Interface>(_ pUnk: consuming ComPtr<C_Interface>) {
+    let raw = pUnk.detach()
+    self.pUnk = ComPtr(consuming: raw?.assumingMemoryBound(to: C_IUnknown.self))!
   }
 
   func detach() -> UnsafeMutableRawPointer? {

--- a/swiftwinrt/Resources/Support/IWeakReference.swift
+++ b/swiftwinrt/Resources/Support/IWeakReference.swift
@@ -50,7 +50,7 @@ fileprivate enum IWeakReferenceBridge: AbiBridge {
         return C_IWeakReference(lpVtbl: &IWeakReferenceVTable)
     }
 
-    static func from(abi: ComPtr<C_IWeakReference>?) -> WeakReference? {
+    static func from(abi: consuming ComPtr<C_IWeakReference>?) -> WeakReference? {
         fatalError("Not needed")
     }
 }

--- a/swiftwinrt/Resources/Support/IWeakReferenceSource.swift
+++ b/swiftwinrt/Resources/Support/IWeakReferenceSource.swift
@@ -43,7 +43,7 @@ fileprivate enum IWeakReferenceSourceBridge: AbiBridge {
         return C_IWeakReferenceSource(lpVtbl: &IWeakReferenceSourceVTable)
     }
 
-    static func from(abi: ComPtr<C_IWeakReferenceSource>?) -> AnyObject? {
+    static func from(abi: consuming ComPtr<C_IWeakReferenceSource>?) -> AnyObject? {
         fatalError("Not needed")
     }
 }

--- a/swiftwinrt/Resources/Support/Marshaler.swift
+++ b/swiftwinrt/Resources/Support/Marshaler.swift
@@ -28,7 +28,7 @@ fileprivate enum IMarshalBridge: AbiBridge {
         return C_IMarshal(lpVtbl: &IMarshalVTable)
     }
 
-    static func from(abi: ComPtr<C_IMarshal>?) -> Marshaler? {
+    static func from(abi: consuming ComPtr<C_IMarshal>?) -> Marshaler? {
         guard let abi = abi else { return nil }
         return try? Marshaler(IUnknownRef(abi))
     }

--- a/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
+++ b/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
@@ -21,7 +21,7 @@ public protocol AbiInterface {
 public protocol AbiBridge {
     associatedtype CABI
     associatedtype SwiftProjection
-    static func from(abi: ComPtr<CABI>?) -> SwiftProjection?
+    static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection?
 }
 
 public protocol SwiftImplementableBridge : AbiBridge {
@@ -178,7 +178,7 @@ open class WinRTWrapperBase<CInterface, Prototype> {
 
 open class WinRTAbiBridgeWrapper<I: AbiBridge> : WinRTWrapperBase<I.CABI, I.SwiftProjection> {
 
-    public static func unwrapFrom(abi pointer: ComPtr<I.CABI>?) -> I.SwiftProjection? {
+    public static func unwrapFrom(abi pointer: consuming ComPtr<I.CABI>?) -> I.SwiftProjection? {
         guard let pointer = pointer else { return nil }
         guard let unwrapped = tryUnwrapFrom(abi: pointer) else { return I.from(abi: pointer) }
         return unwrapped

--- a/swiftwinrt/code_writers/class_writers.cpp
+++ b/swiftwinrt/code_writers/class_writers.cpp
@@ -219,7 +219,7 @@ override % func _getABI<T>() -> UnsafeMutablePointer<T>? {
                 w.write("public typealias CABI = %\n", bind_type_mangled(default_interface));
                 // We unwrap composable types to try and get to any derived type.
                 // If not composable, then create a new instance
-                w.write("public static func from(abi: ComPtr<%>?) -> %? {\n",
+                w.write("public static func from(abi: consuming ComPtr<%>?) -> %? {\n",
                     bind_type_mangled(default_interface), type);
                 {
                     auto indent = w.push_indent();

--- a/swiftwinrt/code_writers/delegate_writers.cpp
+++ b/swiftwinrt/code_writers/delegate_writers.cpp
@@ -52,7 +52,7 @@ namespace swiftwinrt
     % typealias CABI = %
     % typealias SwiftABI = %.%
 
-    % static func from(abi: ComPtr<CABI>?) -> Handler? {
+    % static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (%) in

--- a/swiftwinrt/code_writers/generic_writers.cpp
+++ b/swiftwinrt/code_writers/generic_writers.cpp
@@ -105,7 +105,7 @@ namespace swiftwinrt
     typealias SwiftProjection = %
     static var IID: %.IID { IID_% }
 
-    static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let val = abi else { return nil }
         var result: %%
         try! CHECKED(val.get().pointee.lpVtbl.pointee.get_Value(val.get(), &result))
@@ -161,7 +161,7 @@ namespace swiftwinrt
         w.write("typealias Bridge = %\n", bind_bridge_name(type));
         w.write("let _default: Bridge.SwiftABI\n");
 
-        w.write("init(_ fromAbi: ComPtr<Bridge.CABI>) {\n");
+        w.write("init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {\n");
         w.write("    _default = Bridge.SwiftABI(fromAbi)\n");
         w.write("}\n\n");
 

--- a/swiftwinrt/code_writers/interface_writers.cpp
+++ b/swiftwinrt/code_writers/interface_writers.cpp
@@ -95,7 +95,7 @@ public class %Maker: MakeFromAbi {
     % typealias CABI = %
     % typealias SwiftABI = %
     % typealias SwiftProjection = %
-    % static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    % static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return %(abi)
     }
@@ -132,7 +132,7 @@ public class %Maker: MakeFromAbi {
     fileprivate typealias Bridge = %
     fileprivate let _default: Bridge.SwiftABI
     fileprivate var thisPtr: %.IInspectable { _default }
-    fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 

--- a/swiftwinrt/code_writers/writer_helpers.h
+++ b/swiftwinrt/code_writers/writer_helpers.h
@@ -468,7 +468,7 @@ namespace swiftwinrt
     var _value: Any
     var propertyType : PropertyType
 
-    fileprivate init(_ abi: ComPtr<__x_ABI_CWindows_CFoundation_CIPropertyValue>) { fatalError("not implemented") }
+    fileprivate init(_ abi: consuming ComPtr<__x_ABI_CWindows_CFoundation_CIPropertyValue>) { fatalError("not implemented") }
     public init(value: Any) {
         _value = value
         propertyType = switch value {

--- a/tests/test_component/Sources/UWP/UWP+Generics.swift
+++ b/tests/test_component/Sources/UWP/UWP+Generics.swift
@@ -48,7 +48,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1_IInspectableBridge 
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1_IInspectable
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerAny
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -101,7 +101,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1_booleanBridge : Win
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1_boolean
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerBool
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -154,7 +154,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRINGBridge : Win
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1_HSTRING
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerString
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -207,7 +207,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32Bridge : WinR
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1_UINT32
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerUInt32
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -260,7 +260,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIMap_2_HSTRING_IInspectable
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIMapString_Any
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -313,7 +313,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__F__CIPro
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__F__CIPropertySet
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIPropertySet
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -366,7 +366,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIVectorViewIStorageItem
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -419,7 +419,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIVectorViewStorageFile
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -472,7 +472,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIVectorViewStorageFolder
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -525,7 +525,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIVectorViewStorageLibraryChange
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -578,7 +578,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUser
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIVectorViewUser
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -631,7 +631,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_C__FIVector_1_HSTRING
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIVectorString
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -684,7 +684,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerBasicProperties
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -737,7 +737,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerDocumentProperties
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -790,7 +790,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerImageProperties
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -843,7 +843,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerMusicProperties
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -896,7 +896,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerStorageItemThumbnail
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -949,7 +949,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerVideoProperties
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1002,7 +1002,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CIStorageItem
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIStorageItem
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1055,7 +1055,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIndexedState
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1108,7 +1108,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFile
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerStorageFile
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1161,7 +1161,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageFolder
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerStorageFolder
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1214,7 +1214,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerStorageStreamTransaction
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1267,7 +1267,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIBuffer
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1320,7 +1320,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIInputStream
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1373,7 +1373,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIRandomAccessStream
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1426,7 +1426,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamReference
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIRandomAccessStreamReference
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1479,7 +1479,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerIRandomAccessStreamWithContentType
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1532,7 +1532,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__C
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1___x_ABI_CWindows__CSystem__CUserAgeConsentResult
     internal typealias SwiftABI = UWP.AsyncOperationCompletedHandlerUserAgeConsentResult
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1585,7 +1585,7 @@ internal class __x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32Bridge 
     internal typealias CABI = __x_ABI_C__FIAsyncOperationProgressHandler_2_UINT32_UINT32
     internal typealias SwiftABI = UWP.AsyncOperationProgressHandlerUInt32_UInt32
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, progressInfo) in
@@ -1638,7 +1638,7 @@ internal class __x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CS
     internal typealias CABI = __x_ABI_C__FIAsyncOperationProgressHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32
     internal typealias SwiftABI = UWP.AsyncOperationProgressHandlerIBuffer_UInt32
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, progressInfo) in
@@ -1691,7 +1691,7 @@ internal class __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_
     internal typealias CABI = __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_UINT32_UINT32
     internal typealias SwiftABI = UWP.AsyncOperationWithProgressCompletedHandlerUInt32_UInt32
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1744,7 +1744,7 @@ internal class __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI
     internal typealias CABI = __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32
     internal typealias SwiftABI = UWP.AsyncOperationWithProgressCompletedHandlerIBuffer_UInt32
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -1812,7 +1812,7 @@ internal enum __x_ABI_C__FIIterable_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterable_1_HSTRING
     internal typealias SwiftABI = IIterableString
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1_HSTRINGImpl(abi)
     }
@@ -1827,7 +1827,7 @@ fileprivate class __x_ABI_C__FIIterable_1_HSTRINGImpl : IIterable, AbiInterfaceI
     typealias T = String
     typealias Bridge = __x_ABI_C__FIIterable_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1899,7 +1899,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegme
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegment
     internal typealias SwiftABI = IIterableTextSegment
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<UWP.TextSegment>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegmentImpl(abi)
     }
@@ -1914,7 +1914,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextS
     typealias T = UWP.TextSegment
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1986,7 +1986,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspe
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable
     internal typealias SwiftABI = IIterableIKeyValuePairString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<WindowsFoundation.AnyIKeyValuePair<String, Any?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableImpl(abi)
     }
@@ -2001,7 +2001,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_II
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, Any?>?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2073,7 +2073,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_AB
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment
     internal typealias SwiftABI = IIterableIKeyValuePairString_IVectorViewTextSegment
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<WindowsFoundation.AnyIKeyValuePair<String, WindowsFoundation.AnyIVectorView<UWP.TextSegment>?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentImpl(abi)
     }
@@ -2088,7 +2088,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, WindowsFoundation.AnyIVectorView<UWP.TextSegment>?>?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2160,7 +2160,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItemB
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItem
     internal typealias SwiftABI = IIterableIStorageItem
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<UWP.AnyIStorageItem?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItemImpl(abi)
     }
@@ -2175,7 +2175,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageI
     typealias T = UWP.AnyIStorageItem?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CIStorageItemBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2247,7 +2247,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSort
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry
     internal typealias SwiftABI = IIterableSortEntry
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<UWP.SortEntry>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryImpl(abi)
     }
@@ -2262,7 +2262,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__C
     typealias T = UWP.SortEntry
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2334,7 +2334,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFileBr
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFile
     internal typealias SwiftABI = IIterableStorageFile
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<UWP.StorageFile?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFileImpl(abi)
     }
@@ -2349,7 +2349,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFi
     typealias T = UWP.StorageFile?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFileBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2421,7 +2421,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolder
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolder
     internal typealias SwiftABI = IIterableStorageFolder
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<UWP.StorageFolder?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolderImpl(abi)
     }
@@ -2436,7 +2436,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFo
     typealias T = UWP.StorageFolder?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageFolderBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2508,7 +2508,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibrar
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibraryChange
     internal typealias SwiftABI = IIterableStorageLibraryChange
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<UWP.StorageLibraryChange?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeImpl(abi)
     }
@@ -2523,7 +2523,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLi
     typealias T = UWP.StorageLibraryChange?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2595,7 +2595,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_CWindows__CSystem__CUserBridge : A
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CSystem__CUser
     internal typealias SwiftABI = IIterableUser
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<UWP.User?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_CWindows__CSystem__CUserImpl(abi)
     }
@@ -2610,7 +2610,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CSystem__CUserImpl :
     typealias T = UWP.User?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CSystem__CUserBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2682,7 +2682,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_CWindows__CSystem__CUserWatcherUpd
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CSystem__CUserWatcherUpdateKind
     internal typealias SwiftABI = IIterableUserWatcherUpdateKind
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<UWP.UserWatcherUpdateKind>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_CWindows__CSystem__CUserWatcherUpdateKindImpl(abi)
     }
@@ -2697,7 +2697,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CSystem__CUserWatche
     typealias T = UWP.UserWatcherUpdateKind
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CSystem__CUserWatcherUpdateKindBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2819,7 +2819,7 @@ internal enum __x_ABI_C__FIIterator_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterator_1_HSTRING
     internal typealias SwiftABI = IIteratorString
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1_HSTRINGImpl(abi)
     }
@@ -2834,7 +2834,7 @@ fileprivate class __x_ABI_C__FIIterator_1_HSTRINGImpl : IIterator, AbiInterfaceI
     typealias T = String
     typealias Bridge = __x_ABI_C__FIIterator_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2971,7 +2971,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegme
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegment
     internal typealias SwiftABI = IIteratorTextSegment
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<UWP.TextSegment>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegmentImpl(abi)
     }
@@ -2986,7 +2986,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextS
     typealias T = UWP.TextSegment
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -3123,7 +3123,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspe
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable
     internal typealias SwiftABI = IIteratorIKeyValuePairString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<WindowsFoundation.AnyIKeyValuePair<String, Any?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableImpl(abi)
     }
@@ -3138,7 +3138,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_II
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, Any?>?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -3275,7 +3275,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_AB
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment
     internal typealias SwiftABI = IIteratorIKeyValuePairString_IVectorViewTextSegment
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<WindowsFoundation.AnyIKeyValuePair<String, WindowsFoundation.AnyIVectorView<UWP.TextSegment>?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentImpl(abi)
     }
@@ -3290,7 +3290,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, WindowsFoundation.AnyIVectorView<UWP.TextSegment>?>?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -3427,7 +3427,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItemB
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItem
     internal typealias SwiftABI = IIteratorIStorageItem
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<UWP.AnyIStorageItem?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItemImpl(abi)
     }
@@ -3442,7 +3442,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageI
     typealias T = UWP.AnyIStorageItem?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CIStorageItemBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -3580,7 +3580,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSort
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry
     internal typealias SwiftABI = IIteratorSortEntry
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<UWP.SortEntry>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryImpl(abi)
     }
@@ -3595,7 +3595,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__C
     typealias T = UWP.SortEntry
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -3731,7 +3731,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFileBr
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFile
     internal typealias SwiftABI = IIteratorStorageFile
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<UWP.StorageFile?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFileImpl(abi)
     }
@@ -3746,7 +3746,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFi
     typealias T = UWP.StorageFile?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFileBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -3882,7 +3882,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolder
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolder
     internal typealias SwiftABI = IIteratorStorageFolder
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<UWP.StorageFolder?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolderImpl(abi)
     }
@@ -3897,7 +3897,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFo
     typealias T = UWP.StorageFolder?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageFolderBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -4033,7 +4033,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibrar
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChange
     internal typealias SwiftABI = IIteratorStorageLibraryChange
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<UWP.StorageLibraryChange?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeImpl(abi)
     }
@@ -4048,7 +4048,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLi
     typealias T = UWP.StorageLibraryChange?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -4184,7 +4184,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_CWindows__CSystem__CUserBridge : A
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CSystem__CUser
     internal typealias SwiftABI = IIteratorUser
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<UWP.User?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_CWindows__CSystem__CUserImpl(abi)
     }
@@ -4199,7 +4199,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CSystem__CUserImpl :
     typealias T = UWP.User?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CSystem__CUserBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -4333,7 +4333,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_CWindows__CSystem__CUserWatcherUpd
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CSystem__CUserWatcherUpdateKind
     internal typealias SwiftABI = IIteratorUserWatcherUpdateKind
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<UWP.UserWatcherUpdateKind>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_CWindows__CSystem__CUserWatcherUpdateKindImpl(abi)
     }
@@ -4348,7 +4348,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CSystem__CUserWatche
     typealias T = UWP.UserWatcherUpdateKind
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CSystem__CUserWatcherUpdateKindBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -4450,7 +4450,7 @@ internal enum __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge : AbiInterf
     internal typealias CABI = __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable
     internal typealias SwiftABI = IKeyValuePairString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIKeyValuePair<String, Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableImpl(abi)
     }
@@ -4466,7 +4466,7 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableImpl : IKeyVal
     typealias V = Any?
     typealias Bridge = __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -4558,7 +4558,7 @@ internal enum __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_
     internal typealias CABI = __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment
     internal typealias SwiftABI = IKeyValuePairString_IVectorViewTextSegment
     internal typealias SwiftProjection = WindowsFoundation.AnyIKeyValuePair<String, WindowsFoundation.AnyIVectorView<UWP.TextSegment>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentImpl(abi)
     }
@@ -4574,7 +4574,7 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1_
     typealias V = WindowsFoundation.AnyIVectorView<UWP.TextSegment>?
     typealias Bridge = __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -4664,7 +4664,7 @@ internal enum __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGBridge : AbiInterfaceBri
     internal typealias CABI = __x_ABI_C__FIMapChangedEventArgs_1_HSTRING
     internal typealias SwiftABI = IMapChangedEventArgsString
     internal typealias SwiftProjection = WindowsFoundation.AnyIMapChangedEventArgs<String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGImpl(abi)
     }
@@ -4679,7 +4679,7 @@ fileprivate class __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGImpl : IMapChangedEv
     typealias K = String
     typealias Bridge = __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -4813,7 +4813,7 @@ internal enum __x_ABI_C__FIMapView_2_HSTRING_IInspectableBridge : AbiInterfaceBr
     internal typealias CABI = __x_ABI_C__FIMapView_2_HSTRING_IInspectable
     internal typealias SwiftABI = IMapViewString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIMapView<String, Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMapView_2_HSTRING_IInspectableImpl(abi)
     }
@@ -4830,7 +4830,7 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING_IInspectableImpl : IMapView, Ab
     typealias V = Any?
     typealias Bridge = __x_ABI_C__FIMapView_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -4980,7 +4980,7 @@ internal enum __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_C
     internal typealias CABI = __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment
     internal typealias SwiftABI = IMapViewString_IVectorViewTextSegment
     internal typealias SwiftProjection = WindowsFoundation.AnyIMapView<String, WindowsFoundation.AnyIVectorView<UWP.TextSegment>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentImpl(abi)
     }
@@ -4997,7 +4997,7 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_A
     typealias V = WindowsFoundation.AnyIVectorView<UWP.TextSegment>?
     typealias Bridge = __x_ABI_C__FIMapView_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -5188,7 +5188,7 @@ internal enum __x_ABI_C__FIMap_2_HSTRING_IInspectableBridge : AbiInterfaceBridge
     internal typealias CABI = __x_ABI_C__FIMap_2_HSTRING_IInspectable
     internal typealias SwiftABI = IMapString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIMap<String, Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMap_2_HSTRING_IInspectableImpl(abi)
     }
@@ -5205,7 +5205,7 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING_IInspectableImpl : IMap, AbiInterfa
     typealias V = Any?
     typealias Bridge = __x_ABI_C__FIMap_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -5411,7 +5411,7 @@ internal enum __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWind
     internal typealias CABI = __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment
     internal typealias SwiftABI = IMapString_IVectorViewTextSegment
     internal typealias SwiftProjection = WindowsFoundation.AnyIMap<String, WindowsFoundation.AnyIVectorView<UWP.TextSegment>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentImpl(abi)
     }
@@ -5428,7 +5428,7 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_C
     typealias V = WindowsFoundation.AnyIVectorView<UWP.TextSegment>?
     typealias Bridge = __x_ABI_C__FIMap_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -5552,7 +5552,7 @@ internal enum __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableBridge : AbiInter
     internal typealias CABI = __x_ABI_C__FIObservableMap_2_HSTRING_IInspectable
     internal typealias SwiftABI = IObservableMapString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIObservableMap<String, Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableImpl(abi)
     }
@@ -5569,7 +5569,7 @@ fileprivate class __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableImpl : IObser
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, Any?>?
     typealias Bridge = __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -5748,7 +5748,7 @@ internal enum __x_ABI_C__FIVectorView_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVectorView_1_HSTRING
     internal typealias SwiftABI = IVectorViewString
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1_HSTRINGImpl(abi)
     }
@@ -5763,7 +5763,7 @@ fileprivate class __x_ABI_C__FIVectorView_1_HSTRINGImpl : IVectorView, AbiInterf
     typealias T = String
     typealias Bridge = __x_ABI_C__FIVectorView_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -5933,7 +5933,7 @@ internal enum __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSeg
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment
     internal typealias SwiftABI = IVectorViewTextSegment
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<UWP.TextSegment>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentImpl(abi)
     }
@@ -5948,7 +5948,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTex
     typealias T = UWP.TextSegment
     typealias Bridge = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegmentBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -6120,7 +6120,7 @@ internal enum __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageIte
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem
     internal typealias SwiftABI = IVectorViewIStorageItem
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<UWP.AnyIStorageItem?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemImpl(abi)
     }
@@ -6135,7 +6135,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorag
     typealias T = UWP.AnyIStorageItem?
     typealias Bridge = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -6307,7 +6307,7 @@ internal enum __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSo
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry
     internal typealias SwiftABI = IVectorViewSortEntry
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<UWP.SortEntry>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryImpl(abi)
     }
@@ -6322,7 +6322,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch_
     typealias T = UWP.SortEntry
     typealias Bridge = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -6491,7 +6491,7 @@ internal enum __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile
     internal typealias SwiftABI = IVectorViewStorageFile
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<UWP.StorageFile?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileImpl(abi)
     }
@@ -6506,7 +6506,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorage
     typealias T = UWP.StorageFile?
     typealias Bridge = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -6675,7 +6675,7 @@ internal enum __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFold
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder
     internal typealias SwiftABI = IVectorViewStorageFolder
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<UWP.StorageFolder?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderImpl(abi)
     }
@@ -6690,7 +6690,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorage
     typealias T = UWP.StorageFolder?
     typealias Bridge = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -6859,7 +6859,7 @@ internal enum __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibr
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange
     internal typealias SwiftABI = IVectorViewStorageLibraryChange
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<UWP.StorageLibraryChange?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeImpl(abi)
     }
@@ -6874,7 +6874,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorage
     typealias T = UWP.StorageLibraryChange?
     typealias Bridge = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -7043,7 +7043,7 @@ internal enum __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUserBridge :
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUser
     internal typealias SwiftABI = IVectorViewUser
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<UWP.User?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUserImpl(abi)
     }
@@ -7058,7 +7058,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUserImpl
     typealias T = UWP.User?
     typealias Bridge = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUserBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -7225,7 +7225,7 @@ internal enum __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUserWatcherU
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUserWatcherUpdateKind
     internal typealias SwiftABI = IVectorViewUserWatcherUpdateKind
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<UWP.UserWatcherUpdateKind>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUserWatcherUpdateKindImpl(abi)
     }
@@ -7240,7 +7240,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUserWatc
     typealias T = UWP.UserWatcherUpdateKind
     typealias Bridge = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUserWatcherUpdateKindBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -7524,7 +7524,7 @@ internal enum __x_ABI_C__FIVector_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVector_1_HSTRING
     internal typealias SwiftABI = IVectorString
     internal typealias SwiftProjection = WindowsFoundation.AnyIVector<String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVector_1_HSTRINGImpl(abi)
     }
@@ -7539,7 +7539,7 @@ fileprivate class __x_ABI_C__FIVector_1_HSTRINGImpl : IVector, AbiInterfaceImpl 
     typealias T = String
     typealias Bridge = __x_ABI_C__FIVector_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -7873,7 +7873,7 @@ internal enum __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEn
     internal typealias CABI = __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntry
     internal typealias SwiftABI = IVectorSortEntry
     internal typealias SwiftProjection = WindowsFoundation.AnyIVector<UWP.SortEntry>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryImpl(abi)
     }
@@ -7888,7 +7888,7 @@ fileprivate class __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSo
     typealias T = UWP.SortEntry
     typealias Bridge = __x_ABI_C__FIVector_1___x_ABI_CWindows__CStorage__CSearch__CSortEntryBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -8038,7 +8038,7 @@ internal class __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableBridge :
     internal typealias CABI = __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectable
     internal typealias SwiftABI = UWP.MapChangedEventHandlerString_Any
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
@@ -8093,7 +8093,7 @@ internal class __x_ABI_C__FIEventHandler_1_IInspectableBridge : WinRTDelegateBri
     internal typealias CABI = __x_ABI_C__FIEventHandler_1_IInspectable
     internal typealias SwiftABI = UWP.EventHandlerAny
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
@@ -8226,7 +8226,7 @@ internal enum __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Bridge : Ab
     internal typealias CABI = __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32
     internal typealias SwiftABI = IAsyncOperationWithProgressUInt32_UInt32
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperationWithProgress<UInt32, UInt32>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Impl(abi)
     }
@@ -8242,7 +8242,7 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Impl : 
     typealias TProgress = UInt32
     typealias Bridge = __x_ABI_C__FIAsyncOperationWithProgress_2_UINT32_UINT32Bridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -8419,7 +8419,7 @@ internal enum __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStora
     internal typealias CABI = __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32
     internal typealias SwiftABI = IAsyncOperationWithProgressIBuffer_UInt32
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperationWithProgress<UWP.AnyIBuffer?, UInt32>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Impl(abi)
     }
@@ -8435,7 +8435,7 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CS
     typealias TProgress = UInt32
     typealias Bridge = __x_ABI_C__FIAsyncOperationWithProgress_2___x_ABI_CWindows__CStorage__CStreams__CIBuffer_UINT32Bridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -8580,7 +8580,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1_IInspectableBridge : AbiInterfaceBri
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1_IInspectable
     internal typealias SwiftABI = IAsyncOperationAny
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1_IInspectableImpl(abi)
     }
@@ -8595,7 +8595,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_IInspectableImpl : IAsyncOperati
     typealias TResult = Any?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -8732,7 +8732,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1_booleanBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1_boolean
     internal typealias SwiftABI = IAsyncOperationBool
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<Bool>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1_booleanImpl(abi)
     }
@@ -8747,7 +8747,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_booleanImpl : IAsyncOperation, A
     typealias TResult = Bool
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1_booleanBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -8884,7 +8884,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1_HSTRING
     internal typealias SwiftABI = IAsyncOperationString
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1_HSTRINGImpl(abi)
     }
@@ -8899,7 +8899,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_HSTRINGImpl : IAsyncOperation, A
     typealias TResult = String
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -9036,7 +9036,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1_UINT32Bridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1_UINT32
     internal typealias SwiftABI = IAsyncOperationUInt32
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UInt32>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1_UINT32Impl(abi)
     }
@@ -9051,7 +9051,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_UINT32Impl : IAsyncOperation, Ab
     typealias TResult = UInt32
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1_UINT32Bridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -9190,7 +9190,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspecta
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectable
     internal typealias SwiftABI = IAsyncOperationIMapString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<WindowsFoundation.AnyIMap<String, Any?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectableImpl(abi)
     }
@@ -9205,7 +9205,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInsp
     typealias TResult = WindowsFoundation.AnyIMap<String, Any?>?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIMap_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -9344,7 +9344,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_C__F__CIPropertySetBridge : 
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__F__CIPropertySet
     internal typealias SwiftABI = IAsyncOperationIPropertySet
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<WindowsFoundation.AnyIPropertySet?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_C__F__CIPropertySetImpl(abi)
     }
@@ -9359,7 +9359,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__F__CIPropertySetImpl 
     typealias TResult = WindowsFoundation.AnyIPropertySet?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__F__CIPropertySetBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -9498,7 +9498,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CW
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItem
     internal typealias SwiftABI = IAsyncOperationIVectorViewIStorageItem
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<WindowsFoundation.AnyIVectorView<UWP.AnyIStorageItem?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemImpl(abi)
     }
@@ -9513,7 +9513,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
     typealias TResult = WindowsFoundation.AnyIVectorView<UWP.AnyIStorageItem?>?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CIStorageItemBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -9652,7 +9652,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CW
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFile
     internal typealias SwiftABI = IAsyncOperationIVectorViewStorageFile
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<WindowsFoundation.AnyIVectorView<UWP.StorageFile?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileImpl(abi)
     }
@@ -9667,7 +9667,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
     typealias TResult = WindowsFoundation.AnyIVectorView<UWP.StorageFile?>?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFileBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -9806,7 +9806,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CW
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolder
     internal typealias SwiftABI = IAsyncOperationIVectorViewStorageFolder
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<WindowsFoundation.AnyIVectorView<UWP.StorageFolder?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderImpl(abi)
     }
@@ -9821,7 +9821,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
     typealias TResult = WindowsFoundation.AnyIVectorView<UWP.StorageFolder?>?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageFolderBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -9960,7 +9960,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CW
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChange
     internal typealias SwiftABI = IAsyncOperationIVectorViewStorageLibraryChange
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<WindowsFoundation.AnyIVectorView<UWP.StorageLibraryChange?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeImpl(abi)
     }
@@ -9975,7 +9975,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
     typealias TResult = WindowsFoundation.AnyIVectorView<UWP.StorageLibraryChange?>?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CStorage__CStorageLibraryChangeBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -10114,7 +10114,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CW
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUser
     internal typealias SwiftABI = IAsyncOperationIVectorViewUser
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<WindowsFoundation.AnyIVectorView<UWP.User?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUserImpl(abi)
     }
@@ -10129,7 +10129,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_AB
     typealias TResult = WindowsFoundation.AnyIVectorView<UWP.User?>?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CSystem__CUserBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -10268,7 +10268,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGBridge 
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRING
     internal typealias SwiftABI = IAsyncOperationIVectorString
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<WindowsFoundation.AnyIVector<String>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGImpl(abi)
     }
@@ -10283,7 +10283,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGImp
     typealias TResult = WindowsFoundation.AnyIVector<String>?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_C__FIVector_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -10421,7 +10421,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePro
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicProperties
     internal typealias SwiftABI = IAsyncOperationBasicProperties
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.BasicProperties?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesImpl(abi)
     }
@@ -10436,7 +10436,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     typealias TResult = UWP.BasicProperties?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CBasicPropertiesBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -10574,7 +10574,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePro
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentProperties
     internal typealias SwiftABI = IAsyncOperationDocumentProperties
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.DocumentProperties?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesImpl(abi)
     }
@@ -10589,7 +10589,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     typealias TResult = UWP.DocumentProperties?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CDocumentPropertiesBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -10727,7 +10727,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePro
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImageProperties
     internal typealias SwiftABI = IAsyncOperationImageProperties
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.ImageProperties?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesImpl(abi)
     }
@@ -10742,7 +10742,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     typealias TResult = UWP.ImageProperties?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CImagePropertiesBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -10880,7 +10880,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePro
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicProperties
     internal typealias SwiftABI = IAsyncOperationMusicProperties
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.MusicProperties?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesImpl(abi)
     }
@@ -10895,7 +10895,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     typealias TResult = UWP.MusicProperties?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CMusicPropertiesBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -11033,7 +11033,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePro
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnail
     internal typealias SwiftABI = IAsyncOperationStorageItemThumbnail
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.StorageItemThumbnail?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailImpl(abi)
     }
@@ -11048,7 +11048,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     typealias TResult = UWP.StorageItemThumbnail?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CStorageItemThumbnailBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -11186,7 +11186,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFilePro
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoProperties
     internal typealias SwiftABI = IAsyncOperationVideoProperties
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.VideoProperties?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesImpl(abi)
     }
@@ -11201,7 +11201,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFil
     typealias TResult = UWP.VideoProperties?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CFileProperties__CVideoPropertiesBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -11340,7 +11340,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorag
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItem
     internal typealias SwiftABI = IAsyncOperationIStorageItem
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.AnyIStorageItem?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItemImpl(abi)
     }
@@ -11355,7 +11355,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CISt
     typealias TResult = UWP.AnyIStorageItem?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CIStorageItemBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -11492,7 +11492,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch_
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedState
     internal typealias SwiftABI = IAsyncOperationIndexedState
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.IndexedState>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateImpl(abi)
     }
@@ -11507,7 +11507,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSea
     typealias TResult = UWP.IndexedState
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSearch__CIndexedStateBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -11645,7 +11645,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorage
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFile
     internal typealias SwiftABI = IAsyncOperationStorageFile
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.StorageFile?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileImpl(abi)
     }
@@ -11660,7 +11660,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
     typealias TResult = UWP.StorageFile?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFileBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -11798,7 +11798,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorage
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolder
     internal typealias SwiftABI = IAsyncOperationStorageFolder
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.StorageFolder?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderImpl(abi)
     }
@@ -11813,7 +11813,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
     typealias TResult = UWP.StorageFolder?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageFolderBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -11951,7 +11951,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorage
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransaction
     internal typealias SwiftABI = IAsyncOperationStorageStreamTransaction
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.StorageStreamTransaction?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionImpl(abi)
     }
@@ -11966,7 +11966,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CSto
     typealias TResult = UWP.StorageStreamTransaction?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStorageStreamTransactionBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -12105,7 +12105,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBuffer
     internal typealias SwiftABI = IAsyncOperationIBuffer
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.AnyIBuffer?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferImpl(abi)
     }
@@ -12120,7 +12120,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
     typealias TResult = UWP.AnyIBuffer?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIBufferBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -12259,7 +12259,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStream
     internal typealias SwiftABI = IAsyncOperationIInputStream
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.AnyIInputStream?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamImpl(abi)
     }
@@ -12274,7 +12274,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
     typealias TResult = UWP.AnyIInputStream?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIInputStreamBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -12413,7 +12413,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStream
     internal typealias SwiftABI = IAsyncOperationIRandomAccessStream
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.AnyIRandomAccessStream?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamImpl(abi)
     }
@@ -12428,7 +12428,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
     typealias TResult = UWP.AnyIRandomAccessStream?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -12567,7 +12567,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamReference
     internal typealias SwiftABI = IAsyncOperationIRandomAccessStreamReference
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.AnyIRandomAccessStreamReference?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamReferenceImpl(abi)
     }
@@ -12582,7 +12582,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
     typealias TResult = UWP.AnyIRandomAccessStreamReference?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamReferenceBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -12721,7 +12721,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentType
     internal typealias SwiftABI = IAsyncOperationIRandomAccessStreamWithContentType
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.AnyIRandomAccessStreamWithContentType?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeImpl(abi)
     }
@@ -12736,7 +12736,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStr
     typealias TResult = UWP.AnyIRandomAccessStreamWithContentType?
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CStorage__CStreams__CIRandomAccessStreamWithContentTypeBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -12873,7 +12873,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CSystem__CUserAgeC
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CSystem__CUserAgeConsentResult
     internal typealias SwiftABI = IAsyncOperationUserAgeConsentResult
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<UWP.UserAgeConsentResult>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CSystem__CUserAgeConsentResultImpl(abi)
     }
@@ -12888,7 +12888,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CSystem__CUser
     typealias TResult = UWP.UserAgeConsentResult
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1___x_ABI_CWindows__CSystem__CUserAgeConsentResultBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -12942,7 +12942,7 @@ internal enum __x_ABI_C__FIReference_1_doubleBridge: ReferenceBridge {
     typealias SwiftProjection = Double
     static var IID: WindowsFoundation.IID { IID___x_ABI_C__FIReference_1_double }
 
-    static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let val = abi else { return nil }
         var result: DOUBLE = 0.0
         try! CHECKED(val.get().pointee.lpVtbl.pointee.get_Value(val.get(), &result))
@@ -13037,7 +13037,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSea
     internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CStorage__CSearch__CIStorageQueryResultBase_IInspectable
     internal typealias SwiftABI = UWP.TypedEventHandlerIStorageQueryResultBase_Any
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
@@ -13090,7 +13090,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CSystem__CUser
     internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CSystem__CUserWatcher_IInspectable
     internal typealias SwiftABI = UWP.TypedEventHandlerUserWatcher_Any
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
@@ -13141,7 +13141,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CSystem__CUser
     internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CSystem__CUserWatcher___x_ABI_CWindows__CSystem__CUserAuthenticationStatusChangingEventArgs
     internal typealias SwiftABI = UWP.TypedEventHandlerUserWatcher_UserAuthenticationStatusChangingEventArgs
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
@@ -13192,7 +13192,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CSystem__CUser
     internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CSystem__CUserWatcher___x_ABI_CWindows__CSystem__CUserChangedEventArgs
     internal typealias SwiftABI = UWP.TypedEventHandlerUserWatcher_UserChangedEventArgs
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageFile.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageFile.swift
@@ -61,7 +61,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFile
         public typealias SwiftABI = __ABI_Windows_Storage.IStorageFile
         public typealias SwiftProjection = AnyIStorageFile
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageFileImpl(abi)
         }
@@ -76,7 +76,7 @@ extension __IMPL_Windows_Storage {
         fileprivate typealias Bridge = IStorageFileBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageFile2.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageFile2.swift
@@ -32,7 +32,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFile2
         public typealias SwiftABI = __ABI_Windows_Storage.IStorageFile2
         public typealias SwiftProjection = AnyIStorageFile2
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageFile2Impl(abi)
         }
@@ -47,7 +47,7 @@ extension __IMPL_Windows_Storage {
         fileprivate typealias Bridge = IStorageFile2Bridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageFilePropertiesWithAvailability.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageFilePropertiesWithAvailability.swift
@@ -30,7 +30,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFilePropertiesWithAvailability
         public typealias SwiftABI = __ABI_Windows_Storage.IStorageFilePropertiesWithAvailability
         public typealias SwiftProjection = AnyIStorageFilePropertiesWithAvailability
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageFilePropertiesWithAvailabilityImpl(abi)
         }
@@ -45,7 +45,7 @@ extension __IMPL_Windows_Storage {
         fileprivate typealias Bridge = IStorageFilePropertiesWithAvailabilityBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageFolder.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageFolder.swift
@@ -51,7 +51,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFolder
         public typealias SwiftABI = __ABI_Windows_Storage.IStorageFolder
         public typealias SwiftProjection = AnyIStorageFolder
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageFolderImpl(abi)
         }
@@ -66,7 +66,7 @@ extension __IMPL_Windows_Storage {
         fileprivate typealias Bridge = IStorageFolderBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageFolder2.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageFolder2.swift
@@ -30,7 +30,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFolder2
         public typealias SwiftABI = __ABI_Windows_Storage.IStorageFolder2
         public typealias SwiftProjection = AnyIStorageFolder2
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageFolder2Impl(abi)
         }
@@ -45,7 +45,7 @@ extension __IMPL_Windows_Storage {
         fileprivate typealias Bridge = IStorageFolder2Bridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageItem.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageItem.swift
@@ -48,7 +48,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageItem
         public typealias SwiftABI = __ABI_Windows_Storage.IStorageItem
         public typealias SwiftProjection = AnyIStorageItem
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageItemImpl(abi)
         }
@@ -63,7 +63,7 @@ extension __IMPL_Windows_Storage {
         fileprivate typealias Bridge = IStorageItemBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageItem2.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageItem2.swift
@@ -35,7 +35,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageItem2
         public typealias SwiftABI = __ABI_Windows_Storage.IStorageItem2
         public typealias SwiftProjection = AnyIStorageItem2
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageItem2Impl(abi)
         }
@@ -50,7 +50,7 @@ extension __IMPL_Windows_Storage {
         fileprivate typealias Bridge = IStorageItem2Bridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageItemProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageItemProperties.swift
@@ -42,7 +42,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageItemProperties
         public typealias SwiftABI = __ABI_Windows_Storage.IStorageItemProperties
         public typealias SwiftProjection = AnyIStorageItemProperties
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageItemPropertiesImpl(abi)
         }
@@ -57,7 +57,7 @@ extension __IMPL_Windows_Storage {
         fileprivate typealias Bridge = IStorageItemPropertiesBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageItemProperties2.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageItemProperties2.swift
@@ -37,7 +37,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageItemProperties2
         public typealias SwiftABI = __ABI_Windows_Storage.IStorageItemProperties2
         public typealias SwiftProjection = AnyIStorageItemProperties2
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageItemProperties2Impl(abi)
         }
@@ -52,7 +52,7 @@ extension __IMPL_Windows_Storage {
         fileprivate typealias Bridge = IStorageItemProperties2Bridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageItemPropertiesWithProvider.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageItemPropertiesWithProvider.swift
@@ -33,7 +33,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageItemPropertiesWithProvider
         public typealias SwiftABI = __ABI_Windows_Storage.IStorageItemPropertiesWithProvider
         public typealias SwiftProjection = AnyIStorageItemPropertiesWithProvider
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageItemPropertiesWithProviderImpl(abi)
         }
@@ -48,7 +48,7 @@ extension __IMPL_Windows_Storage {
         fileprivate typealias Bridge = IStorageItemPropertiesWithProviderBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStreamedFileDataRequest.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStreamedFileDataRequest.swift
@@ -30,7 +30,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStreamedFileDataRequest
         public typealias SwiftABI = __ABI_Windows_Storage.IStreamedFileDataRequest
         public typealias SwiftProjection = AnyIStreamedFileDataRequest
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStreamedFileDataRequestImpl(abi)
         }
@@ -45,7 +45,7 @@ extension __IMPL_Windows_Storage {
         fileprivate typealias Bridge = IStreamedFileDataRequestBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+StorageFile.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StorageFile.swift
@@ -292,7 +292,7 @@ extension __IMPL_Windows_Storage {
     public enum StorageFileBridge: AbiBridge {
         public typealias SwiftProjection = StorageFile
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFile
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageFile>?) -> StorageFile? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CIStorageFile>?) -> StorageFile? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage+StorageFolder.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StorageFolder.swift
@@ -325,7 +325,7 @@ extension __IMPL_Windows_Storage {
     public enum StorageFolderBridge: AbiBridge {
         public typealias SwiftProjection = StorageFolder
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageFolder
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageFolder>?) -> StorageFolder? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CIStorageFolder>?) -> StorageFolder? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage+StorageLibraryChange.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StorageLibraryChange.swift
@@ -59,7 +59,7 @@ extension __IMPL_Windows_Storage {
     public enum StorageLibraryChangeBridge: AbiBridge {
         public typealias SwiftProjection = StorageLibraryChange
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageLibraryChange
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChange>?) -> StorageLibraryChange? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChange>?) -> StorageLibraryChange? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage+StorageLibraryChangeReader.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StorageLibraryChangeReader.swift
@@ -51,7 +51,7 @@ extension __IMPL_Windows_Storage {
     public enum StorageLibraryChangeReaderBridge: AbiBridge {
         public typealias SwiftProjection = StorageLibraryChangeReader
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader>?) -> StorageLibraryChangeReader? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeReader>?) -> StorageLibraryChangeReader? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage+StorageLibraryChangeTracker.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StorageLibraryChangeTracker.swift
@@ -61,7 +61,7 @@ extension __IMPL_Windows_Storage {
     public enum StorageLibraryChangeTrackerBridge: AbiBridge {
         public typealias SwiftProjection = StorageLibraryChangeTracker
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker>?) -> StorageLibraryChangeTracker? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeTracker>?) -> StorageLibraryChangeTracker? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage+StorageLibraryChangeTrackerOptions.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StorageLibraryChangeTrackerOptions.swift
@@ -45,7 +45,7 @@ extension __IMPL_Windows_Storage {
     public enum StorageLibraryChangeTrackerOptionsBridge: AbiBridge {
         public typealias SwiftProjection = StorageLibraryChangeTrackerOptions
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageLibraryChangeTrackerOptions
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeTrackerOptions>?) -> StorageLibraryChangeTrackerOptions? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CIStorageLibraryChangeTrackerOptions>?) -> StorageLibraryChangeTrackerOptions? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage+StorageProvider.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StorageProvider.swift
@@ -51,7 +51,7 @@ extension __IMPL_Windows_Storage {
     public enum StorageProviderBridge: AbiBridge {
         public typealias SwiftProjection = StorageProvider
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageProvider
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageProvider>?) -> StorageProvider? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CIStorageProvider>?) -> StorageProvider? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage+StorageStreamTransaction.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StorageStreamTransaction.swift
@@ -54,7 +54,7 @@ extension __IMPL_Windows_Storage {
     public enum StorageStreamTransactionBridge: AbiBridge {
         public typealias SwiftProjection = StorageStreamTransaction
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStorageStreamTransaction
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CIStorageStreamTransaction>?) -> StorageStreamTransaction? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CIStorageStreamTransaction>?) -> StorageStreamTransaction? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage+StreamedFileDataRequest.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StreamedFileDataRequest.swift
@@ -61,7 +61,7 @@ extension __IMPL_Windows_Storage {
     public enum StreamedFileDataRequestBridge: AbiBridge {
         public typealias SwiftProjection = StreamedFileDataRequest
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIOutputStream
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIOutputStream>?) -> StreamedFileDataRequest? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIOutputStream>?) -> StreamedFileDataRequest? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage+StreamedFileDataRequestedHandler.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StreamedFileDataRequestedHandler.swift
@@ -15,7 +15,7 @@ extension __IMPL_Windows_Storage {
         public typealias CABI = __x_ABI_CWindows_CStorage_CIStreamedFileDataRequestedHandler
         public typealias SwiftABI = __ABI_Windows_Storage.StreamedFileDataRequestedHandler
 
-        public static func from(abi: ComPtr<CABI>?) -> Handler? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (stream) in

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+BasicProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+BasicProperties.swift
@@ -69,7 +69,7 @@ extension __IMPL_Windows_Storage_FileProperties {
     public enum BasicPropertiesBridge: AbiBridge {
         public typealias SwiftProjection = BasicProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties>?) -> BasicProperties? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIBasicProperties>?) -> BasicProperties? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+DocumentProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+DocumentProperties.swift
@@ -76,7 +76,7 @@ extension __IMPL_Windows_Storage_FileProperties {
     public enum DocumentPropertiesBridge: AbiBridge {
         public typealias SwiftProjection = DocumentProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties>?) -> DocumentProperties? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties>?) -> DocumentProperties? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+IStorageItemExtraProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+IStorageItemExtraProperties.swift
@@ -34,7 +34,7 @@ extension __IMPL_Windows_Storage_FileProperties {
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemExtraProperties
         public typealias SwiftABI = __ABI_Windows_Storage_FileProperties.IStorageItemExtraProperties
         public typealias SwiftProjection = AnyIStorageItemExtraProperties
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageItemExtraPropertiesImpl(abi)
         }
@@ -49,7 +49,7 @@ extension __IMPL_Windows_Storage_FileProperties {
         fileprivate typealias Bridge = IStorageItemExtraPropertiesBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+ImageProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+ImageProperties.swift
@@ -119,7 +119,7 @@ extension __IMPL_Windows_Storage_FileProperties {
     public enum ImagePropertiesBridge: AbiBridge {
         public typealias SwiftProjection = ImageProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties>?) -> ImageProperties? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties>?) -> ImageProperties? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+MusicProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+MusicProperties.swift
@@ -143,7 +143,7 @@ extension __IMPL_Windows_Storage_FileProperties {
     public enum MusicPropertiesBridge: AbiBridge {
         public typealias SwiftProjection = MusicProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties>?) -> MusicProperties? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties>?) -> MusicProperties? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+StorageItemContentProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+StorageItemContentProperties.swift
@@ -74,7 +74,7 @@ extension __IMPL_Windows_Storage_FileProperties {
     public enum StorageItemContentPropertiesBridge: AbiBridge {
         public typealias SwiftProjection = StorageItemContentProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties>?) -> StorageItemContentProperties? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIStorageItemContentProperties>?) -> StorageItemContentProperties? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+StorageItemThumbnail.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+StorageItemThumbnail.swift
@@ -135,7 +135,7 @@ extension __IMPL_Windows_Storage_FileProperties {
     public enum StorageItemThumbnailBridge: AbiBridge {
         public typealias SwiftProjection = StorageItemThumbnail
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamWithContentType
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamWithContentType>?) -> StorageItemThumbnail? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamWithContentType>?) -> StorageItemThumbnail? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+VideoProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+VideoProperties.swift
@@ -139,7 +139,7 @@ extension __IMPL_Windows_Storage_FileProperties {
     public enum VideoPropertiesBridge: AbiBridge {
         public typealias SwiftProjection = VideoProperties
         public typealias CABI = __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties>?) -> VideoProperties? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties>?) -> VideoProperties? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.Search+IStorageFolderQueryOperations.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Search+IStorageFolderQueryOperations.swift
@@ -62,7 +62,7 @@ extension __IMPL_Windows_Storage_Search {
         public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryOperations
         public typealias SwiftABI = __ABI_Windows_Storage_Search.IStorageFolderQueryOperations
         public typealias SwiftProjection = AnyIStorageFolderQueryOperations
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageFolderQueryOperationsImpl(abi)
         }
@@ -77,7 +77,7 @@ extension __IMPL_Windows_Storage_Search {
         fileprivate typealias Bridge = IStorageFolderQueryOperationsBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.Search+IStorageQueryResultBase.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Search+IStorageQueryResultBase.swift
@@ -42,7 +42,7 @@ extension __IMPL_Windows_Storage_Search {
         public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageQueryResultBase
         public typealias SwiftABI = __ABI_Windows_Storage_Search.IStorageQueryResultBase
         public typealias SwiftProjection = AnyIStorageQueryResultBase
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStorageQueryResultBaseImpl(abi)
         }
@@ -57,7 +57,7 @@ extension __IMPL_Windows_Storage_Search {
         fileprivate typealias Bridge = IStorageQueryResultBaseBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.Search+QueryOptions.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Search+QueryOptions.swift
@@ -125,7 +125,7 @@ extension __IMPL_Windows_Storage_Search {
     public enum QueryOptionsBridge: AbiBridge {
         public typealias SwiftProjection = QueryOptions
         public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIQueryOptions>?) -> QueryOptions? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIQueryOptions>?) -> QueryOptions? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.Search+StorageFileQueryResult.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Search+StorageFileQueryResult.swift
@@ -107,7 +107,7 @@ extension __IMPL_Windows_Storage_Search {
     public enum StorageFileQueryResultBridge: AbiBridge {
         public typealias SwiftProjection = StorageFileQueryResult
         public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult>?) -> StorageFileQueryResult? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageFileQueryResult>?) -> StorageFileQueryResult? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.Search+StorageFolderQueryResult.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Search+StorageFolderQueryResult.swift
@@ -100,7 +100,7 @@ extension __IMPL_Windows_Storage_Search {
     public enum StorageFolderQueryResultBridge: AbiBridge {
         public typealias SwiftProjection = StorageFolderQueryResult
         public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult>?) -> StorageFolderQueryResult? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageFolderQueryResult>?) -> StorageFolderQueryResult? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.Search+StorageItemQueryResult.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Search+StorageItemQueryResult.swift
@@ -100,7 +100,7 @@ extension __IMPL_Windows_Storage_Search {
     public enum StorageItemQueryResultBridge: AbiBridge {
         public typealias SwiftProjection = StorageItemQueryResult
         public typealias CABI = __x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult>?) -> StorageItemQueryResult? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CSearch_CIStorageItemQueryResult>?) -> StorageItemQueryResult? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.Streams+Buffer.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Streams+Buffer.swift
@@ -72,7 +72,7 @@ extension __IMPL_Windows_Storage_Streams {
     public enum BufferBridge: AbiBridge {
         public typealias SwiftProjection = Buffer
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIBuffer
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?) -> Buffer? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CStorage_CStreams_CIBuffer>?) -> Buffer? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.Storage.Streams+IBuffer.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Streams+IBuffer.swift
@@ -41,7 +41,7 @@ extension __IMPL_Windows_Storage_Streams {
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIBuffer
         public typealias SwiftABI = __ABI_Windows_Storage_Streams.IBuffer
         public typealias SwiftProjection = AnyIBuffer
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IBufferImpl(abi)
         }
@@ -56,7 +56,7 @@ extension __IMPL_Windows_Storage_Streams {
         fileprivate typealias Bridge = IBufferBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.Streams+IContentTypeProvider.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Streams+IContentTypeProvider.swift
@@ -30,7 +30,7 @@ extension __IMPL_Windows_Storage_Streams {
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIContentTypeProvider
         public typealias SwiftABI = __ABI_Windows_Storage_Streams.IContentTypeProvider
         public typealias SwiftProjection = AnyIContentTypeProvider
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IContentTypeProviderImpl(abi)
         }
@@ -45,7 +45,7 @@ extension __IMPL_Windows_Storage_Streams {
         fileprivate typealias Bridge = IContentTypeProviderBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.Streams+IInputStream.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Streams+IInputStream.swift
@@ -33,7 +33,7 @@ extension __IMPL_Windows_Storage_Streams {
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIInputStream
         public typealias SwiftABI = __ABI_Windows_Storage_Streams.IInputStream
         public typealias SwiftProjection = AnyIInputStream
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IInputStreamImpl(abi)
         }
@@ -48,7 +48,7 @@ extension __IMPL_Windows_Storage_Streams {
         fileprivate typealias Bridge = IInputStreamBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.Streams+IInputStreamReference.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Streams+IInputStreamReference.swift
@@ -30,7 +30,7 @@ extension __IMPL_Windows_Storage_Streams {
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIInputStreamReference
         public typealias SwiftABI = __ABI_Windows_Storage_Streams.IInputStreamReference
         public typealias SwiftProjection = AnyIInputStreamReference
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IInputStreamReferenceImpl(abi)
         }
@@ -45,7 +45,7 @@ extension __IMPL_Windows_Storage_Streams {
         fileprivate typealias Bridge = IInputStreamReferenceBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.Streams+IOutputStream.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Streams+IOutputStream.swift
@@ -35,7 +35,7 @@ extension __IMPL_Windows_Storage_Streams {
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIOutputStream
         public typealias SwiftABI = __ABI_Windows_Storage_Streams.IOutputStream
         public typealias SwiftProjection = AnyIOutputStream
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IOutputStreamImpl(abi)
         }
@@ -50,7 +50,7 @@ extension __IMPL_Windows_Storage_Streams {
         fileprivate typealias Bridge = IOutputStreamBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.Streams+IRandomAccessStream.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Streams+IRandomAccessStream.swift
@@ -53,7 +53,7 @@ extension __IMPL_Windows_Storage_Streams {
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStream
         public typealias SwiftABI = __ABI_Windows_Storage_Streams.IRandomAccessStream
         public typealias SwiftProjection = AnyIRandomAccessStream
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IRandomAccessStreamImpl(abi)
         }
@@ -68,7 +68,7 @@ extension __IMPL_Windows_Storage_Streams {
         fileprivate typealias Bridge = IRandomAccessStreamBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.Streams+IRandomAccessStreamReference.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Streams+IRandomAccessStreamReference.swift
@@ -30,7 +30,7 @@ extension __IMPL_Windows_Storage_Streams {
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamReference
         public typealias SwiftABI = __ABI_Windows_Storage_Streams.IRandomAccessStreamReference
         public typealias SwiftProjection = AnyIRandomAccessStreamReference
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IRandomAccessStreamReferenceImpl(abi)
         }
@@ -45,7 +45,7 @@ extension __IMPL_Windows_Storage_Streams {
         fileprivate typealias Bridge = IRandomAccessStreamReferenceBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.Streams+IRandomAccessStreamWithContentType.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Streams+IRandomAccessStreamWithContentType.swift
@@ -43,7 +43,7 @@ extension __IMPL_Windows_Storage_Streams {
         public typealias CABI = __x_ABI_CWindows_CStorage_CStreams_CIRandomAccessStreamWithContentType
         public typealias SwiftABI = __ABI_Windows_Storage_Streams.IRandomAccessStreamWithContentType
         public typealias SwiftProjection = AnyIRandomAccessStreamWithContentType
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IRandomAccessStreamWithContentTypeImpl(abi)
         }
@@ -58,7 +58,7 @@ extension __IMPL_Windows_Storage_Streams {
         fileprivate typealias Bridge = IRandomAccessStreamWithContentTypeBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.System+User.swift
+++ b/tests/test_component/Sources/UWP/Windows.System+User.swift
@@ -103,7 +103,7 @@ extension __IMPL_Windows_System {
     public enum UserBridge: AbiBridge {
         public typealias SwiftProjection = User
         public typealias CABI = __x_ABI_CWindows_CSystem_CIUser
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CSystem_CIUser>?) -> User? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CSystem_CIUser>?) -> User? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.System+UserAuthenticationStatusChangeDeferral.swift
+++ b/tests/test_component/Sources/UWP/Windows.System+UserAuthenticationStatusChangeDeferral.swift
@@ -39,7 +39,7 @@ extension __IMPL_Windows_System {
     public enum UserAuthenticationStatusChangeDeferralBridge: AbiBridge {
         public typealias SwiftProjection = UserAuthenticationStatusChangeDeferral
         public typealias CABI = __x_ABI_CWindows_CSystem_CIUserAuthenticationStatusChangeDeferral
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CSystem_CIUserAuthenticationStatusChangeDeferral>?) -> UserAuthenticationStatusChangeDeferral? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CSystem_CIUserAuthenticationStatusChangeDeferral>?) -> UserAuthenticationStatusChangeDeferral? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.System+UserAuthenticationStatusChangingEventArgs.swift
+++ b/tests/test_component/Sources/UWP/Windows.System+UserAuthenticationStatusChangingEventArgs.swift
@@ -54,7 +54,7 @@ extension __IMPL_Windows_System {
     public enum UserAuthenticationStatusChangingEventArgsBridge: AbiBridge {
         public typealias SwiftProjection = UserAuthenticationStatusChangingEventArgs
         public typealias CABI = __x_ABI_CWindows_CSystem_CIUserAuthenticationStatusChangingEventArgs
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CSystem_CIUserAuthenticationStatusChangingEventArgs>?) -> UserAuthenticationStatusChangingEventArgs? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CSystem_CIUserAuthenticationStatusChangingEventArgs>?) -> UserAuthenticationStatusChangingEventArgs? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.System+UserChangedEventArgs.swift
+++ b/tests/test_component/Sources/UWP/Windows.System+UserChangedEventArgs.swift
@@ -46,7 +46,7 @@ extension __IMPL_Windows_System {
     public enum UserChangedEventArgsBridge: AbiBridge {
         public typealias SwiftProjection = UserChangedEventArgs
         public typealias CABI = __x_ABI_CWindows_CSystem_CIUserChangedEventArgs
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CSystem_CIUserChangedEventArgs>?) -> UserChangedEventArgs? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CSystem_CIUserChangedEventArgs>?) -> UserChangedEventArgs? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/UWP/Windows.System+UserWatcher.swift
+++ b/tests/test_component/Sources/UWP/Windows.System+UserWatcher.swift
@@ -140,7 +140,7 @@ extension __IMPL_Windows_System {
     public enum UserWatcherBridge: AbiBridge {
         public typealias SwiftProjection = UserWatcher
         public typealias CABI = __x_ABI_CWindows_CSystem_CIUserWatcher
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CSystem_CIUserWatcher>?) -> UserWatcher? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CSystem_CIUserWatcher>?) -> UserWatcher? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/WindowsFoundation/Support/aggregation.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/aggregation.swift
@@ -105,7 +105,7 @@ public class UnsealedWinRTClassWrapper<Composable: ComposableImpl> : WinRTAbiBri
         super.init(abi, Composable.SwiftProjection(impl))
     }
 
-    public static func unwrapFrom(base: ComPtr<Composable.Default.CABI>) -> Composable.Class? {
+    public static func unwrapFrom(base: borrowing ComPtr<Composable.Default.CABI>) -> Composable.Class? {
         let overrides: Composable.SwiftABI = try! base.queryInterface()
         if let weakRef = tryUnwrapFrom(abi: RawPointer(overrides)) { return weakRef.instance }
         guard let instance = makeFrom(abi: overrides) else {
@@ -127,7 +127,7 @@ public class UnsealedWinRTClassWrapper<Composable: ComposableImpl> : WinRTAbiBri
 }
 
 public extension ComposableImpl {
-    static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         return nil
     }
 }

--- a/tests/test_component/Sources/WindowsFoundation/Support/comptr.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/comptr.swift
@@ -24,7 +24,7 @@ public class ComPtr<CInterface> {
         self.init(ptr)
     }
 
-    fileprivate init?(takingOwnership ptr: UnsafeMutablePointer<CInterface>?) {
+    init?(consuming ptr: UnsafeMutablePointer<CInterface>?) {
         guard let ptr else { return nil }
         self.pUnk = ptr
     }
@@ -81,13 +81,13 @@ public struct ComPtrs {
     public static func initialize<I>(to: I.Type, _ body: (inout UnsafeMutableRawPointer?) throws -> ()) rethrows -> (ComPtr<I>?) {
         var ptrRaw: UnsafeMutableRawPointer?
         try body(&ptrRaw)
-        return (ComPtr(takingOwnership: ptrRaw?.assumingMemoryBound(to: I.self)))
+        return (ComPtr(consuming: ptrRaw?.assumingMemoryBound(to: I.self)))
     }
 
     public static func initialize<I>(_ body: (inout UnsafeMutablePointer<I>?) throws -> ()) rethrows -> (ComPtr<I>?) {
         var ptr: UnsafeMutablePointer<I>?
         try body(&ptr)
-        return (ComPtr(takingOwnership: ptr))
+        return (ComPtr(consuming: ptr))
     }
 
 }

--- a/tests/test_component/Sources/WindowsFoundation/Support/ibufferbyteaccess.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/ibufferbyteaccess.swift
@@ -34,7 +34,7 @@ public enum IBufferByteAccessBridge: AbiInterfaceBridge {
         return CABI(lpVtbl: &IBufferByteAccessVTable)
     }
 
-    public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         // This code path is not actually reachable since IBufferByteAccess is not a WinRT interface.
         // It is a COM interface which is implemented by any object which implements the IBuffer interface.
         // And the IBufferImpl object will correctly have the implementation of this interface, so this isn't needed

--- a/tests/test_component/Sources/WindowsFoundation/Support/iinspectable.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/iinspectable.swift
@@ -66,7 +66,7 @@ public enum __ABI_ {
             return try super.toABI(body)
         }
       }
-      public static func unwrapFrom(abi: ComPtr<C_IInspectable>?) -> Any? {
+      public static func unwrapFrom(abi: consuming ComPtr<C_IInspectable>?) -> Any? {
         guard let abi = abi else { return nil }
         if let instance = tryUnwrapFrom(abi: abi) {
           if let weakRef = instance as? AnyObjectWrapper { return weakRef.obj }
@@ -151,7 +151,7 @@ public enum __IMPL_ {
             return .init(lpVtbl: vtblPtr)
         }
 
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi else { return nil }
             let ref = IInspectable(abi)
             return makeFrom(abi: ref) ?? ref

--- a/tests/test_component/Sources/WindowsFoundation/Support/imemorybufferbyteaccess.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/imemorybufferbyteaccess.swift
@@ -39,7 +39,7 @@ public enum IMemoryBufferByteAccessBridge: AbiInterfaceBridge {
         return CABI(lpVtbl: &IMemoryBufferByteAccessVTable)
     }
 
-    public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         // This code path is not actually reachable since IMemoryBufferByteAccess is not a WinRT interface.
         // It is a COM interface which is implemented by any object which implements the IMemoryBufferReference interface.
         // And the IMemoryBufferReferenceImpl object will correctly have the implementation of this interface, so this isn't needed

--- a/tests/test_component/Sources/WindowsFoundation/Support/iunknown.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/iunknown.swift
@@ -11,7 +11,7 @@ open class IUnknown : HasIID {
 
   open class var IID: WindowsFoundation.IID { IID_IUnknown }
 
-  public required init<CInterface>(_ pointer: ComPtr<CInterface>) {
+  public required init<CInterface>(_ pointer: consuming ComPtr<CInterface>) {
     self.pUnk = .init(pointer)
   }
 

--- a/tests/test_component/Sources/WindowsFoundation/Support/iunknownref.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/iunknownref.swift
@@ -5,10 +5,9 @@
 public final class IUnknownRef {
   private var pUnk: ComPtr<C_IUnknown>
 
-  init<C_Interface>(_ pUnk: ComPtr<C_Interface>) {
-    let pointer: UnsafeMutablePointer<C_IUnknown> =
-        UnsafeMutableRawPointer(pUnk.get()).bindMemory(to: C_IUnknown.self, capacity: 1)
-    self.pUnk = .init(pointer)
+  init<C_Interface>(_ pUnk: consuming ComPtr<C_Interface>) {
+    let raw = pUnk.detach()
+    self.pUnk = ComPtr(consuming: raw?.assumingMemoryBound(to: C_IUnknown.self))!
   }
 
   func detach() -> UnsafeMutableRawPointer? {

--- a/tests/test_component/Sources/WindowsFoundation/Support/iweakreference.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/iweakreference.swift
@@ -50,7 +50,7 @@ fileprivate enum IWeakReferenceBridge: AbiBridge {
         return C_IWeakReference(lpVtbl: &IWeakReferenceVTable)
     }
 
-    static func from(abi: ComPtr<C_IWeakReference>?) -> WeakReference? {
+    static func from(abi: consuming ComPtr<C_IWeakReference>?) -> WeakReference? {
         fatalError("Not needed")
     }
 }

--- a/tests/test_component/Sources/WindowsFoundation/Support/iweakreferencesource.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/iweakreferencesource.swift
@@ -43,7 +43,7 @@ fileprivate enum IWeakReferenceSourceBridge: AbiBridge {
         return C_IWeakReferenceSource(lpVtbl: &IWeakReferenceSourceVTable)
     }
 
-    static func from(abi: ComPtr<C_IWeakReferenceSource>?) -> AnyObject? {
+    static func from(abi: consuming ComPtr<C_IWeakReferenceSource>?) -> AnyObject? {
         fatalError("Not needed")
     }
 }

--- a/tests/test_component/Sources/WindowsFoundation/Support/marshaler.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/marshaler.swift
@@ -28,7 +28,7 @@ fileprivate enum IMarshalBridge: AbiBridge {
         return C_IMarshal(lpVtbl: &IMarshalVTable)
     }
 
-    static func from(abi: ComPtr<C_IMarshal>?) -> Marshaler? {
+    static func from(abi: consuming ComPtr<C_IMarshal>?) -> Marshaler? {
         guard let abi = abi else { return nil }
         return try? Marshaler(IUnknownRef(abi))
     }

--- a/tests/test_component/Sources/WindowsFoundation/Support/winrtwrapperbase.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/winrtwrapperbase.swift
@@ -21,7 +21,7 @@ public protocol AbiInterface {
 public protocol AbiBridge {
     associatedtype CABI
     associatedtype SwiftProjection
-    static func from(abi: ComPtr<CABI>?) -> SwiftProjection?
+    static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection?
 }
 
 public protocol SwiftImplementableBridge : AbiBridge {
@@ -178,7 +178,7 @@ open class WinRTWrapperBase<CInterface, Prototype> {
 
 open class WinRTAbiBridgeWrapper<I: AbiBridge> : WinRTWrapperBase<I.CABI, I.SwiftProjection> {
 
-    public static func unwrapFrom(abi pointer: ComPtr<I.CABI>?) -> I.SwiftProjection? {
+    public static func unwrapFrom(abi pointer: consuming ComPtr<I.CABI>?) -> I.SwiftProjection? {
         guard let pointer = pointer else { return nil }
         guard let unwrapped = tryUnwrapFrom(abi: pointer) else { return I.from(abi: pointer) }
         return unwrapped

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+AsyncActionCompletedHandler.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+AsyncActionCompletedHandler.swift
@@ -14,7 +14,7 @@ extension __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIAsyncActionCompletedHandler
         public typealias SwiftABI = __ABI_Windows_Foundation.AsyncActionCompletedHandler
 
-        public static func from(abi: ComPtr<CABI>?) -> Handler? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (asyncInfo, asyncStatus) in

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+Deferral.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+Deferral.swift
@@ -53,7 +53,7 @@ extension __IMPL_Windows_Foundation {
     public enum DeferralBridge: AbiBridge {
         public typealias SwiftProjection = Deferral
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIDeferral
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIDeferral>?) -> Deferral? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CFoundation_CIDeferral>?) -> Deferral? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+DeferralCompletedHandler.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+DeferralCompletedHandler.swift
@@ -14,7 +14,7 @@ extension __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIDeferralCompletedHandler
         public typealias SwiftABI = __ABI_Windows_Foundation.DeferralCompletedHandler
 
-        public static func from(abi: ComPtr<CABI>?) -> Handler? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IAsyncAction.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IAsyncAction.swift
@@ -47,7 +47,7 @@ extension __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIAsyncAction
         public typealias SwiftABI = __ABI_Windows_Foundation.IAsyncAction
         public typealias SwiftProjection = AnyIAsyncAction
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IAsyncActionImpl(abi)
         }
@@ -62,7 +62,7 @@ extension __IMPL_Windows_Foundation {
         fileprivate typealias Bridge = IAsyncActionBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IAsyncInfo.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IAsyncInfo.swift
@@ -37,7 +37,7 @@ extension __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIAsyncInfo
         public typealias SwiftABI = __ABI_Windows_Foundation.IAsyncInfo
         public typealias SwiftProjection = AnyIAsyncInfo
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IAsyncInfoImpl(abi)
         }
@@ -52,7 +52,7 @@ extension __IMPL_Windows_Foundation {
         fileprivate typealias Bridge = IAsyncInfoBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IClosable.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IClosable.swift
@@ -29,7 +29,7 @@ extension __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIClosable
         public typealias SwiftABI = __ABI_Windows_Foundation.IClosable
         public typealias SwiftProjection = AnyIClosable
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IClosableImpl(abi)
         }
@@ -44,7 +44,7 @@ extension __IMPL_Windows_Foundation {
         fileprivate typealias Bridge = IClosableBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IMemoryBuffer.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IMemoryBuffer.swift
@@ -32,7 +32,7 @@ extension __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIMemoryBuffer
         public typealias SwiftABI = __ABI_Windows_Foundation.IMemoryBuffer
         public typealias SwiftProjection = AnyIMemoryBuffer
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IMemoryBufferImpl(abi)
         }
@@ -47,7 +47,7 @@ extension __IMPL_Windows_Foundation {
         fileprivate typealias Bridge = IMemoryBufferBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IMemoryBufferReference.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IMemoryBufferReference.swift
@@ -43,7 +43,7 @@ extension __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIMemoryBufferReference
         public typealias SwiftABI = __ABI_Windows_Foundation.IMemoryBufferReference
         public typealias SwiftProjection = AnyIMemoryBufferReference
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IMemoryBufferReferenceImpl(abi)
         }
@@ -58,7 +58,7 @@ extension __IMPL_Windows_Foundation {
         fileprivate typealias Bridge = IMemoryBufferReferenceBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IPropertyValue.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IPropertyValue.swift
@@ -95,7 +95,7 @@ extension __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIPropertyValue
         public typealias SwiftABI = __ABI_Windows_Foundation.IPropertyValue
         public typealias SwiftProjection = AnyIPropertyValue
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IPropertyValueImpl(abi)
         }
@@ -111,7 +111,7 @@ extension __IMPL_Windows_Foundation {
         var _value: Any
         var propertyType : PropertyType
 
-        fileprivate init(_ abi: ComPtr<__x_ABI_CWindows_CFoundation_CIPropertyValue>) { fatalError("not implemented") }
+        fileprivate init(_ abi: consuming ComPtr<__x_ABI_CWindows_CFoundation_CIPropertyValue>) { fatalError("not implemented") }
         public init(value: Any) {
             _value = value
             propertyType = switch value {

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IStringable.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IStringable.swift
@@ -29,7 +29,7 @@ extension __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIStringable
         public typealias SwiftABI = __ABI_Windows_Foundation.IStringable
         public typealias SwiftProjection = AnyIStringable
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IStringableImpl(abi)
         }
@@ -44,7 +44,7 @@ extension __IMPL_Windows_Foundation {
         fileprivate typealias Bridge = IStringableBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IWwwFormUrlDecoderEntry.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IWwwFormUrlDecoderEntry.swift
@@ -31,7 +31,7 @@ extension __IMPL_Windows_Foundation {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderEntry
         public typealias SwiftABI = __ABI_Windows_Foundation.IWwwFormUrlDecoderEntry
         public typealias SwiftProjection = AnyIWwwFormUrlDecoderEntry
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IWwwFormUrlDecoderEntryImpl(abi)
         }
@@ -46,7 +46,7 @@ extension __IMPL_Windows_Foundation {
         fileprivate typealias Bridge = IWwwFormUrlDecoderEntryBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+MemoryBuffer.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+MemoryBuffer.swift
@@ -53,7 +53,7 @@ extension __IMPL_Windows_Foundation {
     public enum MemoryBufferBridge: AbiBridge {
         public typealias SwiftProjection = MemoryBuffer
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIMemoryBuffer
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIMemoryBuffer>?) -> MemoryBuffer? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CFoundation_CIMemoryBuffer>?) -> MemoryBuffer? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+Uri.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+Uri.swift
@@ -160,7 +160,7 @@ extension __IMPL_Windows_Foundation {
     public enum UriBridge: AbiBridge {
         public typealias SwiftProjection = Uri
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIUriRuntimeClass
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIUriRuntimeClass>?) -> Uri? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CFoundation_CIUriRuntimeClass>?) -> Uri? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+WwwFormUrlDecoder.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+WwwFormUrlDecoder.swift
@@ -98,7 +98,7 @@ extension __IMPL_Windows_Foundation {
     public enum WwwFormUrlDecoderBridge: AbiBridge {
         public typealias SwiftProjection = WwwFormUrlDecoder
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass>?) -> WwwFormUrlDecoder? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass>?) -> WwwFormUrlDecoder? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation.Collections+IPropertySet.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation.Collections+IPropertySet.swift
@@ -36,7 +36,7 @@ extension __IMPL_Windows_Foundation_Collections {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CCollections_CIPropertySet
         public typealias SwiftABI = __ABI_Windows_Foundation_Collections.IPropertySet
         public typealias SwiftProjection = AnyIPropertySet
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IPropertySetImpl(abi)
         }
@@ -51,7 +51,7 @@ extension __IMPL_Windows_Foundation_Collections {
         fileprivate typealias Bridge = IPropertySetBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation.Collections+IVectorChangedEventArgs.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation.Collections+IVectorChangedEventArgs.swift
@@ -31,7 +31,7 @@ extension __IMPL_Windows_Foundation_Collections {
         public typealias CABI = __x_ABI_CWindows_CFoundation_CCollections_CIVectorChangedEventArgs
         public typealias SwiftABI = __ABI_Windows_Foundation_Collections.IVectorChangedEventArgs
         public typealias SwiftProjection = AnyIVectorChangedEventArgs
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IVectorChangedEventArgsImpl(abi)
         }
@@ -46,7 +46,7 @@ extension __IMPL_Windows_Foundation_Collections {
         fileprivate typealias Bridge = IVectorChangedEventArgsBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation.Collections+PropertySet.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation.Collections+PropertySet.swift
@@ -103,7 +103,7 @@ extension __IMPL_Windows_Foundation_Collections {
     public enum PropertySetBridge: AbiBridge {
         public typealias SwiftProjection = PropertySet
         public typealias CABI = __x_ABI_CWindows_CFoundation_CCollections_CIPropertySet
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CCollections_CIPropertySet>?) -> PropertySet? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CFoundation_CCollections_CIPropertySet>?) -> PropertySet? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation.Collections+StringMap.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation.Collections+StringMap.swift
@@ -101,7 +101,7 @@ extension __IMPL_Windows_Foundation_Collections {
     public enum StringMapBridge: AbiBridge {
         public typealias SwiftProjection = StringMap
         public typealias CABI = __x_ABI_C__FIMap_2_HSTRING_HSTRING
-        public static func from(abi: ComPtr<__x_ABI_C__FIMap_2_HSTRING_HSTRING>?) -> StringMap? {
+        public static func from(abi: consuming ComPtr<__x_ABI_C__FIMap_2_HSTRING_HSTRING>?) -> StringMap? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation.Collections+ValueSet.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation.Collections+ValueSet.swift
@@ -103,7 +103,7 @@ extension __IMPL_Windows_Foundation_Collections {
     public enum ValueSetBridge: AbiBridge {
         public typealias SwiftProjection = ValueSet
         public typealias CABI = __x_ABI_CWindows_CFoundation_CCollections_CIPropertySet
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CCollections_CIPropertySet>?) -> ValueSet? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CFoundation_CCollections_CIPropertySet>?) -> ValueSet? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/WindowsFoundation/WindowsFoundation+Generics.swift
+++ b/tests/test_component/Sources/WindowsFoundation/WindowsFoundation+Generics.swift
@@ -62,7 +62,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspe
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable
     internal typealias SwiftABI = IIterableIKeyValuePairString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<WindowsFoundation.AnyIKeyValuePair<String, Any?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableImpl(abi)
     }
@@ -77,7 +77,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_II
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, Any?>?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -149,7 +149,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRIN
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
     internal typealias SwiftABI = IIterableIKeyValuePairString_String
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<WindowsFoundation.AnyIKeyValuePair<String, String>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGImpl(abi)
     }
@@ -164,7 +164,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HS
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, String>?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -236,7 +236,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUr
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry
     internal typealias SwiftABI = IIterableIWwwFormUrlDecoderEntry
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<WindowsFoundation.AnyIWwwFormUrlDecoderEntry?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryImpl(abi)
     }
@@ -251,7 +251,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFo
     typealias T = WindowsFoundation.AnyIWwwFormUrlDecoderEntry?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -373,7 +373,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspe
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable
     internal typealias SwiftABI = IIteratorIKeyValuePairString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<WindowsFoundation.AnyIKeyValuePair<String, Any?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableImpl(abi)
     }
@@ -388,7 +388,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_II
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, Any?>?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -525,7 +525,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRIN
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
     internal typealias SwiftABI = IIteratorIKeyValuePairString_String
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<WindowsFoundation.AnyIKeyValuePair<String, String>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGImpl(abi)
     }
@@ -540,7 +540,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HS
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, String>?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -677,7 +677,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUr
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry
     internal typealias SwiftABI = IIteratorIWwwFormUrlDecoderEntry
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<WindowsFoundation.AnyIWwwFormUrlDecoderEntry?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryImpl(abi)
     }
@@ -692,7 +692,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFo
     typealias T = WindowsFoundation.AnyIWwwFormUrlDecoderEntry?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -794,7 +794,7 @@ internal enum __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge : AbiInterf
     internal typealias CABI = __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable
     internal typealias SwiftABI = IKeyValuePairString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIKeyValuePair<String, Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableImpl(abi)
     }
@@ -810,7 +810,7 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableImpl : IKeyVal
     typealias V = Any?
     typealias Bridge = __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -900,7 +900,7 @@ internal enum __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge : AbiInterfaceBr
     internal typealias CABI = __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
     internal typealias SwiftABI = IKeyValuePairString_String
     internal typealias SwiftProjection = WindowsFoundation.AnyIKeyValuePair<String, String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGImpl(abi)
     }
@@ -916,7 +916,7 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGImpl : IKeyValuePai
     typealias V = String
     typealias Bridge = __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1006,7 +1006,7 @@ internal enum __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGBridge : AbiInterfaceBri
     internal typealias CABI = __x_ABI_C__FIMapChangedEventArgs_1_HSTRING
     internal typealias SwiftABI = IMapChangedEventArgsString
     internal typealias SwiftProjection = WindowsFoundation.AnyIMapChangedEventArgs<String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGImpl(abi)
     }
@@ -1021,7 +1021,7 @@ fileprivate class __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGImpl : IMapChangedEv
     typealias K = String
     typealias Bridge = __x_ABI_C__FIMapChangedEventArgs_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1155,7 +1155,7 @@ internal enum __x_ABI_C__FIMapView_2_HSTRING_IInspectableBridge : AbiInterfaceBr
     internal typealias CABI = __x_ABI_C__FIMapView_2_HSTRING_IInspectable
     internal typealias SwiftABI = IMapViewString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIMapView<String, Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMapView_2_HSTRING_IInspectableImpl(abi)
     }
@@ -1172,7 +1172,7 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING_IInspectableImpl : IMapView, Ab
     typealias V = Any?
     typealias Bridge = __x_ABI_C__FIMapView_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1320,7 +1320,7 @@ internal enum __x_ABI_C__FIMapView_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge 
     internal typealias CABI = __x_ABI_C__FIMapView_2_HSTRING_HSTRING
     internal typealias SwiftABI = IMapViewString_String
     internal typealias SwiftProjection = WindowsFoundation.AnyIMapView<String, String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMapView_2_HSTRING_HSTRINGImpl(abi)
     }
@@ -1337,7 +1337,7 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING_HSTRINGImpl : IMapView, AbiInte
     typealias V = String
     typealias Bridge = __x_ABI_C__FIMapView_2_HSTRING_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1528,7 +1528,7 @@ internal enum __x_ABI_C__FIMap_2_HSTRING_IInspectableBridge : AbiInterfaceBridge
     internal typealias CABI = __x_ABI_C__FIMap_2_HSTRING_IInspectable
     internal typealias SwiftABI = IMapString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIMap<String, Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMap_2_HSTRING_IInspectableImpl(abi)
     }
@@ -1545,7 +1545,7 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING_IInspectableImpl : IMap, AbiInterfa
     typealias V = Any?
     typealias Bridge = __x_ABI_C__FIMap_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1748,7 +1748,7 @@ internal enum __x_ABI_C__FIMap_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIMap_2_HSTRING_HSTRING
     internal typealias SwiftABI = IMapString_String
     internal typealias SwiftProjection = WindowsFoundation.AnyIMap<String, String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMap_2_HSTRING_HSTRINGImpl(abi)
     }
@@ -1765,7 +1765,7 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING_HSTRINGImpl : IMap, AbiInterfaceImp
     typealias V = String
     typealias Bridge = __x_ABI_C__FIMap_2_HSTRING_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1889,7 +1889,7 @@ internal enum __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableBridge : AbiInter
     internal typealias CABI = __x_ABI_C__FIObservableMap_2_HSTRING_IInspectable
     internal typealias SwiftABI = IObservableMapString_Any
     internal typealias SwiftProjection = WindowsFoundation.AnyIObservableMap<String, Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableImpl(abi)
     }
@@ -1906,7 +1906,7 @@ fileprivate class __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableImpl : IObser
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, Any?>?
     typealias Bridge = __x_ABI_C__FIObservableMap_2_HSTRING_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2044,7 +2044,7 @@ internal enum __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGBridge : AbiInterfaceB
     internal typealias CABI = __x_ABI_C__FIObservableMap_2_HSTRING_HSTRING
     internal typealias SwiftABI = IObservableMapString_String
     internal typealias SwiftProjection = WindowsFoundation.AnyIObservableMap<String, String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGImpl(abi)
     }
@@ -2061,7 +2061,7 @@ fileprivate class __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGImpl : IObservable
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, String>?
     typealias Bridge = __x_ABI_C__FIObservableMap_2_HSTRING_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2241,7 +2241,7 @@ internal enum __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwForm
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntry
     internal typealias SwiftABI = IVectorViewIWwwFormUrlDecoderEntry
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<WindowsFoundation.AnyIWwwFormUrlDecoderEntry?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryImpl(abi)
     }
@@ -2256,7 +2256,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWww
     typealias T = WindowsFoundation.AnyIWwwFormUrlDecoderEntry?
     typealias Bridge = __x_ABI_C__FIVectorView_1___x_ABI_CWindows__CFoundation__CIWwwFormUrlDecoderEntryBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2357,7 +2357,7 @@ internal class __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectableBridge :
     internal typealias CABI = __x_ABI_C__FMapChangedEventHandler_2_HSTRING_IInspectable
     internal typealias SwiftABI = WindowsFoundation.MapChangedEventHandlerString_Any
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
@@ -2412,7 +2412,7 @@ internal class __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRINGBridge : WinR
     internal typealias CABI = __x_ABI_C__FMapChangedEventHandler_2_HSTRING_HSTRING
     internal typealias SwiftABI = WindowsFoundation.MapChangedEventHandlerString_String
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
@@ -2467,7 +2467,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__C
     internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_CWindows__CFoundation__CIMemoryBufferReference_IInspectable
     internal typealias SwiftABI = WindowsFoundation.TypedEventHandlerIMemoryBufferReference_Any
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in

--- a/tests/test_component/Sources/test_component/test_component+ArrayMethodCallback.swift
+++ b/tests/test_component/Sources/test_component/test_component+ArrayMethodCallback.swift
@@ -15,7 +15,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIArrayMethodCallback
         public typealias SwiftABI = __ABI_test_component.ArrayMethodCallback
 
-        public static func from(abi: ComPtr<CABI>?) -> Handler? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (value) in

--- a/tests/test_component/Sources/test_component/test_component+AsyncOperationInt.swift
+++ b/tests/test_component/Sources/test_component/test_component+AsyncOperationInt.swift
@@ -78,7 +78,7 @@ extension __IMPL_test_component {
     public enum AsyncOperationIntBridge: AbiBridge {
         public typealias SwiftProjection = AsyncOperationInt
         public typealias CABI = __x_ABI_Ctest__component_CIAsyncOperationInt
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIAsyncOperationInt>?) -> AsyncOperationInt? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIAsyncOperationInt>?) -> AsyncOperationInt? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+Base.swift
+++ b/tests/test_component/Sources/test_component/test_component+Base.swift
@@ -73,7 +73,7 @@ extension __IMPL_test_component {
     public enum BaseBridge: ComposableBridge {
         public typealias SwiftProjection = Base
         public typealias CABI = __x_ABI_Ctest__component_CIBase
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIBase>?) -> Base? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIBase>?) -> Base? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }

--- a/tests/test_component/Sources/test_component/test_component+BaseCollection.swift
+++ b/tests/test_component/Sources/test_component/test_component+BaseCollection.swift
@@ -139,7 +139,7 @@ extension __IMPL_test_component {
     public enum BaseCollectionBridge: ComposableBridge {
         public typealias SwiftProjection = BaseCollection
         public typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase
-        public static func from(abi: ComPtr<__x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase>?) -> BaseCollection? {
+        public static func from(abi: consuming ComPtr<__x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase>?) -> BaseCollection? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }

--- a/tests/test_component/Sources/test_component/test_component+BaseMapCollection.swift
+++ b/tests/test_component/Sources/test_component/test_component+BaseMapCollection.swift
@@ -73,7 +73,7 @@ extension __IMPL_test_component {
     public enum BaseMapCollectionBridge: AbiBridge {
         public typealias SwiftProjection = BaseMapCollection
         public typealias CABI = __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
-        public static func from(abi: ComPtr<__x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase>?) -> BaseMapCollection? {
+        public static func from(abi: consuming ComPtr<__x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase>?) -> BaseMapCollection? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+BaseNoOverrides.swift
+++ b/tests/test_component/Sources/test_component/test_component+BaseNoOverrides.swift
@@ -58,7 +58,7 @@ extension __IMPL_test_component {
     public enum BaseNoOverridesBridge: ComposableBridge {
         public typealias SwiftProjection = BaseNoOverrides
         public typealias CABI = __x_ABI_Ctest__component_CIBaseNoOverrides
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIBaseNoOverrides>?) -> BaseNoOverrides? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIBaseNoOverrides>?) -> BaseNoOverrides? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }

--- a/tests/test_component/Sources/test_component/test_component+BaseObservableCollection.swift
+++ b/tests/test_component/Sources/test_component/test_component+BaseObservableCollection.swift
@@ -136,7 +136,7 @@ extension __IMPL_test_component {
     public enum BaseObservableCollectionBridge: AbiBridge {
         public typealias SwiftProjection = BaseObservableCollection
         public typealias CABI = __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase
-        public static func from(abi: ComPtr<__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase>?) -> BaseObservableCollection? {
+        public static func from(abi: consuming ComPtr<__x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase>?) -> BaseObservableCollection? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+Class.swift
+++ b/tests/test_component/Sources/test_component/test_component+Class.swift
@@ -251,7 +251,7 @@ extension __IMPL_test_component {
     public enum ClassBridge: AbiBridge {
         public typealias SwiftProjection = Class
         public typealias CABI = __x_ABI_Ctest__component_CIClass
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIClass>?) -> Class? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIClass>?) -> Class? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+CollectionTester.swift
+++ b/tests/test_component/Sources/test_component/test_component+CollectionTester.swift
@@ -72,7 +72,7 @@ extension __IMPL_test_component {
     public enum CollectionTesterBridge: AbiBridge {
         public typealias SwiftProjection = CollectionTester
         public typealias CABI = __x_ABI_Ctest__component_CICollectionTester
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CICollectionTester>?) -> CollectionTester? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CICollectionTester>?) -> CollectionTester? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+DeferrableEventArgs.swift
+++ b/tests/test_component/Sources/test_component/test_component+DeferrableEventArgs.swift
@@ -42,7 +42,7 @@ extension __IMPL_test_component {
     public enum DeferrableEventArgsBridge: AbiBridge {
         public typealias SwiftProjection = DeferrableEventArgs
         public typealias CABI = __x_ABI_Ctest__component_CIDeferrableEventArgs
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDeferrableEventArgs>?) -> DeferrableEventArgs? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIDeferrableEventArgs>?) -> DeferrableEventArgs? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+Derived.swift
+++ b/tests/test_component/Sources/test_component/test_component+Derived.swift
@@ -49,7 +49,7 @@ extension __IMPL_test_component {
     public enum DerivedBridge: AbiBridge {
         public typealias SwiftProjection = Derived
         public typealias CABI = __x_ABI_Ctest__component_CIDerived
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDerived>?) -> Derived? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIDerived>?) -> Derived? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+DerivedFromNoConstructor.swift
+++ b/tests/test_component/Sources/test_component/test_component+DerivedFromNoConstructor.swift
@@ -38,7 +38,7 @@ extension __IMPL_test_component {
     public enum DerivedFromNoConstructorBridge: AbiBridge {
         public typealias SwiftProjection = DerivedFromNoConstructor
         public typealias CABI = __x_ABI_Ctest__component_CIDerivedFromNoConstructor
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIDerivedFromNoConstructor>?) -> DerivedFromNoConstructor? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIDerivedFromNoConstructor>?) -> DerivedFromNoConstructor? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+EventTester.swift
+++ b/tests/test_component/Sources/test_component/test_component+EventTester.swift
@@ -55,7 +55,7 @@ extension __IMPL_test_component {
     public enum EventTesterBridge: AbiBridge {
         public typealias SwiftProjection = EventTester
         public typealias CABI = __x_ABI_Ctest__component_CIEventTester
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIEventTester>?) -> EventTester? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIEventTester>?) -> EventTester? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -49,7 +49,7 @@ internal class __x_ABI_C__FIAsyncOperationCompletedHandler_1_intBridge : WinRTDe
     internal typealias CABI = __x_ABI_C__FIAsyncOperationCompletedHandler_1_int
     internal typealias SwiftABI = test_component.AsyncOperationCompletedHandlerInt32
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -102,7 +102,7 @@ internal class __x_ABI_C__FIAsyncOperationProgressHandler_2_int_doubleBridge : W
     internal typealias CABI = __x_ABI_C__FIAsyncOperationProgressHandler_2_int_double
     internal typealias SwiftABI = test_component.AsyncOperationProgressHandlerInt32_Double
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, progressInfo) in
@@ -155,7 +155,7 @@ internal class __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_dou
     internal typealias CABI = __x_ABI_C__FIAsyncOperationWithProgressCompletedHandler_2_int_double
     internal typealias SwiftABI = test_component.AsyncOperationWithProgressCompletedHandlerInt32_Double
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (asyncInfo, asyncStatus) in
@@ -223,7 +223,7 @@ internal enum __x_ABI_C__FIIterable_1_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterable_1_IInspectable
     internal typealias SwiftABI = IIterableAny
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1_IInspectableImpl(abi)
     }
@@ -238,7 +238,7 @@ fileprivate class __x_ABI_C__FIIterable_1_IInspectableImpl : IIterable, AbiInter
     typealias T = Any?
     typealias Bridge = __x_ABI_C__FIIterable_1_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -310,7 +310,7 @@ internal enum __x_ABI_C__FIIterable_1_GUIDBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterable_1_GUID
     internal typealias SwiftABI = IIterableUUID
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<Foundation.UUID>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1_GUIDImpl(abi)
     }
@@ -325,7 +325,7 @@ fileprivate class __x_ABI_C__FIIterable_1_GUIDImpl : IIterable, AbiInterfaceImpl
     typealias T = Foundation.UUID
     typealias Bridge = __x_ABI_C__FIIterable_1_GUIDBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -397,7 +397,7 @@ internal enum __x_ABI_C__FIIterable_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterable_1_HSTRING
     internal typealias SwiftABI = IIterableString
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1_HSTRINGImpl(abi)
     }
@@ -412,7 +412,7 @@ fileprivate class __x_ABI_C__FIIterable_1_HSTRINGImpl : IIterable, AbiInterfaceI
     typealias T = String
     typealias Bridge = __x_ABI_C__FIIterable_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -484,7 +484,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRIN
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
     internal typealias SwiftABI = IIterableIKeyValuePairString_String
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<WindowsFoundation.AnyIKeyValuePair<String, String>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGImpl(abi)
     }
@@ -499,7 +499,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HS
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, String>?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -571,7 +571,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_AB
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IIterableIKeyValuePairString_Base
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<WindowsFoundation.AnyIKeyValuePair<String, Base?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseImpl(abi)
     }
@@ -586,7 +586,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, Base?>?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -658,7 +658,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseBridge : A
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IIterableBase
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<Base?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseImpl(abi)
     }
@@ -673,7 +673,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseImpl :
     typealias T = Base?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CBaseBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -745,7 +745,7 @@ internal enum __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicBridge :
     internal typealias CABI = __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = IIterableIBasic
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterable<AnyIBasic?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicImpl(abi)
     }
@@ -760,7 +760,7 @@ fileprivate class __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicImpl
     typealias T = AnyIBasic?
     typealias Bridge = __x_ABI_C__FIIterable_1___x_ABI_Ctest__zcomponent__CIBasicBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -882,7 +882,7 @@ internal enum __x_ABI_C__FIIterator_1_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterator_1_IInspectable
     internal typealias SwiftABI = IIteratorAny
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1_IInspectableImpl(abi)
     }
@@ -897,7 +897,7 @@ fileprivate class __x_ABI_C__FIIterator_1_IInspectableImpl : IIterator, AbiInter
     typealias T = Any?
     typealias Bridge = __x_ABI_C__FIIterator_1_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1034,7 +1034,7 @@ internal enum __x_ABI_C__FIIterator_1_GUIDBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterator_1_GUID
     internal typealias SwiftABI = IIteratorUUID
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<Foundation.UUID>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1_GUIDImpl(abi)
     }
@@ -1049,7 +1049,7 @@ fileprivate class __x_ABI_C__FIIterator_1_GUIDImpl : IIterator, AbiInterfaceImpl
     typealias T = Foundation.UUID
     typealias Bridge = __x_ABI_C__FIIterator_1_GUIDBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1186,7 +1186,7 @@ internal enum __x_ABI_C__FIIterator_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIIterator_1_HSTRING
     internal typealias SwiftABI = IIteratorString
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1_HSTRINGImpl(abi)
     }
@@ -1201,7 +1201,7 @@ fileprivate class __x_ABI_C__FIIterator_1_HSTRINGImpl : IIterator, AbiInterfaceI
     typealias T = String
     typealias Bridge = __x_ABI_C__FIIterator_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1338,7 +1338,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRIN
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
     internal typealias SwiftABI = IIteratorIKeyValuePairString_String
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<WindowsFoundation.AnyIKeyValuePair<String, String>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGImpl(abi)
     }
@@ -1353,7 +1353,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HS
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, String>?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1490,7 +1490,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_AB
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IIteratorIKeyValuePairString_Base
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<WindowsFoundation.AnyIKeyValuePair<String, Base?>?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseImpl(abi)
     }
@@ -1505,7 +1505,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___
     typealias T = WindowsFoundation.AnyIKeyValuePair<String, Base?>?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1641,7 +1641,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseBridge : A
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IIteratorBase
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<Base?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseImpl(abi)
     }
@@ -1656,7 +1656,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseImpl :
     typealias T = Base?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CBaseBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1793,7 +1793,7 @@ internal enum __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicBridge :
     internal typealias CABI = __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = IIteratorIBasic
     internal typealias SwiftProjection = WindowsFoundation.AnyIIterator<AnyIBasic?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicImpl(abi)
     }
@@ -1808,7 +1808,7 @@ fileprivate class __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicImpl
     typealias T = AnyIBasic?
     typealias Bridge = __x_ABI_C__FIIterator_1___x_ABI_Ctest__zcomponent__CIBasicBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -1908,7 +1908,7 @@ internal enum __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge : AbiInterfaceBr
     internal typealias CABI = __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING
     internal typealias SwiftABI = IKeyValuePairString_String
     internal typealias SwiftProjection = WindowsFoundation.AnyIKeyValuePair<String, String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGImpl(abi)
     }
@@ -1924,7 +1924,7 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGImpl : IKeyValuePai
     typealias V = String
     typealias Bridge = __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2015,7 +2015,7 @@ internal enum __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBa
     internal typealias CABI = __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IKeyValuePairString_Base
     internal typealias SwiftProjection = WindowsFoundation.AnyIKeyValuePair<String, Base?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseImpl(abi)
     }
@@ -2031,7 +2031,7 @@ fileprivate class __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent_
     typealias V = Base?
     typealias Bridge = __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2163,7 +2163,7 @@ internal enum __x_ABI_C__FIMapView_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge 
     internal typealias CABI = __x_ABI_C__FIMapView_2_HSTRING_HSTRING
     internal typealias SwiftABI = IMapViewString_String
     internal typealias SwiftProjection = WindowsFoundation.AnyIMapView<String, String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMapView_2_HSTRING_HSTRINGImpl(abi)
     }
@@ -2180,7 +2180,7 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING_HSTRINGImpl : IMapView, AbiInte
     typealias V = String
     typealias Bridge = __x_ABI_C__FIMapView_2_HSTRING_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2329,7 +2329,7 @@ internal enum __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBri
     internal typealias CABI = __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IMapViewString_Base
     internal typealias SwiftProjection = WindowsFoundation.AnyIMapView<String, Base?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseImpl(abi)
     }
@@ -2346,7 +2346,7 @@ fileprivate class __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBas
     typealias V = Base?
     typealias Bridge = __x_ABI_C__FIMapView_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2534,7 +2534,7 @@ internal enum __x_ABI_C__FIMap_2_HSTRING_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIMap_2_HSTRING_HSTRING
     internal typealias SwiftABI = IMapString_String
     internal typealias SwiftProjection = WindowsFoundation.AnyIMap<String, String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMap_2_HSTRING_HSTRINGImpl(abi)
     }
@@ -2551,7 +2551,7 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING_HSTRINGImpl : IMap, AbiInterfaceImp
     typealias V = String
     typealias Bridge = __x_ABI_C__FIMap_2_HSTRING_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2754,7 +2754,7 @@ internal enum __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge 
     internal typealias CABI = __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IMapString_Base
     internal typealias SwiftProjection = WindowsFoundation.AnyIMap<String, Base?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseImpl(abi)
     }
@@ -2771,7 +2771,7 @@ fileprivate class __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseImp
     typealias V = Base?
     typealias Bridge = __x_ABI_C__FIMap_2_HSTRING___x_ABI_Ctest__zcomponent__CBaseBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -2895,7 +2895,7 @@ internal enum __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseBr
     internal typealias CABI = __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IObservableVectorBase
     internal typealias SwiftProjection = WindowsFoundation.AnyIObservableVector<Base?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseImpl(abi)
     }
@@ -2910,7 +2910,7 @@ fileprivate class __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBa
     typealias T = Base?
     typealias Bridge = __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CBaseBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -3103,7 +3103,7 @@ internal enum __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias CABI = __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = IObservableVectorIBasic
     internal typealias SwiftProjection = WindowsFoundation.AnyIObservableVector<AnyIBasic?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicImpl(abi)
     }
@@ -3118,7 +3118,7 @@ fileprivate class __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIB
     typealias T = AnyIBasic?
     typealias Bridge = __x_ABI_C__FIObservableVector_1___x_ABI_Ctest__zcomponent__CIBasicBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -3353,7 +3353,7 @@ internal enum __x_ABI_C__FIVectorView_1_IInspectableBridge : AbiInterfaceBridge 
     internal typealias CABI = __x_ABI_C__FIVectorView_1_IInspectable
     internal typealias SwiftABI = IVectorViewAny
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1_IInspectableImpl(abi)
     }
@@ -3368,7 +3368,7 @@ fileprivate class __x_ABI_C__FIVectorView_1_IInspectableImpl : IVectorView, AbiI
     typealias T = Any?
     typealias Bridge = __x_ABI_C__FIVectorView_1_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -3538,7 +3538,7 @@ internal enum __x_ABI_C__FIVectorView_1_GUIDBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVectorView_1_GUID
     internal typealias SwiftABI = IVectorViewUUID
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<Foundation.UUID>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1_GUIDImpl(abi)
     }
@@ -3553,7 +3553,7 @@ fileprivate class __x_ABI_C__FIVectorView_1_GUIDImpl : IVectorView, AbiInterface
     typealias T = Foundation.UUID
     typealias Bridge = __x_ABI_C__FIVectorView_1_GUIDBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -3724,7 +3724,7 @@ internal enum __x_ABI_C__FIVectorView_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVectorView_1_HSTRING
     internal typealias SwiftABI = IVectorViewString
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1_HSTRINGImpl(abi)
     }
@@ -3739,7 +3739,7 @@ fileprivate class __x_ABI_C__FIVectorView_1_HSTRINGImpl : IVectorView, AbiInterf
     typealias T = String
     typealias Bridge = __x_ABI_C__FIVectorView_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -3908,7 +3908,7 @@ internal enum __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseBridge :
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IVectorViewBase
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<Base?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseImpl(abi)
     }
@@ -3923,7 +3923,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseImpl
     typealias T = Base?
     typealias Bridge = __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CBaseBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -4095,7 +4095,7 @@ internal enum __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicBridge
     internal typealias CABI = __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = IVectorViewIBasic
     internal typealias SwiftProjection = WindowsFoundation.AnyIVectorView<AnyIBasic?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicImpl(abi)
     }
@@ -4110,7 +4110,7 @@ fileprivate class __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicIm
     typealias T = AnyIBasic?
     typealias Bridge = __x_ABI_C__FIVectorView_1___x_ABI_Ctest__zcomponent__CIBasicBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -4398,7 +4398,7 @@ internal enum __x_ABI_C__FIVector_1_IInspectableBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVector_1_IInspectable
     internal typealias SwiftABI = IVectorAny
     internal typealias SwiftProjection = WindowsFoundation.AnyIVector<Any?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVector_1_IInspectableImpl(abi)
     }
@@ -4413,7 +4413,7 @@ fileprivate class __x_ABI_C__FIVector_1_IInspectableImpl : IVector, AbiInterface
     typealias T = Any?
     typealias Bridge = __x_ABI_C__FIVector_1_IInspectableBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -4742,7 +4742,7 @@ internal enum __x_ABI_C__FIVector_1_GUIDBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVector_1_GUID
     internal typealias SwiftABI = IVectorUUID
     internal typealias SwiftProjection = WindowsFoundation.AnyIVector<Foundation.UUID>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVector_1_GUIDImpl(abi)
     }
@@ -4757,7 +4757,7 @@ fileprivate class __x_ABI_C__FIVector_1_GUIDImpl : IVector, AbiInterfaceImpl {
     typealias T = Foundation.UUID
     typealias Bridge = __x_ABI_C__FIVector_1_GUIDBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -5090,7 +5090,7 @@ internal enum __x_ABI_C__FIVector_1_HSTRINGBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIVector_1_HSTRING
     internal typealias SwiftABI = IVectorString
     internal typealias SwiftProjection = WindowsFoundation.AnyIVector<String>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVector_1_HSTRINGImpl(abi)
     }
@@ -5105,7 +5105,7 @@ fileprivate class __x_ABI_C__FIVector_1_HSTRINGImpl : IVector, AbiInterfaceImpl 
     typealias T = String
     typealias Bridge = __x_ABI_C__FIVector_1_HSTRINGBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -5433,7 +5433,7 @@ internal enum __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseBridge : Abi
     internal typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = IVectorBase
     internal typealias SwiftProjection = WindowsFoundation.AnyIVector<Base?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseImpl(abi)
     }
@@ -5448,7 +5448,7 @@ fileprivate class __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseImpl : I
     typealias T = Base?
     typealias Bridge = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CBaseBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -5785,7 +5785,7 @@ internal enum __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicBridge : A
     internal typealias CABI = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = IVectorIBasic
     internal typealias SwiftProjection = WindowsFoundation.AnyIVector<AnyIBasic?>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicImpl(abi)
     }
@@ -5800,7 +5800,7 @@ fileprivate class __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicImpl :
     typealias T = AnyIBasic?
     typealias Bridge = __x_ABI_C__FIVector_1___x_ABI_Ctest__zcomponent__CIBasicBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -5950,7 +5950,7 @@ internal class __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent
     internal typealias CABI = __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CBase
     internal typealias SwiftABI = test_component.VectorChangedEventHandlerBase
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
@@ -6005,7 +6005,7 @@ internal class __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent
     internal typealias CABI = __x_ABI_C__FVectorChangedEventHandler_1___x_ABI_Ctest__zcomponent__CIBasic
     internal typealias SwiftABI = test_component.VectorChangedEventHandlerIBasic
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, event) in
@@ -6060,7 +6060,7 @@ internal class __x_ABI_C__FIEventHandler_1_IInspectableBridge : WinRTDelegateBri
     internal typealias CABI = __x_ABI_C__FIEventHandler_1_IInspectable
     internal typealias SwiftABI = test_component.EventHandlerAny
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
@@ -6193,7 +6193,7 @@ internal enum __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleBridge : AbiIn
     internal typealias CABI = __x_ABI_C__FIAsyncOperationWithProgress_2_int_double
     internal typealias SwiftABI = IAsyncOperationWithProgressInt32_Double
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperationWithProgress<Int32, Double>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleImpl(abi)
     }
@@ -6209,7 +6209,7 @@ fileprivate class __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleImpl : IAs
     typealias TProgress = Double
     typealias Bridge = __x_ABI_C__FIAsyncOperationWithProgress_2_int_doubleBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -6352,7 +6352,7 @@ internal enum __x_ABI_C__FIAsyncOperation_1_intBridge : AbiInterfaceBridge {
     internal typealias CABI = __x_ABI_C__FIAsyncOperation_1_int
     internal typealias SwiftABI = IAsyncOperationInt32
     internal typealias SwiftProjection = WindowsFoundation.AnyIAsyncOperation<Int32>
-    internal static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let abi = abi else { return nil }
         return __x_ABI_C__FIAsyncOperation_1_intImpl(abi)
     }
@@ -6367,7 +6367,7 @@ fileprivate class __x_ABI_C__FIAsyncOperation_1_intImpl : IAsyncOperation, AbiIn
     typealias TResult = Int32
     typealias Bridge = __x_ABI_C__FIAsyncOperation_1_intBridge
     let _default: Bridge.SwiftABI
-    init(_ fromAbi: ComPtr<Bridge.CABI>) {
+    init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
         _default = Bridge.SwiftABI(fromAbi)
     }
 
@@ -6421,7 +6421,7 @@ internal enum __x_ABI_C__FIReference_1_GUIDBridge: ReferenceBridge {
     typealias SwiftProjection = Foundation.UUID
     static var IID: WindowsFoundation.IID { IID___x_ABI_C__FIReference_1_GUID }
 
-    static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let val = abi else { return nil }
         var result: WindowsFoundation.GUID = .init()
         try! CHECKED(val.get().pointee.lpVtbl.pointee.get_Value(val.get(), &result))
@@ -6479,7 +6479,7 @@ internal enum __x_ABI_C__FIReference_1_intBridge: ReferenceBridge {
     typealias SwiftProjection = Int32
     static var IID: WindowsFoundation.IID { IID___x_ABI_C__FIReference_1_int }
 
-    static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let val = abi else { return nil }
         var result: INT32 = 0
         try! CHECKED(val.get().pointee.lpVtbl.pointee.get_Value(val.get(), &result))
@@ -6537,7 +6537,7 @@ internal enum __x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSignedBridge:
     typealias SwiftProjection = test_component.Signed
     static var IID: WindowsFoundation.IID { IID___x_ABI_C__FIReference_1___x_ABI_Ctest__zcomponent__CSigned }
 
-    static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+    static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
         guard let val = abi else { return nil }
         var result: __x_ABI_Ctest__component_CSigned = .init(0)
         try! CHECKED(val.get().pointee.lpVtbl.pointee.get_Value(val.get(), &result))
@@ -6628,7 +6628,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClas
     internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CClass___x_ABI_Ctest__zcomponent__CDeferrableEventArgs
     internal typealias SwiftABI = test_component.TypedEventHandlerClass_DeferrableEventArgs
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in
@@ -6679,7 +6679,7 @@ internal class __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimp
     internal typealias CABI = __x_ABI_C__FITypedEventHandler_2___x_ABI_Ctest__zcomponent__CSimple___x_ABI_Ctest__zcomponent__CSimpleEventArgs
     internal typealias SwiftABI = test_component.TypedEventHandlerSimple_SimpleEventArgs
 
-    internal static func from(abi: ComPtr<CABI>?) -> Handler? {
+    internal static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
         guard let abi = abi else { return nil }
         let _default = SwiftABI(abi)
         let handler: Handler = { (sender, args) in

--- a/tests/test_component/Sources/test_component/test_component+IArrayScenarios.swift
+++ b/tests/test_component/Sources/test_component/test_component+IArrayScenarios.swift
@@ -37,7 +37,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIArrayScenarios
         public typealias SwiftABI = __ABI_test_component.IArrayScenarios
         public typealias SwiftProjection = AnyIArrayScenarios
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IArrayScenariosImpl(abi)
         }
@@ -52,7 +52,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = IArrayScenariosBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+IArrayShouldBuild.swift
+++ b/tests/test_component/Sources/test_component/test_component+IArrayShouldBuild.swift
@@ -28,7 +28,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIArrayShouldBuild
         public typealias SwiftABI = __ABI_test_component.IArrayShouldBuild
         public typealias SwiftProjection = AnyIArrayShouldBuild
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IArrayShouldBuildImpl(abi)
         }
@@ -43,7 +43,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = IArrayShouldBuildBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+IAsyncMethodsWithProgress.swift
+++ b/tests/test_component/Sources/test_component/test_component+IAsyncMethodsWithProgress.swift
@@ -28,7 +28,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIAsyncMethodsWithProgress
         public typealias SwiftABI = __ABI_test_component.IAsyncMethodsWithProgress
         public typealias SwiftProjection = AnyIAsyncMethodsWithProgress
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IAsyncMethodsWithProgressImpl(abi)
         }
@@ -43,7 +43,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = IAsyncMethodsWithProgressBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+IAsyncOperationInt.swift
+++ b/tests/test_component/Sources/test_component/test_component+IAsyncOperationInt.swift
@@ -29,7 +29,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIAsyncOperationInt
         public typealias SwiftABI = __ABI_test_component.IAsyncOperationInt
         public typealias SwiftProjection = AnyIAsyncOperationInt
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IAsyncOperationIntImpl(abi)
         }
@@ -44,7 +44,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = IAsyncOperationIntBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+IBasic.swift
+++ b/tests/test_component/Sources/test_component/test_component+IBasic.swift
@@ -28,7 +28,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIBasic
         public typealias SwiftABI = __ABI_test_component.IBasic
         public typealias SwiftProjection = AnyIBasic
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IBasicImpl(abi)
         }
@@ -43,7 +43,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = IBasicBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+IIAmImplementable.swift
+++ b/tests/test_component/Sources/test_component/test_component+IIAmImplementable.swift
@@ -53,7 +53,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIIAmImplementable
         public typealias SwiftABI = __ABI_test_component.IIAmImplementable
         public typealias SwiftProjection = AnyIIAmImplementable
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IIAmImplementableImpl(abi)
         }
@@ -68,7 +68,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = IIAmImplementableBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+IInterfaceWithObservableVector.swift
+++ b/tests/test_component/Sources/test_component/test_component+IInterfaceWithObservableVector.swift
@@ -28,7 +28,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIInterfaceWithObservableVector
         public typealias SwiftABI = __ABI_test_component.IInterfaceWithObservableVector
         public typealias SwiftProjection = AnyIInterfaceWithObservableVector
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IInterfaceWithObservableVectorImpl(abi)
         }
@@ -43,7 +43,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = IInterfaceWithObservableVectorBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+IReferenceTarget.swift
+++ b/tests/test_component/Sources/test_component/test_component+IReferenceTarget.swift
@@ -28,7 +28,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIReferenceTarget
         public typealias SwiftABI = __ABI_test_component.IReferenceTarget
         public typealias SwiftProjection = AnyIReferenceTarget
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return IReferenceTargetImpl(abi)
         }
@@ -43,7 +43,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = IReferenceTargetBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+ISimpleDelegate.swift
+++ b/tests/test_component/Sources/test_component/test_component+ISimpleDelegate.swift
@@ -29,7 +29,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CISimpleDelegate
         public typealias SwiftABI = __ABI_test_component.ISimpleDelegate
         public typealias SwiftProjection = AnyISimpleDelegate
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return ISimpleDelegateImpl(abi)
         }
@@ -44,7 +44,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = ISimpleDelegateBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+InterfaceWithReturnDelegate.swift
+++ b/tests/test_component/Sources/test_component/test_component+InterfaceWithReturnDelegate.swift
@@ -38,7 +38,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CInterfaceWithReturnDelegate
         public typealias SwiftABI = __ABI_test_component.InterfaceWithReturnDelegate
         public typealias SwiftProjection = AnyInterfaceWithReturnDelegate
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return InterfaceWithReturnDelegateImpl(abi)
         }
@@ -53,7 +53,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = InterfaceWithReturnDelegateBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+NoopClosable.swift
+++ b/tests/test_component/Sources/test_component/test_component+NoopClosable.swift
@@ -46,7 +46,7 @@ extension __IMPL_test_component {
     public enum NoopClosableBridge: AbiBridge {
         public typealias SwiftProjection = NoopClosable
         public typealias CABI = __x_ABI_CWindows_CFoundation_CIClosable
-        public static func from(abi: ComPtr<__x_ABI_CWindows_CFoundation_CIClosable>?) -> NoopClosable? {
+        public static func from(abi: consuming ComPtr<__x_ABI_CWindows_CFoundation_CIClosable>?) -> NoopClosable? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+ObjectHandler.swift
+++ b/tests/test_component/Sources/test_component/test_component+ObjectHandler.swift
@@ -15,7 +15,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIObjectHandler
         public typealias SwiftABI = __ABI_test_component.ObjectHandler
 
-        public static func from(abi: ComPtr<CABI>?) -> Handler? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (item) in

--- a/tests/test_component/Sources/test_component/test_component+Simple.swift
+++ b/tests/test_component/Sources/test_component/test_component+Simple.swift
@@ -151,7 +151,7 @@ extension __IMPL_test_component {
     public enum SimpleBridge: AbiBridge {
         public typealias SwiftProjection = Simple
         public typealias CABI = __x_ABI_Ctest__component_CISimple
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CISimple>?) -> Simple? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CISimple>?) -> Simple? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+UnsealedDerived.swift
+++ b/tests/test_component/Sources/test_component/test_component+UnsealedDerived.swift
@@ -89,7 +89,7 @@ extension __IMPL_test_component {
     public enum UnsealedDerivedBridge: ComposableBridge {
         public typealias SwiftProjection = UnsealedDerived
         public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerived>?) -> UnsealedDerived? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIUnsealedDerived>?) -> UnsealedDerived? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }

--- a/tests/test_component/Sources/test_component/test_component+UnsealedDerived2.swift
+++ b/tests/test_component/Sources/test_component/test_component+UnsealedDerived2.swift
@@ -64,7 +64,7 @@ extension __IMPL_test_component {
     public enum UnsealedDerived2Bridge: ComposableBridge {
         public typealias SwiftProjection = UnsealedDerived2
         public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerived2
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerived2>?) -> UnsealedDerived2? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIUnsealedDerived2>?) -> UnsealedDerived2? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }

--- a/tests/test_component/Sources/test_component/test_component+UnsealedDerivedFromNoConstructor.swift
+++ b/tests/test_component/Sources/test_component/test_component+UnsealedDerivedFromNoConstructor.swift
@@ -52,7 +52,7 @@ extension __IMPL_test_component {
     public enum UnsealedDerivedFromNoConstructorBridge: ComposableBridge {
         public typealias SwiftProjection = UnsealedDerivedFromNoConstructor
         public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor>?) -> UnsealedDerivedFromNoConstructor? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedFromNoConstructor>?) -> UnsealedDerivedFromNoConstructor? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }

--- a/tests/test_component/Sources/test_component/test_component+UnsealedDerivedNoConstructor.swift
+++ b/tests/test_component/Sources/test_component/test_component+UnsealedDerivedNoConstructor.swift
@@ -46,7 +46,7 @@ extension __IMPL_test_component {
     public enum UnsealedDerivedNoConstructorBridge: ComposableBridge {
         public typealias SwiftProjection = UnsealedDerivedNoConstructor
         public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor>?) -> UnsealedDerivedNoConstructor? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedNoConstructor>?) -> UnsealedDerivedNoConstructor? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }

--- a/tests/test_component/Sources/test_component/test_component+UnsealedDerivedNoOverrides.swift
+++ b/tests/test_component/Sources/test_component/test_component+UnsealedDerivedNoOverrides.swift
@@ -52,7 +52,7 @@ extension __IMPL_test_component {
     public enum UnsealedDerivedNoOverridesBridge: ComposableBridge {
         public typealias SwiftProjection = UnsealedDerivedNoOverrides
         public typealias CABI = __x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides>?) -> UnsealedDerivedNoOverrides? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIUnsealedDerivedNoOverrides>?) -> UnsealedDerivedNoOverrides? {
             guard let abi = abi else { return nil }
             return UnsealedWinRTClassWrapper<Composable>.unwrapFrom(base: abi)
         }

--- a/tests/test_component/Sources/test_component/test_component+VoidToVoidDelegate.swift
+++ b/tests/test_component/Sources/test_component/test_component+VoidToVoidDelegate.swift
@@ -15,7 +15,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CIVoidToVoidDelegate
         public typealias SwiftABI = __ABI_test_component.VoidToVoidDelegate
 
-        public static func from(abi: ComPtr<CABI>?) -> Handler? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in

--- a/tests/test_component/Sources/test_component/test_component+WeakReferencer.swift
+++ b/tests/test_component/Sources/test_component/test_component+WeakReferencer.swift
@@ -43,7 +43,7 @@ extension __IMPL_test_component {
     public enum WeakReferencerBridge: AbiBridge {
         public typealias SwiftProjection = WeakReferencer
         public typealias CABI = __x_ABI_Ctest__component_CIWeakReferencer
-        public static func from(abi: ComPtr<__x_ABI_Ctest__component_CIWeakReferencer>?) -> WeakReferencer? {
+        public static func from(abi: consuming ComPtr<__x_ABI_Ctest__component_CIWeakReferencer>?) -> WeakReferencer? {
             guard let abi = abi else { return nil }
             return .init(fromAbi: WindowsFoundation.IInspectable(abi))
         }

--- a/tests/test_component/Sources/test_component/test_component+WithIterableGuids.swift
+++ b/tests/test_component/Sources/test_component/test_component+WithIterableGuids.swift
@@ -28,7 +28,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CWithIterableGuids
         public typealias SwiftABI = __ABI_test_component.WithIterableGuids
         public typealias SwiftProjection = AnyWithIterableGuids
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return WithIterableGuidsImpl(abi)
         }
@@ -43,7 +43,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = WithIterableGuidsBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+WithKeyword.swift
+++ b/tests/test_component/Sources/test_component/test_component+WithKeyword.swift
@@ -31,7 +31,7 @@ extension __IMPL_test_component {
         public typealias CABI = __x_ABI_Ctest__component_CWithKeyword
         public typealias SwiftABI = __ABI_test_component.WithKeyword
         public typealias SwiftProjection = AnyWithKeyword
-        public static func from(abi: ComPtr<CABI>?) -> SwiftProjection? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> SwiftProjection? {
             guard let abi = abi else { return nil }
             return WithKeywordImpl(abi)
         }
@@ -46,7 +46,7 @@ extension __IMPL_test_component {
         fileprivate typealias Bridge = WithKeywordBridge
         fileprivate let _default: Bridge.SwiftABI
         fileprivate var thisPtr: WindowsFoundation.IInspectable { _default }
-        fileprivate init(_ fromAbi: ComPtr<Bridge.CABI>) {
+        fileprivate init(_ fromAbi: consuming ComPtr<Bridge.CABI>) {
             _default = Bridge.SwiftABI(fromAbi)
         }
 

--- a/tests/test_component/Sources/test_component/test_component.Delegates+InDelegate.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+InDelegate.swift
@@ -15,7 +15,7 @@ extension __IMPL_test_component_Delegates {
         public typealias CABI = __x_ABI_Ctest__component_CDelegates_CIInDelegate
         public typealias SwiftABI = __ABI_test_component_Delegates.InDelegate
 
-        public static func from(abi: ComPtr<CABI>?) -> Handler? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (value) in

--- a/tests/test_component/Sources/test_component/test_component.Delegates+InObjectDelegate.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+InObjectDelegate.swift
@@ -15,7 +15,7 @@ extension __IMPL_test_component_Delegates {
         public typealias CABI = __x_ABI_Ctest__component_CDelegates_CIInObjectDelegate
         public typealias SwiftABI = __ABI_test_component_Delegates.InObjectDelegate
 
-        public static func from(abi: ComPtr<CABI>?) -> Handler? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { (value) in

--- a/tests/test_component/Sources/test_component/test_component.Delegates+ReturnInt32Delegate.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+ReturnInt32Delegate.swift
@@ -15,7 +15,7 @@ extension __IMPL_test_component_Delegates {
         public typealias CABI = __x_ABI_Ctest__component_CDelegates_CIReturnInt32Delegate
         public typealias SwiftABI = __ABI_test_component_Delegates.ReturnInt32Delegate
 
-        public static func from(abi: ComPtr<CABI>?) -> Handler? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in

--- a/tests/test_component/Sources/test_component/test_component.Delegates+SignalDelegate.swift
+++ b/tests/test_component/Sources/test_component/test_component.Delegates+SignalDelegate.swift
@@ -15,7 +15,7 @@ extension __IMPL_test_component_Delegates {
         public typealias CABI = __x_ABI_Ctest__component_CDelegates_CISignalDelegate
         public typealias SwiftABI = __ABI_test_component_Delegates.SignalDelegate
 
-        public static func from(abi: ComPtr<CABI>?) -> Handler? {
+        public static func from(abi: consuming ComPtr<CABI>?) -> Handler? {
             guard let abi = abi else { return nil }
             let _default = SwiftABI(abi)
             let handler: Handler = { () in


### PR DESCRIPTION
Adds `consuming`/`borrowing` ownership annotations to everywhere a `ComPtr` is passed as a parameter.

# Context

Upstack in #243 I convert `ComPtr` to a non-copyable struct. The reference counting Swift does on the `ComPtr` class instances itself is a hot path in application code performance traces. Converting it to be a non-copyable struct removes this additional Swift reference counting (on top of the COM pointer reference counting), and shows meaningful improvements across much of my local benchmarking suite due to `ComPtr`s fundamental role.

This PR just pulls out the addition of these ownership annotations, which are necessary for the `ComPtr` non-copyable change, but can be made independently.