### PR TITLE
Lazily compute `Error.description`

### DIFF
--- a/swiftwinrt/Resources/Support/Error.swift
+++ b/swiftwinrt/Resources/Support/Error.swift
@@ -101,44 +101,6 @@ public var E_XAMLPARSEFAILED : WinSDK.HRESULT {
   HRESULT(bitPattern: 0x802B000A)
 }
 
-private func getErrorDescription(expecting hr: HRESULT) -> String? {
-  var errorInfo: UnsafeMutablePointer<IRestrictedErrorInfo>?
-  guard GetRestrictedErrorInfo(&errorInfo) == S_OK else { return nil }
-  defer {
-    _ = errorInfo?.pointee.lpVtbl.pointee.Release(errorInfo)
-  }
-
-  var errorDescription: BSTR?
-  var restrictedDescription: BSTR?
-  var capabilitySid: BSTR?
-  defer {
-    SysFreeString(errorDescription)
-    SysFreeString(restrictedDescription)
-    SysFreeString(capabilitySid)
-  }
-  var resultLocal: HRESULT = S_OK
-  _ = errorInfo?.pointee.lpVtbl.pointee.GetErrorDetails(
-    errorInfo,
-    &errorDescription,
-    &resultLocal,
-    &restrictedDescription,
-    &capabilitySid)
-
-  guard resultLocal == hr else { return nil }
-  
-  // Favor restrictedDescription as this is a more user friendly message, which
-  // is intended to be displayed to the caller to help them understand why the
-  // api call failed. If it's not set, then fallback to the generic error message
-  // for the result
-  if SysStringLen(restrictedDescription) > 0 {
-    return String(decodingCString: restrictedDescription!, as: UTF16.self)
-  } else if SysStringLen(errorDescription) > 0 {
-    return String(decodingCString: errorDescription!, as: UTF16.self)
-  } else {
-    return nil
-  }
-}
-
 private func hrToString(_ hr: HRESULT) -> String {
   let dwFlags: DWORD = DWORD(FORMAT_MESSAGE_ALLOCATE_BUFFER)
                        | DWORD(FORMAT_MESSAGE_FROM_SYSTEM)
@@ -160,14 +122,73 @@ private func hrToString(_ hr: HRESULT) -> String {
 }
 
 public struct Error : Swift.Error, CustomStringConvertible {
-  public let description: String
   public let hr: HRESULT
+  private let info: Info?
+
+  // hrToString calls FormatMessageW which is expensive (loads resource DLLs
+  // and searches localized message tables). Many WinRT patterns use try? to
+  // discard errors, so we defer formatting until description is actually read.
+  public var description: String {
+    info?.description(expectingResult: hr) ?? hrToString(hr)
+  }
 
   public init(hr: HRESULT) {
-    self.description = getErrorDescription(expecting: hr) ?? hrToString(hr)
     self.hr = hr
+
+    var errorInfo: UnsafeMutablePointer<IRestrictedErrorInfo>?
+    guard GetRestrictedErrorInfo(&errorInfo) == S_OK, let errorInfo else {
+      self.info = nil
+      return
+    }
+    self.info = Info(errorInfo)
   }
-}   
+
+  fileprivate final class Info {
+    private let ptr: UnsafeMutablePointer<IRestrictedErrorInfo>
+
+    init(_ ptr: UnsafeMutablePointer<IRestrictedErrorInfo>) {
+      self.ptr = ptr
+    }
+
+    deinit {
+      _ = ptr.pointee.lpVtbl.pointee.Release(ptr)
+    }
+
+    func description(expectingResult hr: HRESULT) -> String? {
+      var errorDescription: BSTR?
+      var restrictedDescription: BSTR?
+      var capabilitySid: BSTR?
+      var resultLocal: HRESULT = S_OK
+
+      defer {
+        SysFreeString(errorDescription)
+        SysFreeString(restrictedDescription)
+        SysFreeString(capabilitySid)
+      }
+
+      _ = ptr.pointee.lpVtbl.pointee.GetErrorDetails(
+        ptr,
+        &errorDescription,
+        &resultLocal,
+        &restrictedDescription,
+        &capabilitySid)
+
+      guard resultLocal == hr else { return nil }
+
+      // Favor restrictedDescription as this is a more user friendly message, which
+      // is intended to be displayed to the caller to help them understand why the
+      // api call failed. If it's not set, then fallback to the generic error message
+      // for the result
+      if SysStringLen(restrictedDescription) > 0 {
+        return String(decodingCString: restrictedDescription!, as: UTF16.self)
+      } else if SysStringLen(errorDescription) > 0 {
+        return String(decodingCString: errorDescription!, as: UTF16.self)
+      } else {
+        return nil
+      }
+    }
+  }
+}
 
 public func failWith(hr: HRESULT) -> HRESULT {
   return hr

--- a/tests/test_component/Sources/WindowsFoundation/Support/error.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/error.swift
@@ -101,44 +101,6 @@ public var E_XAMLPARSEFAILED : WinSDK.HRESULT {
   HRESULT(bitPattern: 0x802B000A)
 }
 
-private func getErrorDescription(expecting hr: HRESULT) -> String? {
-  var errorInfo: UnsafeMutablePointer<IRestrictedErrorInfo>?
-  guard GetRestrictedErrorInfo(&errorInfo) == S_OK else { return nil }
-  defer {
-    _ = errorInfo?.pointee.lpVtbl.pointee.Release(errorInfo)
-  }
-
-  var errorDescription: BSTR?
-  var restrictedDescription: BSTR?
-  var capabilitySid: BSTR?
-  defer {
-    SysFreeString(errorDescription)
-    SysFreeString(restrictedDescription)
-    SysFreeString(capabilitySid)
-  }
-  var resultLocal: HRESULT = S_OK
-  _ = errorInfo?.pointee.lpVtbl.pointee.GetErrorDetails(
-    errorInfo,
-    &errorDescription,
-    &resultLocal,
-    &restrictedDescription,
-    &capabilitySid)
-
-  guard resultLocal == hr else { return nil }
-  
-  // Favor restrictedDescription as this is a more user friendly message, which
-  // is intended to be displayed to the caller to help them understand why the
-  // api call failed. If it's not set, then fallback to the generic error message
-  // for the result
-  if SysStringLen(restrictedDescription) > 0 {
-    return String(decodingCString: restrictedDescription!, as: UTF16.self)
-  } else if SysStringLen(errorDescription) > 0 {
-    return String(decodingCString: errorDescription!, as: UTF16.self)
-  } else {
-    return nil
-  }
-}
-
 private func hrToString(_ hr: HRESULT) -> String {
   let dwFlags: DWORD = DWORD(FORMAT_MESSAGE_ALLOCATE_BUFFER)
                        | DWORD(FORMAT_MESSAGE_FROM_SYSTEM)
@@ -160,14 +122,73 @@ private func hrToString(_ hr: HRESULT) -> String {
 }
 
 public struct Error : Swift.Error, CustomStringConvertible {
-  public let description: String
   public let hr: HRESULT
+  private let info: Info?
+
+  // hrToString calls FormatMessageW which is expensive (loads resource DLLs
+  // and searches localized message tables). Many WinRT patterns use try? to
+  // discard errors, so we defer formatting until description is actually read.
+  public var description: String {
+    info?.description(expectingResult: hr) ?? hrToString(hr)
+  }
 
   public init(hr: HRESULT) {
-    self.description = getErrorDescription(expecting: hr) ?? hrToString(hr)
     self.hr = hr
+
+    var errorInfo: UnsafeMutablePointer<IRestrictedErrorInfo>?
+    guard GetRestrictedErrorInfo(&errorInfo) == S_OK, let errorInfo else {
+      self.info = nil
+      return
+    }
+    self.info = Info(errorInfo)
   }
-}   
+
+  fileprivate final class Info {
+    private let ptr: UnsafeMutablePointer<IRestrictedErrorInfo>
+
+    init(_ ptr: UnsafeMutablePointer<IRestrictedErrorInfo>) {
+      self.ptr = ptr
+    }
+
+    deinit {
+      _ = ptr.pointee.lpVtbl.pointee.Release(ptr)
+    }
+
+    func description(expectingResult hr: HRESULT) -> String? {
+      var errorDescription: BSTR?
+      var restrictedDescription: BSTR?
+      var capabilitySid: BSTR?
+      var resultLocal: HRESULT = S_OK
+
+      defer {
+        SysFreeString(errorDescription)
+        SysFreeString(restrictedDescription)
+        SysFreeString(capabilitySid)
+      }
+
+      _ = ptr.pointee.lpVtbl.pointee.GetErrorDetails(
+        ptr,
+        &errorDescription,
+        &resultLocal,
+        &restrictedDescription,
+        &capabilitySid)
+
+      guard resultLocal == hr else { return nil }
+
+      // Favor restrictedDescription as this is a more user friendly message, which
+      // is intended to be displayed to the caller to help them understand why the
+      // api call failed. If it's not set, then fallback to the generic error message
+      // for the result
+      if SysStringLen(restrictedDescription) > 0 {
+        return String(decodingCString: restrictedDescription!, as: UTF16.self)
+      } else if SysStringLen(errorDescription) > 0 {
+        return String(decodingCString: errorDescription!, as: UTF16.self)
+      } else {
+        return nil
+      }
+    }
+  }
+}
 
 public func failWith(hr: HRESULT) -> HRESULT {
   return hr


### PR DESCRIPTION
Optimizes `WindowsFoundation.Error` throwing by lazily executing `hrToString` only if the error's `description` is requested.

This eager execution of, transitively, `FormatMessageW`, happens in hot paths where `QueryInterface` fails, even if the error is silently dropped (via `try?`).

# Changes
- Adds an `Error.Info` class to capture the `IRestrictedErrorInfo` pointer and release it in `deinit`.
- Make the `Error.description` a _computed_ property, so it only incurs the overhead if something actually wants to use the error string.

# Testing

This improves several benchmarks significantly, most notably the `event.cpp_type_erased`, which is intended to simulate WinUI routed event firing:

| Benchmark | Baseline (ns) | Optimized (ns) | Change | Speedup | p-value |
|-----------|--------------|----------------|--------|---------|---------|
| **Event** |
| `event.cpp_type_erased` | 4750.3 | 1575.0 | -66.8% | 3.02x | <0.001 *** |
| **Object** |
| `object.out_cpp` | 4911.0 | 1731.4 | -64.7% | 2.84x | <0.001 *** |
| **Collection** |
| `collection.vector_out` | 5522.7 | 2215.6 | -59.9% | 2.49x | <0.001 *** |
| `collection.map_out` | 6702.1 | 3520.3 | -47.5% | 1.90x | <0.001 *** |
| `collection.vector_in` | 4565.1 | 4257.9 | -6.7% | 1.07x | 0.003 ** |
| **Integration** |
| `integration` | **76583.1** | **66375.8** | **-13.3%** | **1.15x** | **<0.001 \*\*\*** |

<details><summary>Claude's analysis of the hot path that was hitting this issue:</summary>
<p>

### Call path: `FormatMessageW` triggered by `QI(ISwiftImplemented)` failure

1. Event callback arrives — C++ fires `m_typeErasedEvent(*this, args)` which invokes the Swift `Invoke` vtable entry (generated code, `test_component+Generics.swift:6612`)

2. Unwrap sender to `Any?` — calls [AnyWrapper.unwrapFrom](https://github.com/thebrowsercompany/swift-winrt/blob/a0fdaa5bd535275e1f89e7eacf75cbccbed3de41/swiftwinrt/Resources/Support/IInspectable.swift#L69-L77), which first tries `tryUnwrapFrom` to find an existing Swift wrapper, falling through to `makeFrom` if nil

3. `tryUnwrapFrom` does a [QueryInterface for ISwiftImplemented](https://github.com/thebrowsercompany/swift-winrt/blob/a0fdaa5bd535275e1f89e7eacf75cbccbed3de41/swiftwinrt/Resources/Support/WinRTWrapperBase.swift#L127) to check if this is a Swift-originated object

4. [ComPtr.queryInterface](https://github.com/thebrowsercompany/swift-winrt/blob/a0fdaa5bd535275e1f89e7eacf75cbccbed3de41/swiftwinrt/Resources/Support/ComPtr.swift#L64-L72) performs the actual COM QI call — the C++ object returns `E_NOINTERFACE` because it doesn't implement `ISwiftImplemented`

5. [CHECKED](https://github.com/thebrowsercompany/swift-winrt/blob/a0fdaa5bd535275e1f89e7eacf75cbccbed3de41/swiftwinrt/Resources/Support/ErrorHandling.swift#L9) wraps the failing HRESULT — `throw Error(hr: E_NOINTERFACE)`

6. [Error.init(hr:)](https://github.com/thebrowsercompany/swift-winrt/blob/a0fdaa5bd535275e1f89e7eacf75cbccbed3de41/swiftwinrt/Resources/Support/Error.swift#L175-L178) eagerly formats the error message by calling [hrToString](https://github.com/thebrowsercompany/swift-winrt/blob/a0fdaa5bd535275e1f89e7eacf75cbccbed3de41/swiftwinrt/Resources/Support/Error.swift#L142-L160) → `FormatMessageW` → loads resource DLLs, searches localized message tables

7. `try?` [discards the error](https://github.com/thebrowsercompany/swift-winrt/blob/a0fdaa5bd535275e1f89e7eacf75cbccbed3de41/swiftwinrt/Resources/Support/WinRTWrapperBase.swift#L127) — the formatted string is never read

This happens on every C++ object unwrap — 23.5% of benchmark CPU.

</p>
</details> 