### PR TITLE
Use workflow token to push to Nuget

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Publish NuGet Package to GHA Packages
         shell: cmd
         env:
-          GITHUB_TOKEN: ${{ secrets.NUGET_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_USERNAME: thebrowsercompany-bot2
           NUGET_PUBLISH_URL: https://nuget.pkg.github.com/thebrowsercompany/index.json
           NUGET_SOURCE_NAME: TheBrowserCompany


### PR DESCRIPTION
The token we're using to push to Nuget has expired, but we can just use the workflow token directly because it is already granted the `packages:write` permission.