### PR TITLE
fix(cmake): quote NuGet install output

### DIFF
--- a/cmake/nuget.cmake
+++ b/cmake/nuget.cmake
@@ -111,7 +111,7 @@ function(nuget)
       ${CMAKE_BINARY_DIR}/${NUGET_PACKAGE}.${NUGET_PACKAGE_VERSION})
   set(NUGET_PACKAGE_INSTALL_ROOT ${NUGET_PACKAGE_INSTALL_ROOT} PARENT_SCOPE)
 
-  string(REPLACE "\n" ";" LINES ${NUGET_INSTALL_OUTPUT})
+  string(REPLACE "\n" ";" LINES "${NUGET_INSTALL_OUTPUT}")
   foreach(LINE ${LINES})
     string(FIND "${LINE}" "Successfully installed" installed_index)
     string(FIND "${LINE}" "already installed" already_installed_index)


### PR DESCRIPTION
## Summary
- quote `NUGET_INSTALL_OUTPUT` before splitting it into CMake list lines
- prevents `string(REPLACE)` from receiving too few arguments when the NuGet output is empty or expands unexpectedly
- keeps the existing filtering behavior for `Successfully installed` / `already installed` messages

Fixes #237.

## Testing
- `git diff --check`
- Not run: full CMake build requires the Windows SDK / Windows toolchain environment described in `README.md` and `AGENTS.md`
