### PR TITLE
Convert `ComPtr` from class to `~Copyable` struct

### DIFF
--- a/swiftwinrt/Resources/Support/ComPtr.swift
+++ b/swiftwinrt/Resources/Support/ComPtr.swift
@@ -9,7 +9,7 @@ import CWinRT
 // anywhere else in the code base.  The only place where UnsafeMutablePointer should be used is
 
 // where it's required at the ABI boundary.
-public class ComPtr<CInterface> {
+public struct ComPtr<CInterface>: ~Copyable {
     fileprivate var pUnk: UnsafeMutablePointer<CInterface>?
 
     public init(_ ptr: UnsafeMutablePointer<CInterface>) {
@@ -19,7 +19,7 @@ public class ComPtr<CInterface> {
         }
     }
 
-    public convenience init?(_ ptr: UnsafeMutablePointer<CInterface>?) {
+    public init?(_ ptr: UnsafeMutablePointer<CInterface>?) {
         guard let ptr else { return nil }
         self.init(ptr)
     }
@@ -32,13 +32,13 @@ public class ComPtr<CInterface> {
     // Release ownership of the underlying pointer and return it. This is
     // useful when assigning to an out parameter and avoids an extra Add/Ref
     // release call.
-    public func detach() -> UnsafeMutableRawPointer? {
+    public mutating func detach() -> UnsafeMutableRawPointer? {
         let result = pUnk
         pUnk = nil
         return UnsafeMutableRawPointer(result)
     }
 
-    public func get() -> UnsafeMutablePointer<CInterface> {
+    public borrowing func get() -> UnsafeMutablePointer<CInterface> {
       guard let pUnk else { preconditionFailure("get() called on nil pointer") }
       return pUnk
     }
@@ -54,14 +54,14 @@ public class ComPtr<CInterface> {
         }
     }
 
-    func asIUnknown<ResultType>(_ body: (UnsafeMutablePointer<C_IUnknown>) throws -> ResultType) rethrows -> ResultType {
+    borrowing func asIUnknown<ResultType: ~Copyable>(_ body: (UnsafeMutablePointer<C_IUnknown>) throws -> ResultType) rethrows -> ResultType {
         guard let pUnk else { preconditionFailure("asIUnknown called on nil pointer") }
         return try pUnk.withMemoryRebound(to: C_IUnknown.self, capacity: 1) { try body($0) }
     }
 }
 
 public extension ComPtr {
-    func queryInterface<Interface: IUnknown>() throws -> Interface {
+    borrowing func queryInterface<Interface: IUnknown>() throws -> Interface {
         let ptr = try self.asIUnknown { pUnk in
             var iid = Interface.IID
             return try ComPtrs.initialize(to: C_IUnknown.self) { result in

--- a/swiftwinrt/Resources/Support/IWeakReferenceSource.swift
+++ b/swiftwinrt/Resources/Support/IWeakReferenceSource.swift
@@ -58,7 +58,7 @@ fileprivate var IWeakReferenceSourceVTable: C_IWeakReferenceSourceVtbl = .init(
 fileprivate func GetWeakReference(
         _ this: UnsafeMutablePointer<C_IWeakReferenceSource>?,
         _ weakReference: UnsafeMutablePointer<UnsafeMutablePointer<C_IWeakReference>?>?) -> HRESULT {
-    guard let object = WeakReferenceSourceWrapper.tryUnwrapFrom(abi: ComPtr(this)) else { return E_FAIL }
+    guard let this, let object = WeakReferenceSourceWrapper.tryUnwrapFrom(abi: ComPtr(this)) else { return E_FAIL }
     guard let weakReference else { return E_INVALIDARG }
     do {
         var rawWeakReference: UnsafeMutableRawPointer? = nil

--- a/swiftwinrt/Resources/Support/Marshaler.swift
+++ b/swiftwinrt/Resources/Support/Marshaler.swift
@@ -84,7 +84,7 @@ private class Marshaler {
         _ pvDestContext: UnsafeMutableRawPointer?,
         _ mshlflags: DWORD,
         _ pCid: UnsafeMutablePointer<CLSID>?) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.GetUnmarshalClass(marshaler, riid, pv, dwDestContext, pvDestContext, mshlflags, pCid)
     }
 
@@ -95,7 +95,7 @@ private class Marshaler {
         _ pvDestContext: UnsafeMutableRawPointer?,
         _ mshlflags: DWORD,
         _ pSize: UnsafeMutablePointer<DWORD>?) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.GetMarshalSizeMax(marshaler, riid, pv, dwDestContext, pvDestContext, mshlflags, pSize)
     }
 
@@ -107,7 +107,7 @@ private class Marshaler {
         _ dwDestContext: DWORD,
         _ pvDestContext: UnsafeMutableRawPointer?,
         _ mshlflags: DWORD) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.MarshalInterface(marshaler, pStm, riid, pv, dwDestContext, pvDestContext, mshlflags)
     }
 
@@ -116,21 +116,21 @@ private class Marshaler {
         _ pStm: UnsafeMutablePointer<IStream>?,
         _ riid: REFIID?,
         _ ppv: UnsafeMutablePointer<UnsafeMutableRawPointer?>?) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.UnmarshalInterface(marshaler, pStm, riid, ppv)
     }
 
     static func ReleaseMarshalData(
         _ this: UnsafeMutablePointer<C_IMarshal>?,
         _ pStm: UnsafeMutablePointer<IStream>?) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.ReleaseMarshalData(marshaler, pStm)
     }
 
     static func DisconnectObject(
         _ this: UnsafeMutablePointer<C_IMarshal>?,
         _ dwReserved: DWORD) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.DisconnectObject(marshaler, dwReserved)
     }
 }

--- a/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
+++ b/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
@@ -123,8 +123,7 @@ open class WinRTWrapperBase<CInterface, Prototype> {
 
     // When unwrapping from the abi, we want to see if the object has an existing implementation so we can use
     // that to get to the existing swift object. if it doesn't exist then we can create a new implementation
-    public static func tryUnwrapFrom(abi pointer: ComPtr<CInterface>?) -> Prototype? {
-        guard let pointer = pointer else { return nil }
+    public static func tryUnwrapFrom(abi pointer: borrowing ComPtr<CInterface>) -> Prototype? {
         guard let wrapper: ISwiftImplemented = try? pointer.queryInterface() else { return nil }
         let pUnk = UnsafeMutableRawPointer(wrapper.pUnk.borrow)
 
@@ -180,8 +179,8 @@ open class WinRTAbiBridgeWrapper<I: AbiBridge> : WinRTWrapperBase<I.CABI, I.Swif
 
     public static func unwrapFrom(abi pointer: consuming ComPtr<I.CABI>?) -> I.SwiftProjection? {
         guard let pointer = pointer else { return nil }
-        guard let unwrapped = tryUnwrapFrom(abi: pointer) else { return I.from(abi: pointer) }
-        return unwrapped
+        if let unwrapped = tryUnwrapFrom(abi: pointer) { return unwrapped }
+        return I.from(abi: pointer)
     }
 
     open class func queryInterface(_ pUnk: UnsafeMutablePointer<I.CABI>?, _ riid: UnsafePointer<SUPPORT_MODULE.IID>?, _ ppvObject: UnsafeMutablePointer<UnsafeMutableRawPointer?>?) -> HRESULT {

--- a/tests/test_component/Sources/WindowsFoundation/Support/comptr.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/comptr.swift
@@ -9,7 +9,7 @@ import CWinRT
 // anywhere else in the code base.  The only place where UnsafeMutablePointer should be used is
 
 // where it's required at the ABI boundary.
-public class ComPtr<CInterface> {
+public struct ComPtr<CInterface>: ~Copyable {
     fileprivate var pUnk: UnsafeMutablePointer<CInterface>?
 
     public init(_ ptr: UnsafeMutablePointer<CInterface>) {
@@ -19,7 +19,7 @@ public class ComPtr<CInterface> {
         }
     }
 
-    public convenience init?(_ ptr: UnsafeMutablePointer<CInterface>?) {
+    public init?(_ ptr: UnsafeMutablePointer<CInterface>?) {
         guard let ptr else { return nil }
         self.init(ptr)
     }
@@ -32,13 +32,13 @@ public class ComPtr<CInterface> {
     // Release ownership of the underlying pointer and return it. This is
     // useful when assigning to an out parameter and avoids an extra Add/Ref
     // release call.
-    public func detach() -> UnsafeMutableRawPointer? {
+    public mutating func detach() -> UnsafeMutableRawPointer? {
         let result = pUnk
         pUnk = nil
         return UnsafeMutableRawPointer(result)
     }
 
-    public func get() -> UnsafeMutablePointer<CInterface> {
+    public borrowing func get() -> UnsafeMutablePointer<CInterface> {
       guard let pUnk else { preconditionFailure("get() called on nil pointer") }
       return pUnk
     }
@@ -54,14 +54,14 @@ public class ComPtr<CInterface> {
         }
     }
 
-    func asIUnknown<ResultType>(_ body: (UnsafeMutablePointer<C_IUnknown>) throws -> ResultType) rethrows -> ResultType {
+    borrowing func asIUnknown<ResultType: ~Copyable>(_ body: (UnsafeMutablePointer<C_IUnknown>) throws -> ResultType) rethrows -> ResultType {
         guard let pUnk else { preconditionFailure("asIUnknown called on nil pointer") }
         return try pUnk.withMemoryRebound(to: C_IUnknown.self, capacity: 1) { try body($0) }
     }
 }
 
 public extension ComPtr {
-    func queryInterface<Interface: IUnknown>() throws -> Interface {
+    borrowing func queryInterface<Interface: IUnknown>() throws -> Interface {
         let ptr = try self.asIUnknown { pUnk in
             var iid = Interface.IID
             return try ComPtrs.initialize(to: C_IUnknown.self) { result in

--- a/tests/test_component/Sources/WindowsFoundation/Support/iweakreferencesource.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/iweakreferencesource.swift
@@ -58,7 +58,7 @@ fileprivate var IWeakReferenceSourceVTable: C_IWeakReferenceSourceVtbl = .init(
 fileprivate func GetWeakReference(
         _ this: UnsafeMutablePointer<C_IWeakReferenceSource>?,
         _ weakReference: UnsafeMutablePointer<UnsafeMutablePointer<C_IWeakReference>?>?) -> HRESULT {
-    guard let object = WeakReferenceSourceWrapper.tryUnwrapFrom(abi: ComPtr(this)) else { return E_FAIL }
+    guard let this, let object = WeakReferenceSourceWrapper.tryUnwrapFrom(abi: ComPtr(this)) else { return E_FAIL }
     guard let weakReference else { return E_INVALIDARG }
     do {
         var rawWeakReference: UnsafeMutableRawPointer? = nil

--- a/tests/test_component/Sources/WindowsFoundation/Support/marshaler.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/marshaler.swift
@@ -84,7 +84,7 @@ private class Marshaler {
         _ pvDestContext: UnsafeMutableRawPointer?,
         _ mshlflags: DWORD,
         _ pCid: UnsafeMutablePointer<CLSID>?) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.GetUnmarshalClass(marshaler, riid, pv, dwDestContext, pvDestContext, mshlflags, pCid)
     }
 
@@ -95,7 +95,7 @@ private class Marshaler {
         _ pvDestContext: UnsafeMutableRawPointer?,
         _ mshlflags: DWORD,
         _ pSize: UnsafeMutablePointer<DWORD>?) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.GetMarshalSizeMax(marshaler, riid, pv, dwDestContext, pvDestContext, mshlflags, pSize)
     }
 
@@ -107,7 +107,7 @@ private class Marshaler {
         _ dwDestContext: DWORD,
         _ pvDestContext: UnsafeMutableRawPointer?,
         _ mshlflags: DWORD) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.MarshalInterface(marshaler, pStm, riid, pv, dwDestContext, pvDestContext, mshlflags)
     }
 
@@ -116,21 +116,21 @@ private class Marshaler {
         _ pStm: UnsafeMutablePointer<IStream>?,
         _ riid: REFIID?,
         _ ppv: UnsafeMutablePointer<UnsafeMutableRawPointer?>?) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.UnmarshalInterface(marshaler, pStm, riid, ppv)
     }
 
     static func ReleaseMarshalData(
         _ this: UnsafeMutablePointer<C_IMarshal>?,
         _ pStm: UnsafeMutablePointer<IStream>?) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.ReleaseMarshalData(marshaler, pStm)
     }
 
     static func DisconnectObject(
         _ this: UnsafeMutablePointer<C_IMarshal>?,
         _ dwReserved: DWORD) -> HRESULT {
-        guard let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
+        guard let this, let marshaler = MarshalWrapper.tryUnwrapFrom(abi: ComPtr(this))?.marshaler else { return E_FAIL }
         return marshaler.pointee.lpVtbl.pointee.DisconnectObject(marshaler, dwReserved)
     }
 }

--- a/tests/test_component/Sources/WindowsFoundation/Support/winrtwrapperbase.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/winrtwrapperbase.swift
@@ -123,8 +123,7 @@ open class WinRTWrapperBase<CInterface, Prototype> {
 
     // When unwrapping from the abi, we want to see if the object has an existing implementation so we can use
     // that to get to the existing swift object. if it doesn't exist then we can create a new implementation
-    public static func tryUnwrapFrom(abi pointer: ComPtr<CInterface>?) -> Prototype? {
-        guard let pointer = pointer else { return nil }
+    public static func tryUnwrapFrom(abi pointer: borrowing ComPtr<CInterface>) -> Prototype? {
         guard let wrapper: ISwiftImplemented = try? pointer.queryInterface() else { return nil }
         let pUnk = UnsafeMutableRawPointer(wrapper.pUnk.borrow)
 
@@ -180,8 +179,8 @@ open class WinRTAbiBridgeWrapper<I: AbiBridge> : WinRTWrapperBase<I.CABI, I.Swif
 
     public static func unwrapFrom(abi pointer: consuming ComPtr<I.CABI>?) -> I.SwiftProjection? {
         guard let pointer = pointer else { return nil }
-        guard let unwrapped = tryUnwrapFrom(abi: pointer) else { return I.from(abi: pointer) }
-        return unwrapped
+        if let unwrapped = tryUnwrapFrom(abi: pointer) { return unwrapped }
+        return I.from(abi: pointer)
     }
 
     open class func queryInterface(_ pUnk: UnsafeMutablePointer<I.CABI>?, _ riid: UnsafePointer<WindowsFoundation.IID>?, _ ppvObject: UnsafeMutablePointer<UnsafeMutableRawPointer?>?) -> HRESULT {


### PR DESCRIPTION
Converts the `ComPtr` type from a class to a noncopyable struct, eliminating the Swift ARC retain/release overhead (on top of COM AddRef/Release).

This builds on the work done in #241 and #242.

This Swift reference counting was identified as a huge source of samples in application profiling traces; converting `ComPtr` to be a non-copyable struct eliminates this overhead.

In my local vibe-coded benchmark harness, the total changeset represented by these three PRs shows significant improvements across many low-level operations in the Swift/WinRT interface layer:

| Benchmark | Change | p-value |
|---|---|---|
| `query_interface` | **-48.2%** | < 1e-4 |
| `object_return_from_method` | **-46.6%** | 1e-4 |
| `object_create_destroy` | **-39.9%** | < 1e-4 |
| `event_fire_typed` | **-34.8%** | 0.0013 |
| `composable_create_destroy` | **-33.6%** | < 1e-4 |
| `weak_ref_create_resolve` | **-18.1%** | < 1e-4 |
| `event_fire_type_erased` | **-7.7%** | < 1e-4 |
| `vector_return_iterate` | **-7.5%** | 0.0036 |
| `map_return_lookup` | **-7.4%** | 0.0075 |
| `integration` | **-4.6%** | 0.0002 |