### PR TITLE
Add `release-pdb` configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,12 @@ project(swiftwinrt LANGUAGES C CXX)
 
 option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
 
+# PDB debug info for C++/linker targets (for ETW profiling with xperf/WPA)
+if(SWIFT_DEBUG_MODE STREQUAL "pdb")
+    add_compile_options("$<$<COMPILE_LANGUAGE:CXX>:-Zi>")
+    add_link_options(LINKER:-debug)
+endif()
+
 if(NOT EXISTS "$ENV{WindowsSdkBinPath}${CMAKE_SYSTEM_VERSION}")
     message(FATAL_ERROR "Windows SDK Version appears not to be installed:\n  Missing folder: $ENV{WindowsSdkBinPath}${CMAKE_SYSTEM_VERSION}")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -44,6 +44,20 @@
                 "CMAKE_C_COMPILER": "cl",
                 "CMAKE_CXX_COMPILER": "cl"
             }
+        },
+        {
+            "name": "release-pdb",
+            "displayName": "Release (PDB)",
+            "description": "Optimized release build with PDB debug information for ETW profiling.",
+            "binaryDir": "${sourceDir}/build/release-pdb",
+            "installDir": "${sourceDir}/out/release-pdb",
+            "inherits": [ "base" ],
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release",
+                "CMAKE_C_COMPILER": "cl",
+                "CMAKE_CXX_COMPILER": "cl",
+                "SWIFT_DEBUG_MODE": "pdb"
+            }
         }
     ],
     "buildPresets": [
@@ -54,6 +68,10 @@
       {
         "name": "release",
         "configurePreset": "release"
+      },
+      {
+        "name": "release-pdb",
+        "configurePreset": "release-pdb"
       }
     ]
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,11 @@ set(SWIFT_BUILD_ARGS ${SWIFT_BUILD_ARGS} -c $<LOWER_CASE:${CMAKE_BUILD_TYPE}>)
 # Output to the cmake binary dir so build outputs are consolidated
 set(SWIFT_BUILD_ARGS ${SWIFT_BUILD_ARGS} --scratch-path ${CMAKE_CURRENT_BINARY_DIR})
 
+# PDB debug info for Swift targets (for ETW profiling with xperf/WPA)
+if(SWIFT_DEBUG_MODE STREQUAL "pdb")
+  set(SWIFT_BUILD_ARGS ${SWIFT_BUILD_ARGS} -Xswiftc -g -Xswiftc -debug-info-format=codeview -Xlinker -debug)
+endif()
+
 # CI machines have path issues so we pass the path to swift as part of configure
 if (DEFINED SWIFT_EXE)
   set(SWIFT_COMMAND ${SWIFT_EXE} build ${SWIFT_BUILD_ARGS})


### PR DESCRIPTION
Adds a `release-pdb` CMake preset to build the test app with debug info.

This allows profiling test app code with `xperf`/WPA.