### PR TITLE
Fix leaking of returned HSTRING values

### DIFF
--- a/swiftwinrt/code_writers/writer_helpers.h
+++ b/swiftwinrt/code_writers/writer_helpers.h
@@ -430,6 +430,10 @@ namespace swiftwinrt
         }
         else
         {
+            if (get_category(return_type.type) == param_category::string_type)
+            {
+                w.write("defer { WindowsDeleteString(%) }\n", return_param_name);
+            }
             w.write("return %", bind<write_consume_type>(return_type.type, return_param_name, true));
         }
 

--- a/tests/test_component/Sources/UWP/UWP+Generics.swift
+++ b/tests/test_component/Sources/UWP/UWP+Generics.swift
@@ -2783,6 +2783,7 @@ public class IIteratorString: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIIterator_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -4432,6 +4433,7 @@ public class IKeyValuePairString_Any: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -4540,6 +4542,7 @@ public class IKeyValuePairString_IVectorViewTextSegment: WindowsFoundation.IInsp
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_C__FIVectorView_1___x_ABI_CWindows__CData__CText__CTextSegment.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -4655,6 +4658,7 @@ public class IMapChangedEventArgsString: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIMapChangedEventArgs_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -5711,6 +5715,7 @@ public class IVectorViewString: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIVectorView_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -7431,6 +7436,7 @@ public class IVectorString: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -8875,6 +8881,7 @@ public class IAsyncOperationString: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIAsyncOperation_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetResults(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageFile.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageFile.swift
@@ -220,6 +220,7 @@ extension __ABI_Windows_Storage {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_FileType(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -228,6 +229,7 @@ extension __ABI_Windows_Storage {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageFile.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ContentType(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageItem.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageItem.swift
@@ -181,6 +181,7 @@ extension __ABI_Windows_Storage {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Name(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -189,6 +190,7 @@ extension __ABI_Windows_Storage {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItem.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Path(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+IStorageItemProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+IStorageItemProperties.swift
@@ -140,6 +140,7 @@ extension __ABI_Windows_Storage {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayName(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -148,6 +149,7 @@ extension __ABI_Windows_Storage {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayType(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -156,6 +158,7 @@ extension __ABI_Windows_Storage {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageItemProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_FolderRelativeId(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+StorageLibraryChange.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StorageLibraryChange.swift
@@ -95,6 +95,7 @@ extension __ABI_Windows_Storage {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Path(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -103,6 +104,7 @@ extension __ABI_Windows_Storage {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageLibraryChange.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_PreviousPath(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage+StorageProvider.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage+StorageProvider.swift
@@ -79,6 +79,7 @@ extension __ABI_Windows_Storage {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageProvider.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Id(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -87,6 +88,7 @@ extension __ABI_Windows_Storage {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CIStorageProvider.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayName(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+DocumentProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+DocumentProperties.swift
@@ -113,6 +113,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -137,6 +138,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIDocumentProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Comment(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+ImageProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+ImageProperties.swift
@@ -200,6 +200,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -233,6 +234,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_CameraManufacturer(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -248,6 +250,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIImageProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_CameraModel(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+MusicProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+MusicProperties.swift
@@ -171,6 +171,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Album(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -186,6 +187,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Artist(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -224,6 +226,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -269,6 +272,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AlbumArtist(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -302,6 +306,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Subtitle(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -326,6 +331,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIMusicProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Publisher(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+VideoProperties.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.FileProperties+VideoProperties.swift
@@ -232,6 +232,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Title(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -247,6 +248,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Subtitle(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -271,6 +273,7 @@ extension __ABI_Windows_Storage_FileProperties {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CFileProperties_CIVideoProperties.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Publisher(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.Search+QueryOptions.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Search+QueryOptions.swift
@@ -176,6 +176,7 @@ extension __ABI_Windows_Storage_Search {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ApplicationSearchFilter(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -191,6 +192,7 @@ extension __ABI_Windows_Storage_Search {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_UserSearchFilter(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -206,6 +208,7 @@ extension __ABI_Windows_Storage_Search {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Language(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -244,6 +247,7 @@ extension __ABI_Windows_Storage_Search {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_GroupPropertyName(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -260,6 +264,7 @@ extension __ABI_Windows_Storage_Search {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CSearch_CIQueryOptions.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.SaveToString(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.Storage.Streams+IContentTypeProvider.swift
+++ b/tests/test_component/Sources/UWP/Windows.Storage.Streams+IContentTypeProvider.swift
@@ -71,6 +71,7 @@ extension __ABI_Windows_Storage_Streams {
             _ = try perform(as: __x_ABI_CWindows_CStorage_CStreams_CIContentTypeProvider.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_ContentType(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/UWP/Windows.System+User.swift
+++ b/tests/test_component/Sources/UWP/Windows.System+User.swift
@@ -131,6 +131,7 @@ extension __ABI_Windows_System {
             _ = try perform(as: __x_ABI_CWindows_CSystem_CIUser.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_NonRoamableId(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IPropertyValue.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IPropertyValue.swift
@@ -333,6 +333,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIPropertyValue.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetString(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IStringable.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IStringable.swift
@@ -70,6 +70,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIStringable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.ToString(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IWwwFormUrlDecoderEntry.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+IWwwFormUrlDecoderEntry.swift
@@ -77,6 +77,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Name(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -85,6 +86,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderEntry.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+Uri.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+Uri.swift
@@ -188,6 +188,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AbsoluteUri(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -196,6 +197,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayUri(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -204,6 +206,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Domain(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -212,6 +215,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Extension(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -220,6 +224,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Fragment(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -228,6 +233,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Host(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -236,6 +242,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Password(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -244,6 +251,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Path(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -252,6 +260,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Query(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -269,6 +278,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_RawUri(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -277,6 +287,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_SchemeName(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -285,6 +296,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_UserName(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -336,6 +348,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClassWithAbsoluteCanonicalUri.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_AbsoluteCanonicalUri(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -344,6 +357,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriRuntimeClassWithAbsoluteCanonicalUri.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_DisplayIri(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -362,6 +376,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriEscapeStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.UnescapeComponent(pThis, _toUnescape.get(), &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 
@@ -371,6 +386,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIUriEscapeStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.EscapeComponent(pThis, _toEscape.get(), &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+WwwFormUrlDecoder.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Windows.Foundation+WwwFormUrlDecoder.swift
@@ -127,6 +127,7 @@ extension __ABI_Windows_Foundation {
             _ = try perform(as: __x_ABI_CWindows_CFoundation_CIWwwFormUrlDecoderRuntimeClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetFirstValueByName(pThis, _name.get(), &phstrValue))
             }
+            defer { WindowsDeleteString(phstrValue) }
             return .init(from: phstrValue)
         }
 

--- a/tests/test_component/Sources/WindowsFoundation/WindowsFoundation+Generics.swift
+++ b/tests/test_component/Sources/WindowsFoundation/WindowsFoundation+Generics.swift
@@ -776,6 +776,7 @@ public class IKeyValuePairString_Any: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_IInspectable.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -883,6 +884,7 @@ public class IKeyValuePairString_String: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -891,6 +893,7 @@ public class IKeyValuePairString_String: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -997,6 +1000,7 @@ public class IMapChangedEventArgsString: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIMapChangedEventArgs_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -1284,6 +1288,7 @@ public class IMapViewString_String: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Lookup(pThis, _key.get(), &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -1690,6 +1695,7 @@ public class IMapString_String: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Lookup(pThis, _key.get(), &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 

--- a/tests/test_component/Sources/test_component/test_component+ArrayMethods.swift
+++ b/tests/test_component/Sources/test_component/test_component+ArrayMethods.swift
@@ -154,6 +154,7 @@ extension __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.InInt32Array(pThis, _value.count, _value.start, &result))
                 }
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -164,6 +165,7 @@ extension __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.InStringArray(pThis, _value.count, _value.start, &result))
                 }
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -174,6 +176,7 @@ extension __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.InObjectArray(pThis, _value.count, _value.start, &result))
                 }
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -184,6 +187,7 @@ extension __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.InStringableArray(pThis, _value.count, _value.start, &result))
                 }
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -194,6 +198,7 @@ extension __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.InStructArray(pThis, _value.count, _value.start, &result))
                 }
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -204,6 +209,7 @@ extension __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.InNonBlittableStructArray(pThis, _value.count, _value.start, &result))
                 }
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -214,6 +220,7 @@ extension __ABI_test_component {
                     try CHECKED(pThis.pointee.lpVtbl.pointee.InEnumArray(pThis, _value.count, _value.start, &result))
                 }
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+Class.swift
+++ b/tests/test_component/Sources/test_component/test_component+Class.swift
@@ -319,6 +319,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InInt32(pThis, value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -328,6 +329,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InString(pThis, _value.get(), &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -338,6 +340,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InObject(pThis, _value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -347,6 +350,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InBlittableStructRef(pThis, &_value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -356,6 +360,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InNonBlittableStructRef(pThis, &_value.val, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -364,6 +369,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InEnum(pThis, value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -479,6 +485,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.NoexceptString(pThis, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -520,6 +527,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIClass.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InChar(pThis, .init(from: value), &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+CollectionTester.swift
+++ b/tests/test_component/Sources/test_component/test_component+CollectionTester.swift
@@ -128,6 +128,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CICollectionTesterStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InMap(pThis, _value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -138,6 +139,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CICollectionTesterStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InMapView(pThis, _value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -148,6 +150,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CICollectionTesterStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InVector(pThis, _value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -158,6 +161,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CICollectionTesterStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InVectorView(pThis, _value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+EventTester.swift
+++ b/tests/test_component/Sources/test_component/test_component+EventTester.swift
@@ -94,6 +94,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIEventTester.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.GetResult(pThis, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+Generics.swift
+++ b/tests/test_component/Sources/test_component/test_component+Generics.swift
@@ -1150,6 +1150,7 @@ public class IIteratorString: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIIterator_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Current(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -1891,6 +1892,7 @@ public class IKeyValuePairString_String: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -1899,6 +1901,7 @@ public class IKeyValuePairString_String: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Value(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -1997,6 +2000,7 @@ public class IKeyValuePairString_Base: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIKeyValuePair_2_HSTRING___x_ABI_Ctest__zcomponent__CBase.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.get_Key(pThis, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -2127,6 +2131,7 @@ public class IMapViewString_String: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIMapView_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Lookup(pThis, _key.get(), &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -2476,6 +2481,7 @@ public class IMapString_String: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIMap_2_HSTRING_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.Lookup(pThis, _key.get(), &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -3687,6 +3693,7 @@ public class IVectorViewString: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIVectorView_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 
@@ -4997,6 +5004,7 @@ public class IVectorString: WindowsFoundation.IInspectable {
         _ = try perform(as: __x_ABI_C__FIVector_1_HSTRING.self) { pThis in
             try CHECKED(pThis.pointee.lpVtbl.pointee.GetAt(pThis, index, &result))
         }
+        defer { WindowsDeleteString(result) }
         return .init(from: result)
     }
 

--- a/tests/test_component/Sources/test_component/test_component+IIAmImplementable.swift
+++ b/tests/test_component/Sources/test_component/test_component+IIAmImplementable.swift
@@ -171,6 +171,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InInt32(pThis, value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -180,6 +181,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InString(pThis, _value.get(), &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -190,6 +192,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InObject(pThis, _value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -199,6 +202,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InBlittableStructRef(pThis, &_value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -208,6 +212,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InNonBlittableStructRef(pThis, &_value.val, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -216,6 +221,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIIAmImplementable.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InEnum(pThis, value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+Simple.swift
+++ b/tests/test_component/Sources/test_component/test_component+Simple.swift
@@ -299,6 +299,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CISimple.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_StringProperty(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+StaticClass.swift
+++ b/tests/test_component/Sources/test_component/test_component+StaticClass.swift
@@ -55,6 +55,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InEnum(pThis, value, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 
@@ -64,6 +65,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CIStaticClassStatics.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.InNonBlittableStruct(pThis, _value.val, &result))
             }
+            defer { WindowsDeleteString(result) }
             return .init(from: result)
         }
 

--- a/tests/test_component/Sources/test_component/test_component+WithKeyword.swift
+++ b/tests/test_component/Sources/test_component/test_component+WithKeyword.swift
@@ -99,6 +99,7 @@ extension __ABI_test_component {
             _ = try perform(as: __x_ABI_Ctest__component_CWithKeyword.self) { pThis in
                 try CHECKED(pThis.pointee.lpVtbl.pointee.get_Struct(pThis, &value))
             }
+            defer { WindowsDeleteString(value) }
             return .init(from: value)
         }
 


### PR DESCRIPTION
Fixes the leaking of all returned `HSTRING` values by adding a call in the generated code to `WindowsDeleteString` for consuming return statements.

This is analogous to what happens a few lines above for array return types, where we add a call to `CoTaskMemFree`. I believe there's a separate leak happening here for array elements, but I'll tackle that in a separate PR.