### PR TITLE
Avoid `String` conversion in `makeFrom` factory cache lookup

### DIFF
--- a/swiftwinrt/Resources/Support/MakeFromAbi.swift
+++ b/swiftwinrt/Resources/Support/MakeFromAbi.swift
@@ -1,3 +1,4 @@
+import CWinRT
 import Foundation
 import WinSDK
 
@@ -14,6 +15,49 @@ func make(typeName: SwiftTypeName, from abi: SUPPORT_MODULE.IInspectable) -> Any
         return nil
     }
     return makerType.from(abi: abi)
+}
+
+/// Dictionary key that wraps a raw HSTRING, hashing and comparing on the UTF-16 content without
+/// converting to a Swift String.
+///
+/// Keys stored in the dictionary duplicate the HSTRING and intentionally never free it; the cache
+/// lives for the process lifetime and contains at most one entry per WinRT class name. Transient
+/// lookup keys borrow the caller's HSTRING without duplicating.
+///
+private struct FactoryCacheKey: Hashable {
+    let hstring: HSTRING
+
+    /// Transient key for dictionary lookups. Does not duplicate the HSTRING.
+    ///
+    /// - Important: Not generally safe to do, but in this narrow case we know the associated
+    /// `HSTRING` will have a non-zero reference count while it's being used here.
+    ///
+    init(_unsafeBorrowing hstring: HSTRING) {
+        self.hstring = hstring
+    }
+
+    /// Persistent key for dictionary storage. Duplicates the HSTRING (never freed).
+    init(duplicating hstring: HSTRING) {
+        var duplicate: HSTRING?
+        _ = WindowsDuplicateString(hstring, &duplicate)
+        guard let duplicate else { fatalError("Out of memory") }
+        self.hstring = duplicate
+    }
+
+    func hash(into hasher: inout Hasher) {
+        var length: UINT32 = 0
+        let buffer = WindowsGetStringRawBuffer(hstring, &length)
+        hasher.combine(bytes: UnsafeRawBufferPointer(
+            start: buffer,
+            count: Int(length) * MemoryLayout<WCHAR>.size
+        ))
+    }
+
+    static func == (lhs: FactoryCacheKey, rhs: FactoryCacheKey) -> Bool {
+        var result: Int32 = 0
+        _ = WindowsCompareStringOrdinal(lhs.hstring, rhs.hstring, &result)
+        return result == 0
+    }
 }
 
 /// Cached result of resolving a WinRT runtime class name to its Swift factory type.
@@ -36,7 +80,7 @@ private enum FactoryCacheEntry {
     case noFactory
 }
 
