### PR TITLE
Cache wrapped ABI pointer in `InterfaceWrapperBase`

### DIFF
--- a/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
+++ b/swiftwinrt/Resources/Support/WinRTWrapperBase.swift
@@ -199,25 +199,28 @@ open class WinRTAbiBridgeWrapper<I: AbiBridge> : WinRTWrapperBase<I.CABI, I.Swif
 
 open class InterfaceWrapperBase<I: AbiInterfaceBridge> : WinRTAbiBridgeWrapper<I> {
     override public class var IID: SUPPORT_MODULE.IID { I.SwiftABI.IID }
+
+    // Cached ABI pointer for objects that conform to AbiInterfaceImpl, avoiding
+    // a dynamic cast (swift_dynamicCast → swift_conformsToProtocol) on every toABI call.
+    private let wrappedAbi: UnsafeMutablePointer<I.CABI>?
+
     public init?(_ impl: I.SwiftProjection?) {
         guard let impl = impl else { return nil }
         // try to see if already wrapping an ABI pointer and if so, use that
         if let internalImpl = impl as? AnyAbiInterfaceImpl<I> {
             let abi: UnsafeMutablePointer<I.CABI> = RawPointer(internalImpl)
+            self.wrappedAbi = abi
             super.init(abi.pointee, impl)
         } else {
-            let abi = I.makeAbi()
-            super.init(abi, impl)
+            self.wrappedAbi = nil
+            super.init(I.makeAbi(), impl)
         }
     }
 
     override public func toABI<ResultType>(_ body: (UnsafeMutablePointer<I.CABI>) throws -> ResultType)
         throws -> ResultType {
-        // If this is an implementation then we're holding onto a WinRT object pointer, get that pointer
-        // and return that.
-        if let internalImpl = swiftObj as? AnyAbiInterfaceImpl<I> {
-            let abi: UnsafeMutablePointer<I.CABI> = RawPointer(internalImpl._default)
-            return try body(abi)
+        if let wrappedAbi {
+            return try body(wrappedAbi)
         } else {
             return try super.toABI(body)
         }

--- a/tests/test_component/Sources/WindowsFoundation/Support/winrtwrapperbase.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/winrtwrapperbase.swift
@@ -199,25 +199,28 @@ open class WinRTAbiBridgeWrapper<I: AbiBridge> : WinRTWrapperBase<I.CABI, I.Swif
 
 open class InterfaceWrapperBase<I: AbiInterfaceBridge> : WinRTAbiBridgeWrapper<I> {
     override public class var IID: WindowsFoundation.IID { I.SwiftABI.IID }
+
+    // Cached ABI pointer for objects that conform to AbiInterfaceImpl, avoiding
+    // a dynamic cast (swift_dynamicCast → swift_conformsToProtocol) on every toABI call.
+    private let wrappedAbi: UnsafeMutablePointer<I.CABI>?
+
     public init?(_ impl: I.SwiftProjection?) {
         guard let impl = impl else { return nil }
         // try to see if already wrapping an ABI pointer and if so, use that
         if let internalImpl = impl as? AnyAbiInterfaceImpl<I> {
             let abi: UnsafeMutablePointer<I.CABI> = RawPointer(internalImpl)
+            self.wrappedAbi = abi
             super.init(abi.pointee, impl)
         } else {
-            let abi = I.makeAbi()
-            super.init(abi, impl)
+            self.wrappedAbi = nil
+            super.init(I.makeAbi(), impl)
         }
     }
 
     override public func toABI<ResultType>(_ body: (UnsafeMutablePointer<I.CABI>) throws -> ResultType)
         throws -> ResultType {
-        // If this is an implementation then we're holding onto a WinRT object pointer, get that pointer
-        // and return that.
-        if let internalImpl = swiftObj as? AnyAbiInterfaceImpl<I> {
-            let abi: UnsafeMutablePointer<I.CABI> = RawPointer(internalImpl._default)
-            return try body(abi)
+        if let wrappedAbi {
+            return try body(wrappedAbi)
         } else {
             return try super.toABI(body)
         }


### PR DESCRIPTION
# Cache internal ABI pointer in `InterfaceWrapperBase`

`InterfaceWrapperBase.toABI` was doing an `as? AnyAbiInterfaceImpl<I>` dynamic cast on every call, which triggers `swift_dynamicCast` → `swift_conformsToProtocol` in the Swift runtime. This caches the result at `init` time in a `wrappedAbi` property so `toABI` becomes a simple nil check.

## Benchmark results (vs lazy-error-fix baseline, 7 runs)

| Benchmark | Baseline (ns) | Optimized (ns) | Change | Speedup | p-value |
|---|---|---|---|---|---|
| **Object** | | | | | |
| `object.in` | 3,998 | 2,560 | -36.0% | 1.56x | *** p<0.001 |
| **Collection** | | | | | |
| `collection.vector_in` | 4,400 | 2,969 | -32.5% | 1.48x | *** p<0.001 |
| `collection.map_out` | 3,542 | 3,355 | -5.3% | 1.06x | *** p<0.001 |
| **Weak Reference** | | | | | |
| `weakref.create_resolve` | 17,506 | 14,543 | -16.9% | 1.20x | *** p<0.001 |
| `weakref.create` | 6,588 | 5,207 | -21.0% | 1.26x | *** p<0.001 |
| `weakref.resolve` | 10,519 | 9,022 | -14.2% | 1.17x | ** p<0.01 |
| **Integration** | | | | | |
| **`integration`** | **68,559** | **62,689** | **-8.6%** | **1.09x** | *** p<0.001 |