-private var factoryCache: [String: FactoryCacheEntry] = [:]
+private var factoryCache: [FactoryCacheKey: FactoryCacheEntry] = [:]
 private var factoryCacheLock = SRWLock()
 
 func makeFrom(abi: SUPPORT_MODULE.IInspectable) -> Any? {
@@ -45,9 +89,15 @@ func makeFrom(abi: SUPPORT_MODULE.IInspectable) -> Any? {
     // but we want to return a Button type.
 
     // Note that we'll *never* be trying to create an app implemented object at this point
-    guard let className = try? String(hString: abi.GetRuntimeClassName()) else { return nil }
 
-    let cached = factoryCacheLock.withLock(.shared) { factoryCache[className] }
+    // Get the raw HSTRING directly, avoiding the String conversion.
+    var rawClassName: HSTRING?
+    _ = try? abi.GetRuntimeClassName(&rawClassName)
+    guard let rawClassName else { return nil }
+    defer { WindowsDeleteString(rawClassName) }
+
+    let lookupKey = FactoryCacheKey(_unsafeBorrowing: rawClassName)
+    let cached = factoryCacheLock.withLock(.shared) { factoryCache[lookupKey] }
 
     if let cached {
         switch cached {
@@ -62,6 +112,8 @@ func makeFrom(abi: SUPPORT_MODULE.IInspectable) -> Any? {
     // may redundantly resolve the same type. This is harmless (the result is identical) and
     // lets us use shared reader locking on the hot path.
 
+    let className = String(from: rawClassName)
+
     let factory: (any MakeFromAbi.Type)?
     if let typeName = IInspectable.GetSwiftTypeName(from: className) {
         factory = NSClassFromString("\(typeName.module).\(typeName.typeName)Maker") as? any MakeFromAbi.Type
@@ -69,8 +121,9 @@ func makeFrom(abi: SUPPORT_MODULE.IInspectable) -> Any? {
         factory = nil
     }
 
+    let storedKey = FactoryCacheKey(duplicating: rawClassName)
     let entry: FactoryCacheEntry = factory.map { .factory($0) } ?? .noFactory
-    factoryCacheLock.withLock(.exclusive) { factoryCache[className] = entry }
+    factoryCacheLock.withLock(.exclusive) { factoryCache[storedKey] = entry }
 
     return factory?.from(abi: abi)
 }

--- a/tests/test_component/Sources/WindowsFoundation/Support/makefromabi.swift
+++ b/tests/test_component/Sources/WindowsFoundation/Support/makefromabi.swift
@@ -1,3 +1,4 @@
+import CWinRT
 import Foundation
 import WinSDK
 
@@ -14,6 +15,49 @@ func make(typeName: SwiftTypeName, from abi: WindowsFoundation.IInspectable) -> 
         return nil
     }
     return makerType.from(abi: abi)
+}
+
+/// Dictionary key that wraps a raw HSTRING, hashing and comparing on the UTF-16 content without
+/// converting to a Swift String.
+///
+/// Keys stored in the dictionary duplicate the HSTRING and intentionally never free it; the cache
+/// lives for the process lifetime and contains at most one entry per WinRT class name. Transient
+/// lookup keys borrow the caller's HSTRING without duplicating.
+///
+private struct FactoryCacheKey: Hashable {
+    let hstring: HSTRING
+
+    /// Transient key for dictionary lookups. Does not duplicate the HSTRING.
+    ///
+    /// - Important: Not generally safe to do, but in this narrow case we know the associated
+    /// `HSTRING` will have a non-zero reference count while it's being used here.
+    ///
+    init(_unsafeBorrowing hstring: HSTRING) {
+        self.hstring = hstring
+    }
+
+    /// Persistent key for dictionary storage. Duplicates the HSTRING (never freed).
+    init(duplicating hstring: HSTRING) {
+        var duplicate: HSTRING?
+        _ = WindowsDuplicateString(hstring, &duplicate)
+        guard let duplicate else { fatalError("Out of memory") }
+        self.hstring = duplicate
+    }
+
+    func hash(into hasher: inout Hasher) {
+        var length: UINT32 = 0
+        let buffer = WindowsGetStringRawBuffer(hstring, &length)
+        hasher.combine(bytes: UnsafeRawBufferPointer(
+            start: buffer,
+            count: Int(length) * MemoryLayout<WCHAR>.size
+        ))
+    }
+
+    static func == (lhs: FactoryCacheKey, rhs: FactoryCacheKey) -> Bool {
+        var result: Int32 = 0
+        _ = WindowsCompareStringOrdinal(lhs.hstring, rhs.hstring, &result)
+        return result == 0
+    }
 }
 
 /// Cached result of resolving a WinRT runtime class name to its Swift factory type.
@@ -36,7 +80,7 @@ private enum FactoryCacheEntry {
     case noFactory
 }
 
-private var factoryCache: [String: FactoryCacheEntry] = [:]
+private var factoryCache: [FactoryCacheKey: FactoryCacheEntry] = [:]
 private var factoryCacheLock = SRWLock()
 
 func makeFrom(abi: WindowsFoundation.IInspectable) -> Any? {
@@ -45,9 +89,15 @@ func makeFrom(abi: WindowsFoundation.IInspectable) -> Any? {
     // but we want to return a Button type.
 
     // Note that we'll *never* be trying to create an app implemented object at this point
-    guard let className = try? String(hString: abi.GetRuntimeClassName()) else { return nil }
 
-    let cached = factoryCacheLock.withLock(.shared) { factoryCache[className] }
+    // Get the raw HSTRING directly, avoiding the String conversion.
+    var rawClassName: HSTRING?
+    _ = try? abi.GetRuntimeClassName(&rawClassName)
+    guard let rawClassName else { return nil }
+    defer { WindowsDeleteString(rawClassName) }
+
+    let lookupKey = FactoryCacheKey(_unsafeBorrowing: rawClassName)
+    let cached = factoryCacheLock.withLock(.shared) { factoryCache[lookupKey] }
 
     if let cached {
         switch cached {
@@ -62,6 +112,8 @@ func makeFrom(abi: WindowsFoundation.IInspectable) -> Any? {
     // may redundantly resolve the same type. This is harmless (the result is identical) and
     // lets us use shared reader locking on the hot path.
 
+    let className = String(from: rawClassName)
+
     let factory: (any MakeFromAbi.Type)?
     if let typeName = IInspectable.GetSwiftTypeName(from: className) {
         factory = NSClassFromString("\(typeName.module).\(typeName.typeName)Maker") as? any MakeFromAbi.Type
@@ -69,8 +121,9 @@ func makeFrom(abi: WindowsFoundation.IInspectable) -> Any? {
         factory = nil
     }
 
+    let storedKey = FactoryCacheKey(duplicating: rawClassName)
     let entry: FactoryCacheEntry = factory.map { .factory($0) } ?? .noFactory
-    factoryCacheLock.withLock(.exclusive) { factoryCache[className] = entry }
+    factoryCacheLock.withLock(.exclusive) { factoryCache[storedKey] = entry }
 
     return factory?.from(abi: abi)
 }


### PR DESCRIPTION
Further optimizes the `makeFrom(abi:)` method by avoiding the `HSTRING` -> `String` conversion in the hot path.

A light wrapper around an `HSTRING` is used as the factory cache key, which skips any `HSTRING` duplication or `String` conversion in the fast lookup path by simply "borrowing" the runtime class value. In the slow path, we use an alternate initializer that duplicates the `HSTRING`, since it is stored in the static cache.

This reduces the overhead of receiving a native WinRT object across the ABI boundary in Swift. In particular, WinUI-style event handlers (with `Object` arguments project as `Any?`) saw a ~2X speedup:

| Benchmark | Before (ns) | After (ns) | Change | Speedup | p-value |
|-----------|---------------|--------------|--------|---------|---------|
| object.out_native | 1752.8 | 820.1 | -53.2% | 2.14x | <0.001 |
| event.fire_type_erased | 1571.8 | 748.0 | -52.4% | 2.10x | <0.001 |

<details><summary>Benchmark details</summary>
<p>

The benchmarks shown above are simple, effectively:

```swift
    let class = Class()
    measure("object.out_native") {
        let obj = try! class.returnObject()
        blackHole(obj)
    }

    // TypedEventHandler<Object, SimpleEventArgs> (Any? sender — matches WinUI pattern)
    let simple = Simple()
    let handler = simple.typeErasedEvent.addHandler { _, _ in }
    measure("event.fire_type_erased") {
        try! simple.fireTypeErasedEvent()
    }
    handler.dispose()
```

where `Simple` and `Class` are both WinRT objects implemented in C++.

</p>
</details> 